### PR TITLE
(RE-3711) Update rpm specfile to build with custom gcc

### DIFF
--- a/templates/project.spec.erb
+++ b/templates/project.spec.erb
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           <%= @name %>
 Version:        <%= @version %>
 Release:        1


### PR DESCRIPTION
The custom gcc used to build cfacter, boost and friends doesn't play
well with EL7. Specifically, the debugging symbols postpackaging steps
error out because of problems with the build_id. This commit disables
generating the debug packages to work around the problem for the moment.
