### PR TITLE
(maint) Encapsulate fetching patches for component

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -67,5 +67,16 @@ class Vanagon
       # Git based sources probably won't set the version, so we load it if it hasn't been already set
       @version ||= @source.version
     end
+
+    # Fetches patches if any are provided for the project.
+    #
+    # @param workdir [String] working directory to put the patches into
+    def get_patches(workdir)
+      unless @patches.empty?
+        patchdir = File.join(workdir, "patches")
+        FileUtils.mkdir_p(patchdir)
+        FileUtils.cp(@patches, patchdir)
+      end
+    end
   end
 end

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -59,11 +59,7 @@ class Vanagon
     def fetch_sources(workdir)
       @components.each do |component|
         component.get_source(workdir)
-        unless component.patches.empty?
-          patchdir = File.join(workdir, "patches")
-          FileUtils.mkdir_p(patchdir)
-          FileUtils.cp(component.patches, patchdir)
-        end
+        component.get_patches(workdir)
       end
     end
 


### PR DESCRIPTION
Without this change, we access @patches directly and perform logic on
it, violating encapsulation of the component logic.

Moves logic for fetching patches on a component into the component
class.
