### PR TITLE
(RE-4159) Add versioned provides and replaces to vanagon

### DIFF
--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -1,4 +1,5 @@
 require 'vanagon/component'
+require 'ostruct'
 require 'json'
 
 class Vanagon
@@ -126,15 +127,17 @@ class Vanagon
       # Indicates that this component replaces a system level package. Replaces can be collected and used by the project and package.
       #
       # @param replacement [String] a package that is replaced with this component
-      def replaces(replacement)
-        @component.replaces << replacement
+      # @param version [String] the version of the package that is replaced
+      def replaces(replacement, version = nil)
+        @component.replaces << OpenStruct.new(:replacement => replacement, :version => version)
       end
 
       # Indicates that this component provides a system level package. Provides can be collected and used by the project and package.
       #
       # @param provide [String] a package that is provided with this component
-      def provides(provide)
-        @component.provides << provide
+      # @param version [String] the version of the package that is provided with this component
+      def provides(provide, version = nil)
+        @component.provides << OpenStruct.new(:provide => provide, :version => version)
       end
 
       # install_service adds the commands to install the various files on

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -127,8 +127,15 @@ end" }
       comp = Vanagon::Component::DSL.new('provides-test', {}, {})
       comp.provides('thing1')
       comp.provides('thing2')
-      expect(comp._component.provides).to include('thing1')
-      expect(comp._component.provides).to include('thing2')
+      expect(comp._component.provides.first.provide).to eq('thing1')
+      expect(comp._component.provides.last.provide).to eq('thing2')
+    end
+
+    it 'supports versioned provides' do
+      comp = Vanagon::Component::DSL.new('provides-test', {}, {})
+      comp.provides('thing1', '1.2.3')
+      expect(comp._component.provides.first.provide).to eq('thing1')
+      expect(comp._component.provides.first.version).to eq('1.2.3')
     end
   end
 
@@ -137,8 +144,15 @@ end" }
       comp = Vanagon::Component::DSL.new('replaces-test', {}, {})
       comp.replaces('thing1')
       comp.replaces('thing2')
-      expect(comp._component.replaces).to be_include('thing1')
-      expect(comp._component.replaces).to be_include('thing2')
+      expect(comp._component.replaces.first.replacement).to eq('thing1')
+      expect(comp._component.replaces.last.replacement).to eq('thing2')
+    end
+
+    it 'supports versioned replaces' do
+      comp = Vanagon::Component::DSL.new('replaces-test', {}, {})
+      comp.replaces('thing1', '1.2.3')
+      expect(comp._component.replaces.first.replacement).to eq('thing1')
+      expect(comp._component.replaces.first.version).to eq('1.2.3')
     end
   end
 

--- a/templates/deb/control.erb
+++ b/templates/deb/control.erb
@@ -10,10 +10,10 @@ Package: <%= @name %>
 Architecture: any
 Section: admin
 Priority: optional
-Replaces: <%= get_replaces.join(", ") %>
-Conflicts: <%= get_replaces.join(", ") %>
+Replaces: <%= get_replaces.map { |replace| "#{replace.replacement} #{replace.version ? "(<< #{replace.version})" : ""}" }.join(", ") %>
+Conflicts: <%= get_replaces.map { |replace| "#{replace.replacement} #{replace.version ? "(<< #{replace.version})" : ""}" }.join(", ") %>
 Depends: <%= get_requires.join(", ") %>
-Provides: <%= get_provides.join(", ") %>
+Provides: <%= get_provides.map { |prov| prov.provide }.join(", ") %>
 Description: <%= @description.lines.first.chomp %>
  <%= @description.lines[1..-1].join("\n ") -%>
  .

--- a/templates/rpm/project.spec.erb
+++ b/templates/rpm/project.spec.erb
@@ -40,13 +40,13 @@ Requires: chkconfig
   <%- end -%>
 <%- end -%>
 
-<%- get_replaces.each do |replacement| -%>
-Conflicts: <%= replacement %>
-Obsoletes: <%= replacement %>
+<%- get_replaces.each do |replace| -%>
+Conflicts: <%= replace.replacement %><%= replace.version ? " < #{replace.version}" : "" %>
+Obsoletes: <%= replace.replacement %><%= replace.version ? " < #{replace.version}" : "" %>
 <%- end -%>
 
-<%- get_provides.each do |provide| -%>
-Provides: <%= provide %>
+<%- get_provides.each do |prov| -%>
+Provides: <%= prov.provide %><%= prov.version ? " >= #{prov.version}" : "" %>
 <%- end -%>
 
 %description


### PR DESCRIPTION
Using unversioned provides and replaces works on modern versions of rpm,
but falls down on EL5 and earlier. It is also not a best practice in
packaging. This commit adds the ability to version provides and
replaces, and updates the packaging accordingly. Debian packaging
doesn't support versioned provides, so that remains unversioned.
