### PR TITLE
(RE-3824) Allow a vanagon project to have runtime deps in package

### DIFF
--- a/examples/projects/project.rb
+++ b/examples/projects/project.rb
@@ -14,6 +14,7 @@ project "my-app" do |proj|
   proj.license "ASL 2.0"
   proj.vendor "Me <info@my-app.com>"
   proj.homepage "https://www.my-app.com"
+  proj.requires "glibc"
 
   proj.component "component1"
   proj.component "component2"

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -7,7 +7,7 @@ require 'ostruct'
 class Vanagon
   class Project
     include Vanagon::Utilities
-    attr_accessor :components, :settings, :platform, :configdir, :name, :version, :directories, :license, :description, :vendor, :homepage
+    attr_accessor :components, :settings, :platform, :configdir, :name, :version, :directories, :license, :description, :vendor, :homepage, :requires
 
     # Loads a given project from the configdir
     #
@@ -38,6 +38,7 @@ class Vanagon
     def initialize(name, platform)
       @name = name
       @components = []
+      @requires = []
       @directories = []
       @settings = {}
       @platform = platform
@@ -69,6 +70,13 @@ class Vanagon
     # @return [Array] array of files installed by components of the project
     def get_files
       @components.map {|comp| comp.files }.flatten
+    end
+
+    def get_requires
+      req = []
+      req << @components.map {|comp| comp.requires }.flatten
+      req << @requires
+      req.flatten.uniq
     end
 
     # Collects any configfiles supplied by components

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -74,6 +74,13 @@ class Vanagon
         @project.homepage = page
       end
 
+      # Sets the run time requirements for the project. Mainly for use in packaging.
+      #
+      # @param req [String] of requirements of the project
+      def requires(req)
+        @project.requires << req
+      end
+
       # Sets the version for the project. Mainly for use in packaging.
       #
       # @param ver [String] version of the project

--- a/templates/deb/control.erb
+++ b/templates/deb/control.erb
@@ -13,6 +13,7 @@ Priority: optional
 #Provides:
 #Replaces:
 #Conflicts:
+Depends: <%= get_requires.join(", ") %>
 Description: <%= @description.lines.first.chomp %>
  <%= @description.lines[1..-1].join("\n ") -%>
  .

--- a/templates/rpm/project.spec.erb
+++ b/templates/rpm/project.spec.erb
@@ -16,7 +16,9 @@ Source0:        %{name}-%{version}.tar.gz
 # Don't provide anything so the system doesn't use our packages to resolve deps
 Autoprov: 0
 Autoreq: 0
-
+<%- get_requires.each do |requires| -%>
+Requires:  <%= requires %>
+<%- end -%>
 <%- if has_services? -%>
   <%- if @platform.servicetype == "systemd" -%>
     <%- if @platform.is_sles? -%>


### PR DESCRIPTION
Prior to this commit, there was not a way to specify a run-time
dependency in a package generated by vanagon. Each component could have
a dependency for build time, but that didn't help much. There was a
component property called requires, but it wasn't used in any packaging.

This was created because code-management needed to depend upon the
puppet-agent both at build and at run time.

This is implemented by adding a requires parameter to the main project
object as well as bubbling up each component-level requires into the RPM
spec file and debian control file.

Both project level and component level requires are multivalued and
modeled as an array.

Note: If you have different requirements on different platforms, you're
probably going to want to mess with that in the component file and not
the project-level one. The project level one is primarily for uniform
dependencies or our own generated metapackages.
