### PR TITLE
(RE-3966) Enable rpm builds when filenames contain spaces.

### DIFF
--- a/lib/vanagon/platform/rpm.rb
+++ b/lib/vanagon/platform/rpm.rb
@@ -11,7 +11,7 @@ class Vanagon
       def generate_package(project)
         ["mkdir -p $(tempdir)/rpmbuild/{SOURCES,SPECS,BUILD,RPMS,SRPMS}",
         "cp #{project.name}-#{project.version}.tar.gz $(tempdir)/rpmbuild/SOURCES",
-        "cp file-list $(tempdir)/rpmbuild/SOURCES",
+        "cp file-list-for-rpm $(tempdir)/rpmbuild/SOURCES",
         "cp #{project.name}.spec $(tempdir)/rpmbuild/SPECS",
         "rpmbuild -bb --define '_topdir $(tempdir)/rpmbuild' $(tempdir)/rpmbuild/SPECS/#{project.name}.spec",
         "mkdir -p output/#{output_dir}",

--- a/templates/Makefile.erb
+++ b/templates/Makefile.erb
@@ -18,6 +18,7 @@ file-list-after-build: <%= @components.map {|comp| comp.name }.join(" ") %>
 
 file-list: <%= dirnames.join(' ') %> <%= @name %>
 	comm -23 file-list-after-build file-list-before-build > file-list
+	comm -23 file-list-after-build file-list-before-build | sed -e 's/\(^.*\s.*$$\)/"\1"/g' > file-list-for-rpm
 
 <%- dirnames.each do |dir| -%>
 <%= dir %>:

--- a/templates/rpm/project.spec.erb
+++ b/templates/rpm/project.spec.erb
@@ -12,7 +12,7 @@ URL:            <%= @homepage %>
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 Source0:        %{name}-%{version}.tar.gz
-Source1:        file-list
+Source1:        file-list-for-rpm
 
 # Don't provide anything so the system doesn't use our packages to resolve deps
 Autoprov: 0


### PR DESCRIPTION
(RE-3966) Enable rpm builds when filenames contain spaces.

```
When building a package such as cmake, some files have spaces in the
name.

/opt/pl-build-tools/share/cmake/Help/generator/Visual Studio 10 2010.rst

Originally, I thought that just shell escaping the spaces would work,
that isn't how rpm works. Instead what we've done is make a new file for
usage by rpm that double quotes files that contain spaces. Tar still
uses the normal file-list rather than file-list-for-rpm.

If they are not double quoted (single quotes break), rpm sees each
whitespace break as a violation of the one file per line directive for
the %files macro and things explode.
```
