### PR TITLE
(RE-3967) Collect flags and args in bin/build

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -9,11 +9,15 @@ def usage
 EOS
 end
 
-project = ARGV[0]
-platform = ARGV[1]
-target = ARGV[2]
-preserve = ARGV.include?("--preserve")
-verbose = ARGV.include?("-v")
+FLAG_REGEX = /^(-|--).*$/
+flags = ARGV.select {|arg| arg.match(FLAG_REGEX) }
+args = ARGV.reject {|arg| arg.match(FLAG_REGEX) }
+
+project = args[0]
+platform = args[1]
+target = args[2]
+preserve = flags.include?("--preserve")
+verbose = flags.include?("-v")
 configdir = File.join(Dir.pwd, "configs")
 
 if project.nil? or platform.nil?


### PR DESCRIPTION
Previously a combination of array position and array inclusion were used
to get both arguments and flags. This broke grabbing things like
--preserve out of the command line because it would interpret --preserve
as the target, or platform, or project, which wouldn't work. This commit
updates the script to collect flags and args separately from ARGV. This
will allow the flags to be collected without affecting other arguments.
