### PR TITLE
Add getter to the platform dsl

### DIFF
--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -24,6 +24,24 @@ class Vanagon::Platform::DSL
     @platform
   end
 
+  # All purpose getter. This object, which is passed to the platform block,
+  # won't have easy access to the attributes of the @platform, so we make a
+  # getter for each attribute.
+  #
+  # We only magically handle get_ methods, any other methods just get the
+  # standard method_missing treatment.
+  #
+  def method_missing(method, *args)
+    attribute_match = method.to_s.match(/get_(.*)/)
+    if attribute_match
+      attribute = attribute_match.captures.first
+    else
+      super
+    end
+
+    @platform.send(attribute)
+  end
+
   # Platform attributes and DSL methods defined below
   #
   #


### PR DESCRIPTION
Because the object in the platform block is actually an instance of the
platform dsl and not the platform itself, attempt to use attributes like
platform.servicetype will fail, as it is a method on the dsl. This
commit adds a method_missing catch to the dsl to redirect get_\* methods
to return the attribute of the platform class. So
platform.get_servicetype will return the servicetype for the platform.
