### PR TITLE
(maint) Fix specs for Driver changes

### DIFF
--- a/spec/lib/vanagon/project/dsl_spec.rb
+++ b/spec/lib/vanagon/project/dsl_spec.rb
@@ -10,7 +10,7 @@ end" }
 
   describe '#version_from_git' do
     it 'sets the version based on the git describe' do
-      Vanagon::Driver.new('abcd', 'abcd', configdir)
+      expect(Vanagon::Driver).to receive(:configdir).and_return(configdir)
       proj = Vanagon::Project::DSL.new('test-fixture', {})
       proj.instance_eval(project_block)
       expect(Vanagon::Utilities).to receive(:git_version).with(File.expand_path('..', configdir)).and_return('1.2.3-1234')


### PR DESCRIPTION
Commit 331e397 changed Vanagon::Driver to load from configdir on
initialization. Specs weren't setup to allow that, so they started
failing.

This commit fixes that by mocking Vanagon::Driver#configdir for
version_from_git, which is the only reason an instance of
Vanagon::Driver was created in the first place.
