### PR TITLE
(RE-3824) Allow a vanagon project to have runtime deps in package

### DIFF
--- a/examples/projects/project.rb
+++ b/examples/projects/project.rb
@@ -14,6 +14,7 @@ project "my-app" do |proj|
   proj.license "ASL 2.0"
   proj.vendor "Me <info@my-app.com>"
   proj.homepage "https://www.my-app.com"
+  proj.requires "glibc"
 
   proj.component "component1"
   proj.component "component2"

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -7,7 +7,7 @@ require 'ostruct'
 class Vanagon
   class Project
     include Vanagon::Utilities
-    attr_accessor :components, :settings, :platform, :configdir, :name, :version, :directories, :license, :description, :vendor, :homepage
+    attr_accessor :components, :settings, :platform, :configdir, :name, :version, :directories, :license, :description, :vendor, :homepage, :requires
 
     # Loads a given project from the configdir
     #

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -74,6 +74,13 @@ class Vanagon
         @project.homepage = page
       end
 
+      # Sets the run time requirements for the project. Mainly for use in packaging.
+      #
+      # @param req [String] of requirements of the project
+      def requires(req)
+        @project.requires = req
+      end
+
       # Sets the version for the project. Mainly for use in packaging.
       #
       # @param ver [String] version of the project

--- a/templates/deb/control.erb
+++ b/templates/deb/control.erb
@@ -13,6 +13,9 @@ Priority: optional
 #Provides:
 #Replaces:
 #Conflicts:
+<% if @requires -%>
+Depends: <%= @requires -%>
+<% end -%>
 Description: <%= @description.lines.first.chomp %>
  <%= @description.lines[1..-1].join("\n ") -%>
  .

--- a/templates/rpm/project.spec.erb
+++ b/templates/rpm/project.spec.erb
@@ -16,7 +16,9 @@ Source0:        %{name}-%{version}.tar.gz
 # Don't provide anything so the system doesn't use our packages to resolve deps
 Autoprov: 0
 Autoreq: 0
-
+<%- if @requires -%>
+Requires:  <%= @requires %>
+<%- end -%>
 <%- if has_services? -%>
   <%- if @platform.servicetype == "systemd" -%>
     <%- if @platform.is_sles? -%>


### PR DESCRIPTION
Prior to this commit, there was not a way to specify a run-time
dependency in a package generated by vanagon. Each component could have
a dependency for build time, but that didn't help much.

This was created because code-management needed to depend upon the
puppet-agent both at build and at run time.

This is implemented by adding a requires parameter to the main project
object.

Limitations: requires is a single string, and is defined at a project
level and is not configurable per OS type (e.g debian has one name and
el has another). Thus far that is an ok trade-off because the only
dependency has the same name. That may need to change in the future.
