### PR TITLE
(maint) Use built-in timing to avoid shell

### DIFF
--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -79,7 +79,7 @@ class Vanagon
     end
 
     def build_artifact_on(target)
-      remote_ssh_command(target, "time #{@platform.make}", @platform.ssh_port)
+      remote_ssh_command(target, @platform.make, @platform.ssh_port)
     end
 
     def retrieve_built_artifact_from(target)

--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -3,6 +3,7 @@ require 'uri'
 require 'json'
 require 'digest'
 require 'erb'
+require 'benchmark'
 
 class Vanagon
   module Utilities
@@ -198,7 +199,7 @@ class Vanagon
     def remote_ssh_command(target, command, port = 22 )
       if target
         puts "Executing '#{command}' on #{target}"
-        Kernel.system("#{ssh_command(port)} -t -o StrictHostKeyChecking=no #{target} '#{command.gsub("'", "'\\\\''")}'")
+        puts Benchmark.measure { Kernel.system("#{ssh_command(port)} -t -o StrictHostKeyChecking=no #{target} '#{command.gsub("'", "'\\\\''")}'") }
         $?.success? or raise "Remote ssh command (#{command}) failed on '#{target}'."
       else
         fail "Need a target to ssh to. Received none."


### PR DESCRIPTION
Without this change, building the project depends on the shell command
'time'. This is not available everywhere, so instead use the built-in
Benchmark module to time ssh commands.
