### PR TITLE
(RE-4160) Add ability to have owner/group on installed file

### DIFF
--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -158,7 +158,7 @@ class Vanagon
         end
 
         # Install the service and default files
-        install_file(service_file, target_service_file, target_mode)
+        install_file(service_file, target_service_file, mode: target_mode)
 
         if default_file
           install_file(default_file, target_default_file)
@@ -173,10 +173,12 @@ class Vanagon
       #
       # @param source [String] path to the file to copy
       # @param target [String] path to the desired target of the file
-      def install_file(source, target, mode = '0644')
+      # @param owner  [String] owner of the file
+      # @param group  [String] group owner of the file
+      def install_file(source, target, mode: '0644', owner: nil, group:  nil )
         @component.install << "install -d '#{File.dirname(target)}'"
         @component.install << "cp -p '#{source}' '#{target}'"
-        @component.files << Vanagon::Common::Pathname.new(target, mode)
+        @component.files << Vanagon::Common::Pathname.new(target, mode, owner, group)
       end
 
       # Marks a file as a configfile to ensure that it is not overwritten on

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -189,6 +189,14 @@ end" }
       expect(comp._component.install).to include("install -d 'place/to/put'")
       expect(comp._component.install).to include("cp -p 'thing1' 'place/to/put/thing1'")
     end
+
+    it 'adds an owner and group to the installation' do
+      comp = Vanagon::Component::DSL.new('install-file-test', {}, {})
+      comp.install_file('thing1', 'place/to/put/thing1', owner: 'bob', group: 'timmy', mode: '0022')
+      expect(comp._component.install).to include("install -d 'place/to/put'")
+      expect(comp._component.install).to include("cp -p 'thing1' 'place/to/put/thing1'")
+      expect(comp._component.files).to include(Vanagon::Common::Pathname.new('place/to/put/thing1', '0022', 'bob', 'timmy'))
+    end
   end
 
   describe '#configfile' do


### PR DESCRIPTION
For the passenger packaging, we need to be able to specify an
owner/group for the config.ru. This is also probably generically useful.
