### PR TITLE
(RE-3958) Add a zypper helper to the dsl

### DIFF
--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -164,6 +164,30 @@ class Vanagon
         end
       end
 
+      # Helper to setup a zypper repository on a target system
+      #
+      # @param definition [String] the repo setup URI or RPM file
+      # @param reponame [String] optional name of the repo, defaults to 'somerepo-md5'
+      def zypper_repo(definition, reponame = "somerepo" )
+        if @platform.os_version == '10'
+          flag = 'sa'
+        else
+          flag = 'ar'
+        end
+        # Add a semi-random suffix to the default in case more than one repo is specificied to use the default
+        reponame = reponame + "-" +   Digest::MD5.hexdigest(definition)[0..6] if reponame == 'somerepo'
+        self.provision_with "yes | zypper -n --no-gpg-checks install curl"
+        if ( definition =~ /^http/ and definition !~ /rpm$/ )
+          # Repo definition is a URI e.g.
+          # http://builds.puppetlabs.lan/puppet-agent/0.2.1/repo_configs/rpm/pl-puppet-agent-0.2.1-el-7-x86_64.repo
+          reponame = reponame + '.repo'  if reponame !~ /\.repo$/
+          self.provision_with "yes | zypper -n --no-gpg-checks #{flag} -t YUM --repo '#{definition}'"
+        else ( definition =~ /rpm$/ )
+          # repo definition is an rpm (like puppetlabs-release)
+          self.provision_with "curl -o local.rpm '#{definition}'; rpm -Uvh local.rpm; rm -f local.rpm"
+        end
+      end
+
     end
   end
 end

--- a/spec/lib/vanagon/platform/dsl_spec.rb
+++ b/spec/lib/vanagon/platform/dsl_spec.rb
@@ -1,18 +1,16 @@
 require 'vanagon/platform/dsl'
 
 describe 'Vanagon::Platform::DSL' do
-  let (:deb_platform_block) {
-"platform 'debian-test-fixture' do |plat|
-end" }
-
-  let (:el_platform_block) {
-"platform 'el-test-fixture' do |plat|
-end"  }
+  let (:deb_platform_block)  {  "platform 'debian-test-fixture' do |plat| end" }
+  let (:el_platform_block)   {  "platform 'el-test-fixture'     do |plat| end" }
+  let (:sles_platform_block) {  "platform 'sles-test-fixture'   do |plat| end" }
 
   let(:apt_definition) { "http://builds.puppetlabs.lan/puppet-agent/0.2.1/repo_configs/deb/pl-puppet-agent-0.2.1-wheezy" }
   let(:apt_definition_deb) { "http://builds.puppetlabs.lan/puppet-agent/0.2.1/repo_configs/deb/pl-puppet-agent-0.2.1-wheezy.deb" }
-  let(:el_definition) { "http://builds.puppetlabs.lan/puppet-agent/0.2.1/repo_configs/rpm/pl-puppet-agent-0.2.1-el-7-x86_64.repo" }
+  let(:el_definition) { "http://builds.puppetlabs.lan/puppet-agent/0.2.1/repo_configs/rpm/pl-puppet-agent-0.2.1-el-7-x86_64" }
   let(:el_definition_rpm) { "http://builds.puppetlabs.lan/puppet-agent/0.2.1/repo_configs/rpm/pl-puppet-agent-0.2.1-release.rpm" }
+  let(:sles_definition) { "http://builds.puppetlabs.lan/puppet-agent/0.2.2/repo_configs/rpm/pl-puppet-agent-0.2.2-sles-12-x86_64" }
+  let(:sles_definition_rpm) { "http://builds.puppetlabs.lan/puppet-agent/0.2.1/repo_configs/rpm/pl-puppet-agent-0.2.1-release.rpm" }
 
   describe '#apt_repo' do
     it "grabs the file and adds .list to it" do
@@ -47,6 +45,24 @@ end"  }
       expect(Digest::MD5).to receive(:hexdigest).with(el_definition_rpm).and_return("abcdefghij")
       plat.yum_repo(el_definition_rpm)
       expect(plat._platform.provisioning).to be_include("yum localinstall -y '#{el_definition_rpm}'")
+    end
+  end
+
+  describe '#zypper_repo' do
+    it "grabs the file and adds .repo to it" do
+      plat = Vanagon::Platform::DSL.new('sles-test-fixture')
+      plat.instance_eval(sles_platform_block)
+      expect(Digest::MD5).to receive(:hexdigest).with(sles_definition).and_return("abcdefghij")
+      plat.zypper_repo(sles_definition)
+      expect(plat._platform.provisioning).to be_include("yes | zypper -n --no-gpg-checks ar -t YUM --repo '#{sles_definition}'")
+    end
+
+    it "installs a sles rpm when given a rpm" do
+      plat = Vanagon::Platform::DSL.new('sles-test-fixture')
+      plat.instance_eval(sles_platform_block)
+      expect(Digest::MD5).to receive(:hexdigest).with(sles_definition_rpm).and_return("abcdefghij")
+      plat.zypper_repo(sles_definition_rpm)
+      expect(plat._platform.provisioning).to be_include("curl -o local.rpm '#{sles_definition_rpm}'; rpm -Uvh local.rpm; rm -f local.rpm")
     end
   end
 end


### PR DESCRIPTION
This allows a zypper_repo type in the platform dsl. It works just like
the yum_repo and apt_repo helpers, but is intended for zypper based
platforms.
