### PR TITLE
(maint) Update repo binary to take an optional argument

### DIFF
--- a/bin/repo
+++ b/bin/repo
@@ -7,7 +7,20 @@ ENV["PROJECT_ROOT"] = Dir.pwd
 # This presumes packages for this ref have already been build and shipped.
 # End of warning.
 
+# repo_target will allow us to be more granular with the selection of repos that will be constructed
+# if we have not built debs or rpms, the packaging repo will fail when creating repos
+if ARGV[0]
+  repo_target = ARGV[0].downcase
+end
+
 require 'packaging'
 Pkg::Util::RakeUtils.load_packaging_tasks
-Pkg::Util::RakeUtils.invoke_task('pl:jenkins:rpm_repos')
-Pkg::Util::RakeUtils.invoke_task('pl:jenkins:deb_repos')
+case repo_target
+when 'rpm'
+  Pkg::Util::RakeUtils.invoke_task('pl:jenkins:rpm_repos')
+when 'deb'
+  Pkg::Util::RakeUtils.invoke_task('pl:jenkins:deb_repos')
+else
+  Pkg::Util::RakeUtils.invoke_task('pl:jenkins:rpm_repos')
+  Pkg::Util::RakeUtils.invoke_task('pl:jenkins:deb_repos')
+end


### PR DESCRIPTION
Because the packaging repo tends to fail when only one platform is
available, this commit updates the repo binary to take an optional
argument of repo target. If deb or rpm are passed as the argument, only
that set of repos will be created. If no arguments are passed (or
garbage), both will be created. This allows a jenkins jobs to decide
which repos to create based on the build targets.
