### PR TITLE
(maint) Fix preserve and verbose options to build

### DIFF
--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -10,7 +10,7 @@ require 'logger'
 class Vanagon
   class Driver
     include Vanagon::Utilities
-    attr_accessor :platform, :project, :target, :workdir
+    attr_accessor :platform, :project, :target, :workdir, :verbose, :preserve
 
     def initialize(platform, project, configdir, target = nil, engine = 'pooler')
       @verbose = false


### PR DESCRIPTION
Without this fix, using --preserve or --verbose with the build command
results in an error, because assignment to the Driver isn't defined.

Define accessors for preserve and verbose so these options work.
