### PR TITLE
(RE-3856) Component listing in pkg desc should be one per line

### DIFF
--- a/templates/deb/control.erb
+++ b/templates/deb/control.erb
@@ -18,4 +18,4 @@ Description: <%= @description.lines.first.chomp %>
  <%= @description.lines[1..-1].join("\n ") -%>
  .
  Contains the following components:
- <%= @components.map {|comp| "#{comp.name} (#{comp.version})" }.join(", ") %>
+ <%= @components.map {|comp| "#{comp.name} (#{comp.version})" }.sort.join("\n ") %>

--- a/templates/rpm/project.spec.erb
+++ b/templates/rpm/project.spec.erb
@@ -43,7 +43,7 @@ Requires: chkconfig
 <%= @description %>
 
 Contains the following components:
-<%= @components.map {|comp| "#{comp.name} (#{comp.version})" }.join(", ") %>
+<%= @components.map {|comp| "#{comp.name} (#{comp.version})" }.sort.join("\n") %>
 
 %prep
 %setup -q -n %{name}-%{version}


### PR DESCRIPTION
Previously each component in a vangon-built package was listed in
arbitrary order and on one line comma separated. This patch changes taht
behavior to make it one component per line and orders them
alphabetically. This should make it easier to parse the output of
querying the package with grep or other such tools.
