### PR TITLE
(RE-3828) Present an error message when a 404 happens

### DIFF
--- a/lib/vanagon/component/source/http.rb
+++ b/lib/vanagon/component/source/http.rb
@@ -55,6 +55,9 @@ class Vanagon
               request = Net::HTTP::Get.new(uri)
 
               http.request request do |response|
+                unless response.is_a? Net::HTTPSuccess
+                  fail "Error: #{response.code.to_s}. Unable to get source from #{@url}"
+                end
                 open(File.join(@workdir, target_file), 'w') do |io|
                   response.read_body do |chunk|
                     io.write(chunk)


### PR DESCRIPTION
Previously, when vanagon couldn't download a source file vanagon would
just throw a checksumming error rather than tell you that it couldn't
find the payload requested. This simple change let's you know if your
source is a 404 regardless.
