### PR TITLE
(RE-3608) Add ship script to vanagon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 group(:development, :test) do
   gem 'rspec', '~> 3.0', :require => false
   gem 'yard', :require => false
+  gem 'packaging', '0.1.0', :github => 'puppetlabs/packaging', :branch => 'master'
 end

--- a/bin/ship
+++ b/bin/ship
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+ENV["PROJECT_ROOT"] = Dir.pwd
+
+# Begin warning: This ship script is an internal tool.
+# This is not intended to function outside of Puppet Labs' infrastructure.
+# End of warning.
+
+unless Dir["output/**/*"].select {|entry| File.file?(entry) }.empty?
+  require 'packaging'
+  Pkg::Util::RakeUtils.load_packaging_tasks
+  Pkg::Util::RakeUtils.invoke_task('pl:jenkins:ship', 'artifacts', 'output')
+else
+  fail "No packages to ship in the output directory. Maybe you want to build some first?"
+end


### PR DESCRIPTION
This commit adds a simple script to vanagon to ship a given build to
builds.delivery.puppetlabs.net if there are builds in the output
directory.
