### PR TITLE
(RE-3878) Add user class, dsl method to projects

### DIFF
--- a/lib/vanagon/common.rb
+++ b/lib/vanagon/common.rb
@@ -1,1 +1,2 @@
 require 'vanagon/common/directory'
+require 'vanagon/common/user'

--- a/lib/vanagon/common/user.rb
+++ b/lib/vanagon/common/user.rb
@@ -1,0 +1,25 @@
+class Vanagon
+  class Common
+    class User
+      attr_accessor :name, :group, :shell, :is_system, :homedir
+      def initialize(name, group = nil, shell = nil, is_system = false, homedir = nil)
+        @name = name
+        @group = group ? group : @name
+        @shell = shell if shell
+        @is_system = is_system if is_system
+        @homedir = homedir if homedir
+      end
+
+      # Equality. How does it even work?
+      #
+      # @return [true, false] true if all attributes have equal values. false otherwise.
+      def ==(other)
+        other.name == self.name && \
+          other.group == self.group && \
+          other.shell == self.shell && \
+          other.is_system == self.is_system && \
+          other.homedir == self.homedir
+      end
+    end
+  end
+end

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -9,7 +9,7 @@ class Vanagon
     include Vanagon::Utilities
     attr_accessor :components, :settings, :platform, :configdir, :name
     attr_accessor :version, :directories, :license, :description, :vendor
-    attr_accessor :homepage, :requires
+    attr_accessor :homepage, :requires, :user
 
     # Loads a given project from the configdir
     #

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -113,6 +113,17 @@ class Vanagon
         @project.directories << Vanagon::Common::Directory.new(dir, mode, owner, group)
       end
 
+      # Add a user to the project
+      #
+      # @param name [String] name of the user to create
+      # @param group [String] group of the user
+      # @param shell [String] login shell to set for the user
+      # @param is_system [true, false] if the user should be a system user
+      # @param homedir [String] home directory for the user
+      def user(name, group: nil, shell: nil, is_system: false, homedir: nil)
+        @project.user = Vanagon::Common::User.new(name, group, shell, is_system, homedir)
+      end
+
       # Sets the license for the project. Mainly for use in packaging.
       #
       # @param lic [String] the license the project is released under

--- a/spec/lib/vanagon/common/user_spec.rb
+++ b/spec/lib/vanagon/common/user_spec.rb
@@ -1,0 +1,36 @@
+require 'vanagon/common/user'
+
+describe 'Vanagon::Common::User' do
+  describe 'initialize' do
+    it 'group defaults to the name of the user' do
+      user = Vanagon::Common::User.new('willamette')
+      expect(user.group).to eq('willamette')
+    end
+  end
+
+  describe 'equality' do
+    it 'is not equal if the names differ' do
+      user1 = Vanagon::Common::User.new('willamette')
+      user2 = Vanagon::Common::User.new('columbia')
+      expect(user1).not_to eq(user2)
+    end
+
+    it 'is not equal if there are different attributes set' do
+      user1 = Vanagon::Common::User.new('willamette', 'group1')
+      user2 = Vanagon::Common::User.new('willamette', 'group2')
+      expect(user1).not_to eq(user2)
+    end
+
+    it 'is equal if there are the same attributes set to the same values' do
+      user1 = Vanagon::Common::User.new('willamette', 'group')
+      user2 = Vanagon::Common::User.new('willamette', 'group')
+      expect(user1).to eq(user2)
+    end
+
+    it 'is equal if the name are the same and the only attribute set' do
+      user1 = Vanagon::Common::User.new('willamette')
+      user2 = Vanagon::Common::User.new('willamette')
+      expect(user1).to eq(user2)
+    end
+  end
+end

--- a/templates/deb/postinst.erb
+++ b/templates/deb/postinst.erb
@@ -16,6 +16,12 @@ fi
   <%- end -%>
 <%- end -%>
 
+<%- if @user -%>
+# Add our user and group
+<%= @platform.add_group(@user) %>
+<%= @platform.add_user(@user) %>
+<%- end -%>
+
 # Set up any specific permissions needed...
 <%- get_directories.select { |dir| dir.has_overrides? }.each do |directory| -%>
   <%= "chmod '#{directory.mode}' '#{directory.path}'" if directory.mode %>

--- a/templates/rpm/project.spec.erb
+++ b/templates/rpm/project.spec.erb
@@ -73,6 +73,13 @@ install -d %{buildroot}
   cp -p <%= file %> %{buildroot}/<%= File.dirname(file) %>
 <%- end -%>
 
+%pre
+<%- if @user -%>
+# Add our user and group
+<%= @platform.add_group(@user) %>
+<%= @platform.add_user(@user) %>
+<%- end -%>
+
 %post
 <%- get_services.each do |service| -%>
   # switch based on systemd vs systemv


### PR DESCRIPTION
This commit adds a user method to the project dsl which is driven by the
Vanagon::Common::User class. The platform class gets some new methods
add_user and add_group to generate the correct scriptlets for the rpm
and deb packaging to add or update users and groups.
