### PR TITLE
(RE-4055) Add provides support to component DSL

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -6,7 +6,7 @@ class Vanagon
     attr_accessor :name, :version, :source, :url, :configure, :build, :install
     attr_accessor :environment, :extract_with, :dirname, :build_requires
     attr_accessor :settings, :platform, :files, :patches, :requires, :service, :options
-    attr_accessor :configfiles, :directories, :replaces
+    attr_accessor :configfiles, :directories, :replaces, :provides
 
     # Loads a given component from the configdir
     #
@@ -50,6 +50,7 @@ class Vanagon
       @configfiles = []
       @directories = []
       @replaces = []
+      @provides = []
     end
 
     # Fetches the primary source for the component. As a side effect, also sets

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -130,6 +130,13 @@ class Vanagon
         @component.replaces << replacement
       end
 
+      # Indicates that this component provides a system level package. Provides can be collected and used by the project and package.
+      #
+      # @param provide [String] a package that is provided with this component
+      def provides(provide)
+        @component.provides << provide
+      end
+
       # install_service adds the commands to install the various files on
       # disk during the package build and registers the service with the project
       #

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -88,6 +88,13 @@ class Vanagon
       @components.map {|comp| comp.replaces }.flatten.uniq
     end
 
+    # Collects all of the provides for the project and its components
+    #
+    # @return [Array] array of package level provides for the project
+    def get_provides
+      @components.map {|comp| comp.provides }.flatten.uniq
+    end
+
     # Collects any configfiles supplied by components
     #
     # @return [Array] array of configfiles installed by components of the project

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -122,6 +122,16 @@ end" }
     end
   end
 
+  describe '#provides' do
+    it 'adds the package provide to the list of provides' do
+      comp = Vanagon::Component::DSL.new('provides-test', {}, {})
+      comp.provides('thing1')
+      comp.provides('thing2')
+      expect(comp._component.provides).to include('thing1')
+      expect(comp._component.provides).to include('thing2')
+    end
+  end
+
   describe '#replaces' do
     it 'adds the package replacement to the list of replacements' do
       comp = Vanagon::Component::DSL.new('replaces-test', {}, {})

--- a/templates/deb/control.erb
+++ b/templates/deb/control.erb
@@ -13,6 +13,7 @@ Priority: optional
 Replaces: <%= get_replaces.join(", ") %>
 Conflicts: <%= get_replaces.join(", ") %>
 Depends: <%= get_requires.join(", ") %>
+Provides: <%= get_provides.join(", ") %>
 Description: <%= @description.lines.first.chomp %>
  <%= @description.lines[1..-1].join("\n ") -%>
  .

--- a/templates/rpm/project.spec.erb
+++ b/templates/rpm/project.spec.erb
@@ -45,6 +45,10 @@ Conflicts: <%= replacement %>
 Obsoletes: <%= replacement %>
 <%- end -%>
 
+<%- get_provides.each do |provide| -%>
+Provides: <%= provide %>
+<%- end -%>
+
 %description
 <%= @description %>
 


### PR DESCRIPTION
It is useful for a package to be able to specify that it provides a
capability. This was previously not possible in vanagon, but this commit
adds a provides dsl method to the component which allows components to
express provides that can be collected for the project and package. In
rpm and deb packages, this is expressed as a provides in the spec or
control file.
