### PR TITLE
(maint) Vanagon pooler support assumes DNS lookup

### DIFF
--- a/lib/vanagon/engine/pooler.rb
+++ b/lib/vanagon/engine/pooler.rb
@@ -17,7 +17,7 @@ class Vanagon
         response = Vanagon::Utilities.http_request("#{@pooler}/vm/#{@platform.vcloud_name}", "POST")
         if response and response["ok"]
           Vanagon::Driver.logger.info "Reserving #{response[@platform.vcloud_name]['hostname']} (#{@platform.vcloud_name})"
-          @target = response[@platform.vcloud_name]['hostname']
+          @target = response[@platform.vcloud_name]['hostname'] + '.' + response['domain']
         else
           raise Vanagon::Error.new("Something went wrong getting a target vm to build on, maybe the pool for #{@platform.vcloud_name} is empty?")
         end


### PR DESCRIPTION
Vanagon's pooler engine assumes DNS lookup is configured to search the
domain section of the json data returned by the pooler. Explicitly use
the full path (hostname+domain) to reduce external configuration
dependencies.
