### PR TITLE
Docker driver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ group(:development, :test) do
   gem 'rspec', '~> 3.0', :require => false
   gem 'yard', :require => false
   gem 'packaging', '~> 0.4.0', :github => 'puppetlabs/packaging', :branch => 'master'
+  gem 'json'
 end

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -5,6 +5,7 @@ class Vanagon
     attr_accessor :make, :servicedir, :defaultdir, :provisioning, :num_cores
     attr_accessor :build_dependencies, :name, :vcloud_name, :cflags, :ldflags, :settings
     attr_accessor :servicetype, :patch, :architecture, :codename, :os_name, :os_version
+    attr_accessor :docker_image, :ssh_port
 
     # Platform names currently contain some information about the platform. Fields
     # within the name are delimited by the '-' character, and this regex can be used to
@@ -85,6 +86,7 @@ HERE
       @os_name = os_name
       @os_version = os_version
       @architecture = architecture
+      @ssh_port = 22
       @provisioning = []
     end
 
@@ -166,6 +168,13 @@ HERE
     # @return [true, false] true if it is an eos variety, false otherwise
     def is_eos?
       return !!@name.match(/^eos-.*$/)
+    end
+
+    # Utility matcher to determine is the platform is an nxos variety
+    #
+    # @return [true, false] true if it is an eos variety, false otherwise
+    def is_nxos?
+      return !!@name.match(/^nxos-.*$/)
     end
   end
 end

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -19,7 +19,7 @@ class Vanagon
       # @param block [Proc] DSL definition of the platform to call
       def platform(name, &block)
         @platform = case name
-                    when /^(el|sles|eos)-/
+                    when /^(el|sles|eos|nxos)-/
                       Vanagon::Platform::RPM.new(@name)
                     when /^(debian|ubuntu)-/
                       Vanagon::Platform::DEB.new(@name)
@@ -117,6 +117,20 @@ class Vanagon
       # @param name [String] name that the pooler uses for this platform
       def vcloud_name(name)
         @platform.vcloud_name = name
+      end
+
+      # Set the name of the docker image to use
+      #
+      # @param name [String] name of the docker image to use
+      def docker_image(name)
+        @platform.docker_image = name
+      end
+
+      # Set the port for ssh to use if it's not 22
+      #
+      # @param port [Integer] port number for ssh
+      def ssh_port(port = 22)
+        @platform.ssh_port = port
       end
 
       # Set any codename this platform may have (debian for example)

--- a/spec/lib/vanagon/utilities_spec.rb
+++ b/spec/lib/vanagon/utilities_spec.rb
@@ -89,13 +89,23 @@ describe "Vanagon::Utilities" do
     it 'adds the correct flags to the command if VANAGON_SSH_KEY is set' do
       expect(Vanagon::Utilities).to receive(:find_program_on_path).with('ssh').and_return('/tmp/ssh')
       ENV['VANAGON_SSH_KEY'] = '/a/b/c'
-      expect(Vanagon::Utilities.ssh_command).to eq('/tmp/ssh -i /a/b/c')
+      expect(Vanagon::Utilities.ssh_command).to include('/tmp/ssh -i /a/b/c')
       ENV['VANAGON_SSH_KEY'] = nil
     end
 
     it 'returns just the path to ssh if VANAGON_SSH_KEY is not set' do
       expect(Vanagon::Utilities).to receive(:find_program_on_path).with('ssh').and_return('/tmp/ssh')
-      expect(Vanagon::Utilities.ssh_command).to eq('/tmp/ssh')
+      expect(Vanagon::Utilities.ssh_command).to include('/tmp/ssh')
+    end
+
+    it 'sets the port to 22 when none is specified' do
+      expect(Vanagon::Utilities).to receive(:find_program_on_path).with('ssh').and_return('/tmp/ssh')
+      expect(Vanagon::Utilities.ssh_command).to include('-p 22')
+    end
+
+    it 'sets the port to 2222 when that is specified' do
+      expect(Vanagon::Utilities).to receive(:find_program_on_path).with('ssh').and_return('/tmp/ssh')
+      expect(Vanagon::Utilities.ssh_command(2222)).to include('-p 2222')
     end
   end
 end


### PR DESCRIPTION
(RE-3949) Allow docker to be a build target
This feature branch allows docker images to be used as a build target
instead of using exclusively vmpooler. To use docker there are few
things that need to happen.
1. You need a docker image. Right now, this assumes that the image is
   available on the host where vanagon is running.
2. Your docker image needs to have ssh available, as that is the primary
   transport mechanism for file tranfer and rpc type commands. You specify
   the ssh_port in your platform definition.
3. You need to define that you're using a docker image in your platform
   definition.

docker_image name and then the SSH port.

   plat.docker_image "nxos_1"
   plat.ssh_port 2222
