### PR TITLE
(RE-3685) Add repo binary to bin to make repos

### DIFF
--- a/bin/repo
+++ b/bin/repo
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+ENV["PROJECT_ROOT"] = Dir.pwd
+
+# Begin warning: This ship script is an internal tool.
+# This is not intended to function outside of Puppet Labs' infrastructure.
+# This presumes packages for this ref have already been build and shipped.
+# End of warning.
+
+require 'packaging'
+Pkg::Util::RakeUtils.load_packaging_tasks
+Pkg::Util::RakeUtils.invoke_task('pl:jenkins:rpm_repos')
+Pkg::Util::RakeUtils.invoke_task('pl:jenkins:deb_repos')

--- a/vanagon.gemspec
+++ b/vanagon.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('yard')
   gem.require_path = 'lib'
   gem.bindir       = 'bin'
-  gem.executables  = ['build', 'ship']
+  gem.executables  = ['build', 'ship', 'repo']
 
   # Ensure the gem is built out of versioned files
   gem.files = Dir['{bin,lib,spec,templates}/**/*', 'README*', 'LICENSE*'] & `git ls-files -z`.split("\0")


### PR DESCRIPTION
Now that artifacts are shipping for the composite artifact, we need to
be able to make repos of them for consumption by beaker. This commit
adds a repo binary which makes repos of the shipped packages. This
assumes the packages have been built and shipped, and assumes both deb
and rpm packages have been built.
