### PR TITLE
(RE-3970) Add logging of host usage with VMpooler

### DIFF
--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -4,6 +4,7 @@ require 'vanagon/component'
 require 'vanagon/utilities'
 require 'vanagon/common'
 require 'tmpdir'
+require 'logger'
 
 class Vanagon
   class Driver
@@ -17,6 +18,8 @@ class Vanagon
       @project_name = project
       @workdir = Dir.mktmpdir
       @@configdir = configdir
+      @logger = Logger.new('vanagon_hosts.log')
+      @logger.progname = 'vanagon'
     end
 
     def load_platform
@@ -47,6 +50,7 @@ class Vanagon
       else
         target = http_request("http://vmpooler.delivery.puppetlabs.net/vm/#{@platform.vcloud_name}", "POST")
         if target and target["ok"]
+          @logger.info "Reserving #{target[@platform.vcloud_name]["hostname"]} (#{@platform.vcloud_name})"
           return target[@platform.vcloud_name]["hostname"]
         else
           puts "something went wrong, maybe the pool for #{@platform.vcloud_name} is empty?"
@@ -88,6 +92,7 @@ class Vanagon
       else
         target = http_request("http://vmpooler.delivery.puppetlabs.net/vm/#{host}", "DELETE")
         if target and target["ok"]
+          @logger.info  "#{host} has been destroyed"
           puts "'#{host}' has been destroyed"
           return true
         else


### PR DESCRIPTION
When using vanagon rapidly and prototyping, you'll end up grabbing lots
of hosts from the VMpooler. By default, hosts are destroyed if vanagon
completes sucessfully, but when it fails, the hosts is kept around. When
working on lots of projects, that can leave many orphans that only get
cleaned up by the VMpooler reaping.

This adds a log in the local directory that shows what hosts are grabbed
(and what pool they are from). It will also show when they are
destroyed.

```
# Logfile created on 2015-02-08 05:13:11 +0000 by logger.rb/41954
I, [2015-02-08T05:13:11.315778 #29183]  INFO -- vanagon: Reserving nand9d4v3tkcrzu (sles-10-x86_64)
I, [2015-02-08T05:22:48.501426 #29183]  INFO -- vanagon: nand9d4v3tkcrzu has been destroyed
```
