### PR TITLE
(RE-3676) Add gemspec to vanagon

### DIFF
--- a/vanagon.gemspec
+++ b/vanagon.gemspec
@@ -1,0 +1,22 @@
+Gem::Specification.new do |gem|
+  gem.name    = 'vanagon'
+  gem.version = %x(git describe --tags).sub('-', '.').chomp
+  gem.date    = Date.today.to_s
+
+  gem.summary = "Another mega-package build tool, now with more Make"
+  gem.description = "Vanagon is a tool to build a single package out of a project, which can itself contain one or more components."
+
+  gem.authors  = ['Puppet Labs']
+  gem.email    = 'info@puppetlabs.com'
+  gem.homepage = 'http://github.com/puppetlabs/vanagon'
+
+  gem.add_development_dependency('rspec', ["~> 3.0"])
+  gem.add_development_dependency('yard')
+  gem.require_path = 'lib'
+  gem.bindir       = 'bin'
+  gem.executables  = ['build', 'ship']
+
+  # Ensure the gem is built out of versioned files
+  gem.files = Dir['{bin,lib,spec,templates}/**/*', 'README*', 'LICENSE*'] & `git ls-files -z`.split("\0")
+  gem.test_files = Dir['spec/**/*_spec.rb']
+end


### PR DESCRIPTION
In order to sanely reference vanagon from other projects using bundler,
a gemspec is essential. It allows users to pin to a specific version or
range of versions, like ~> 0.1 instead of just the 0.1.0 tag. This will
also allow us to easily ship vanagon to rubygems when we want to.
