### PR TITLE
(maint) Have git do a recursive clone

### DIFF
--- a/lib/vanagon/component/source/git.rb
+++ b/lib/vanagon/component/source/git.rb
@@ -18,7 +18,7 @@ class Vanagon
 
         def fetch
           Dir.chdir(@workdir) do
-            git('clone', @url)
+            git('clone', '--recursive', @url)
             Dir.chdir(dirname) do
               git('checkout', @ref)
               @version = git('describe', '--tags')


### PR DESCRIPTION
For cfacter, we include a submodule for the boost-nowide project. The
nowide project was meant to be included in the main boost project, but
this has yet to happen. So instead, we need to have the capacity to
recursively clone into the repo to ensure we have the submodule
available during the build.

Projects that do not contain submodules in their repo should not see any
change because of this addition.
