### PR TITLE
(RE-3491) Add replaces component DSL method

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -6,7 +6,7 @@ class Vanagon
     attr_accessor :name, :version, :source, :url, :configure, :build, :install
     attr_accessor :environment, :extract_with, :dirname, :build_requires
     attr_accessor :settings, :platform, :files, :patches, :requires, :service, :options
-    attr_accessor :configfiles, :directories
+    attr_accessor :configfiles, :directories, :replaces
 
     # Loads a given component from the configdir
     #
@@ -49,6 +49,7 @@ class Vanagon
       @files = []
       @configfiles = []
       @directories = []
+      @replaces = []
     end
 
     # Fetches the primary source for the component. As a side effect, also sets

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -123,6 +123,13 @@ class Vanagon
         @component.requires << requirement
       end
 
+      # Indicates that this component replaces a system level package. Replaces can be collected and used by the project and package.
+      #
+      # @param replacement [String] a package that is replaced with this component
+      def replaces(replacement)
+        @component.replaces << replacement
+      end
+
       # install_service adds the commands to install the various files on
       # disk during the package build and registers the service with the project
       #

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -84,6 +84,13 @@ class Vanagon
       req.flatten.uniq
     end
 
+    # Collects all of the replacements for the project and its components
+    #
+    # @return [Array] array of package level replacements for the project
+    def get_replaces
+      @components.map {|comp| comp.replaces }.flatten.uniq
+    end
+
     # Collects any configfiles supplied by components
     #
     # @return [Array] array of configfiles installed by components of the project

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -122,6 +122,16 @@ end" }
     end
   end
 
+  describe '#replaces' do
+    it 'adds the package replacement to the list of replacements' do
+      comp = Vanagon::Component::DSL.new('replaces-test', {}, {})
+      comp.replaces('thing1')
+      comp.replaces('thing2')
+      expect(comp._component.replaces).to be_include('thing1')
+      expect(comp._component.replaces).to be_include('thing2')
+    end
+  end
+
   describe '#install_service' do
     it 'adds the correct command to the install for the component for sysv platforms' do
       comp = Vanagon::Component::DSL.new('service-test', {}, dummy_platform_sysv)

--- a/templates/deb/control.erb
+++ b/templates/deb/control.erb
@@ -10,9 +10,8 @@ Package: <%= @name %>
 Architecture: any
 Section: admin
 Priority: optional
-#Provides:
-#Replaces:
-#Conflicts:
+Replaces: <%= get_replaces.join(", ") %>
+Conflicts: <%= get_replaces.join(", ") %>
 Depends: <%= get_requires.join(", ") %>
 Description: <%= @description.lines.first.chomp %>
  <%= @description.lines[1..-1].join("\n ") -%>

--- a/templates/rpm/project.spec.erb
+++ b/templates/rpm/project.spec.erb
@@ -40,6 +40,11 @@ Requires: chkconfig
   <%- end -%>
 <%- end -%>
 
+<%- get_replaces.each do |replacement| -%>
+Conflicts: <%= replacement %>
+Obsoletes: <%= replacement %>
+<%- end -%>
+
 %description
 <%= @description %>
 


### PR DESCRIPTION
This commit adds a new component DSL method, replaces, which is used to
indicate when a component replaces a system package. These replaces are
collected via get_replaces in the project and automatically generate the
correct packaging snippets to force removal of the package being
replaced during installation.
