### PR TITLE
(maint) Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: ruby
+bundler_args: --without development
+before_script:
+  - 'git config --global user.email "you@example.com"'
+  - 'git config --global user.name "Your Name"'
+script: "bundle exec rspec spec"
+notifications:
+  email: false
+rvm:
+  - 2.1.5


### PR DESCRIPTION
Run specs using Travis CI. Initializes git global settings before specs
because specs create a dummy commit using git, and this config is
required before commits will work.
