### PR TITLE
(RE-3661) Provide number of available processes

### DIFF
--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -2,7 +2,7 @@ require 'vanagon/platform/dsl'
 
 class Vanagon
   class Platform
-    attr_accessor :make, :servicedir, :defaultdir, :provisioning
+    attr_accessor :make, :servicedir, :defaultdir, :provisioning, :num_cores
     attr_accessor :build_dependencies, :name, :vcloud_name, :cflags, :ldflags, :settings
     attr_accessor :servicetype, :patch, :architecture, :codename, :os_name, :os_version
 

--- a/lib/vanagon/platform/deb.rb
+++ b/lib/vanagon/platform/deb.rb
@@ -38,6 +38,7 @@ class Vanagon
         @name = name
         @make = "/usr/bin/make"
         @patch = "/usr/bin/patch"
+        @num_cores = "/usr/bin/nproc"
         super(name)
       end
     end

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -55,6 +55,14 @@ class Vanagon
         @platform.patch = patch_cmd
       end
 
+
+      # Sets the command to retrieve the number of cores available on a platform.
+      #
+      # @param num_cores_cmd [String] the command to retrieve the number of available cores on a platform.
+      def num_cores(num_cores_cmd)
+        @platform.num_cores = num_cores_cmd
+      end
+
       def provision_with(command)
         @platform.provisioning = command
       end

--- a/lib/vanagon/platform/rpm.rb
+++ b/lib/vanagon/platform/rpm.rb
@@ -29,6 +29,7 @@ class Vanagon
         @name = name
         @make = "/usr/bin/make"
         @patch = "/usr/bin/patch"
+        @num_cores = "/bin/grep -c 'processor' /proc/cpuinfo"
         super(name)
       end
     end


### PR DESCRIPTION
In some cases, we would like to build projects in parallel, when
available. When using make, we can specify the number of jobs to run in
parallel. This number usually corresponds to the number of processes
available on the machine plus one. This pull request adds in the ability
to determine how many processes are available for use, and makes that
data available during build time.
