### PR TITLE
(RE-4222) Fix submodule init

### DIFF
--- a/lib/vanagon/component/source/git.rb
+++ b/lib/vanagon/component/source/git.rb
@@ -26,9 +26,10 @@ class Vanagon
         # a side effect.
         def fetch
           Dir.chdir(@workdir) do
-            git('clone', '--recursive', @url)
+            git('clone', @url)
             Dir.chdir(dirname) do
               git('checkout', @ref)
+              git('submodule', 'update', '--init', '--recursive')
               @version = git_version
             end
           end


### PR DESCRIPTION
Without this change, submodules are initialized to the master branch,
not the requested ref. Fix by doing submodule update after checkout of
the ref.
