### PR TITLE
(RE-4161) Add single file sources to Vanagon

### DIFF
--- a/lib/vanagon/component/source/http.rb
+++ b/lib/vanagon/component/source/http.rb
@@ -85,8 +85,8 @@ class Vanagon
           case @extension
           when '.tar.gz', '.tgz'
             return "gunzip -c '#{@file}' | tar xf -"
-          when '.gem'
-            # Don't need to unpack gems
+          when '.gem', '.ru', '.txt', '.conf', '.ini'
+            # Don't need to unpack gems, ru, txt, conf, ini
             return nil
           else
             fail "Extraction unimplemented for '#{@extension}' in source '#{@file}'. Please teach me."
@@ -98,7 +98,7 @@ class Vanagon
         # @return [String] the extension of @file
         # @raise [RuntimeError] an exception is raised if the extension isn't in the current list
         def get_extension
-          extension_match = @file.match(/.*(\.tar\.gz|\.tgz|\.gem|\.tar\.bz)/)
+          extension_match = @file.match(/.*(\.tar\.gz|\.tgz|\.gem|\.tar\.bz|\.ru|\.txt|\.conf|\.ini)/)
           unless extension_match
             fail "Unrecognized extension for '#{@file}'. Don't know how to extract this format. Please teach me."
           end
@@ -114,8 +114,9 @@ class Vanagon
           case @extension
           when '.tar.gz', '.tgz'
             return @file.chomp(@extension)
-          when '.gem'
-            # Because we cd into the source dir, using ./ here avoids special casing gems in the Makefile
+          when '.gem', '.ru', '.txt', '.conf', '.ini'
+            # Because we cd into the source dir, using ./ here avoids special casing single file
+            # sources in the Makefile
             return './'
           else
             fail "Don't know how to guess dirname for '#{@file}' with extension: '#{@extension}'. Please teach me."


### PR DESCRIPTION
Prior to this commit, Vanagon assumed that sources were either
compressed files (tar.gz) or gems. This commit adds the ability for
vanagon to have .conf, .txt, .ru, .ini files as sources.
