### PR TITLE
(RE-4235) Add target_repo method to project DSL

### DIFF
--- a/lib/vanagon/platform/deb.rb
+++ b/lib/vanagon/platform/deb.rb
@@ -6,14 +6,15 @@ class Vanagon
       # @param project [Vanagon::Project] project to build a debian package of
       # @return [Array] list of commands required to build a debian package for the given project from a tarball
       def generate_package(project)
-        ["mkdir -p output/#{output_dir}",
+        target_dir = project.repo ? output_dir(project.repo) : output_dir
+        ["mkdir -p output/#{target_dir}",
         "mkdir -p $(tempdir)/#{project.name}-#{project.version}",
         "cp #{project.name}-#{project.version}.tar.gz $(tempdir)/#{project.name}_#{project.version}.orig.tar.gz",
         "cat file-list >> debian/install",
         "cp -pr debian $(tempdir)/#{project.name}-#{project.version}",
         "gunzip -c #{project.name}-#{project.version}.tar.gz | tar -C '$(tempdir)/#{project.name}-#{project.version}' --strip-components 1 -xf -",
         "(cd $(tempdir)/#{project.name}-#{project.version}; debuild --no-lintian -uc -us)",
-        "cp $(tempdir)/*.deb ./output/#{output_dir}"]
+        "cp $(tempdir)/*.deb ./output/#{target_dir}"]
       end
 
       # Method to generate the files required to build a debian package for the project
@@ -48,8 +49,8 @@ class Vanagon
       # use some standard tools to ship internally.
       #
       # @return [String] relative path to where debian packages should be staged
-      def output_dir
-        File.join("deb", @codename)
+      def output_dir(target_repo = "")
+        File.join("deb", @codename, target_repo)
       end
 
       # Constructor. Sets up some defaults for the debian platform and calls the parent constructor

--- a/lib/vanagon/platform/rpm.rb
+++ b/lib/vanagon/platform/rpm.rb
@@ -9,13 +9,14 @@ class Vanagon
       # @param project [Vanagon::Project] project to build an rpm package of
       # @return [Array] list of commands required to build an rpm package for the given project from a tarball
       def generate_package(project)
+        target_dir = project.repo ? output_dir(project.repo) : output_dir
         ["mkdir -p $(tempdir)/rpmbuild/{SOURCES,SPECS,BUILD,RPMS,SRPMS}",
         "cp #{project.name}-#{project.version}.tar.gz $(tempdir)/rpmbuild/SOURCES",
         "cp file-list-for-rpm $(tempdir)/rpmbuild/SOURCES",
         "cp #{project.name}.spec $(tempdir)/rpmbuild/SPECS",
         "rpmbuild -bb #{rpm_defines} $(tempdir)/rpmbuild/SPECS/#{project.name}.spec",
-        "mkdir -p output/#{output_dir}",
-        "cp $(tempdir)/rpmbuild/*RPMS/**/*.rpm ./output/#{output_dir}"]
+        "mkdir -p output/#{target_dir}",
+        "cp $(tempdir)/rpmbuild/*RPMS/**/*.rpm ./output/#{target_dir}"]
       end
 
       # Method to generate the files required to build an rpm package for the project
@@ -39,8 +40,8 @@ class Vanagon
       # use some standard tools to ship internally.
       #
       # @return [String] relative path to where rpm packages should be staged
-      def output_dir
-        File.join(@os_name, @os_version, "products", @architecture)
+      def output_dir(target_repo = "products")
+        File.join(@os_name, @os_version, target_repo, @architecture)
       end
 
       def rpm_defines

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -9,7 +9,7 @@ class Vanagon
     include Vanagon::Utilities
     attr_accessor :components, :settings, :platform, :configdir, :name
     attr_accessor :version, :directories, :license, :description, :vendor
-    attr_accessor :homepage, :requires, :user
+    attr_accessor :homepage, :requires, :user, :repo
 
     # Loads a given project from the configdir
     #

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -144,6 +144,13 @@ class Vanagon
           @project.components << component if component.url
         end
       end
+
+      # Adds a target repo for the project
+      #
+      # @param repo [String] name of the target repository to ship to used in laying out the packages on disk
+      def target_repo(repo)
+        @project.repo = repo
+      end
     end
   end
 end

--- a/spec/lib/vanagon/platform/deb_spec.rb
+++ b/spec/lib/vanagon/platform/deb_spec.rb
@@ -4,20 +4,22 @@ describe "Vanagon::Platform::DEB" do
   let(:platforms) do
     [
       {
-        :name         => "ubuntu-10.04-i386",
-        :os_name      => "ubuntu",
-        :os_version   => "10.04",
-        :architecture => "i386",
-        :output_dir   => "deb/lucid",
-        :codename     => "lucid",
+        :name                   => "ubuntu-10.04-i386",
+        :os_name                => "ubuntu",
+        :os_version             => "10.04",
+        :architecture           => "i386",
+        :output_dir             => "deb/lucid/",
+        :output_dir_with_target => "deb/lucid/thing",
+        :codename               => "lucid",
       },
       {
-        :name         => "debian-7-amd64",
-        :os_name      => "debian",
-        :os_version   => "7",
-        :architecture => "amd64",
-        :output_dir   => "deb/wheezy",
-        :codename     => "wheezy",
+        :name                   => "debian-7-amd64",
+        :os_name                => "debian",
+        :os_version             => "7",
+        :architecture           => "amd64",
+        :output_dir             => "deb/wheezy/",
+        :output_dir_with_target => "deb/wheezy/thing",
+        :codename               => "wheezy",
       },
     ]
   end
@@ -35,6 +37,21 @@ describe "Vanagon::Platform::DEB" do
         cur_plat = Vanagon::Platform::DSL.new(plat[:name])
         cur_plat.instance_eval(plat_block)
         expect(cur_plat._platform.output_dir).to eq(plat[:output_dir])
+      end
+    end
+
+    it "adds the target repo in the right place" do
+      platforms.each do |plat|
+
+        plat_block = %Q[
+        platform "#{plat[:name]}" do |plat|
+          plat.codename "#{plat[:codename]}"
+        end
+        ]
+
+        cur_plat = Vanagon::Platform::DSL.new(plat[:name])
+        cur_plat.instance_eval(plat_block)
+        expect(cur_plat._platform.output_dir('thing')).to eq(plat[:output_dir_with_target])
       end
     end
   end

--- a/spec/lib/vanagon/platform/rpm_spec.rb
+++ b/spec/lib/vanagon/platform/rpm_spec.rb
@@ -4,18 +4,20 @@ describe "Vanagon::Platform::RPM" do
   let(:platforms) do
     [
       {
-        :name         => "el-5-i386",
-        :os_name      => "el",
-        :os_version   => "5",
-        :architecture => "i386",
-        :output_dir   => "el/5/products/i386",
+        :name                   => "el-5-i386",
+        :os_name                => "el",
+        :os_version             => "5",
+        :architecture           => "i386",
+        :output_dir             => "el/5/products/i386",
+        :output_dir_with_target => "el/5/thing/i386",
       },
       {
-        :name         => "fedora-21-x86_64",
-        :os_name      => "fedora",
-        :os_version   => "21",
-        :architecture => "x86_64",
-        :output_dir   => "fedora/21/products/x86_64",
+        :name                   => "fedora-21-x86_64",
+        :os_name                => "fedora",
+        :os_version             => "21",
+        :architecture           => "x86_64",
+        :output_dir             => "fedora/21/products/x86_64",
+        :output_dir_with_target => "fedora/21/thing/x86_64",
       },
     ]
   end
@@ -25,6 +27,13 @@ describe "Vanagon::Platform::RPM" do
       platforms.each do |plat|
         cur_plat = Vanagon::Platform::RPM.new(plat[:name])
         expect(cur_plat.output_dir).to eq(plat[:output_dir])
+      end
+    end
+
+    it "adds the target repo in the right way" do
+      platforms.each do |plat|
+        cur_plat = Vanagon::Platform::RPM.new(plat[:name])
+        expect(cur_plat.output_dir('thing')).to eq(plat[:output_dir_with_target])
       end
     end
   end

--- a/spec/lib/vanagon/project/dsl_spec.rb
+++ b/spec/lib/vanagon/project/dsl_spec.rb
@@ -36,4 +36,13 @@ end" }
       expect(proj._project.user).to eq(Vanagon::Common::User.new('test-user'))
     end
   end
+
+  describe '#target_repo' do
+    it 'sets the target_repo for the project' do
+      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj.instance_eval(project_block)
+      proj.target_repo "pc1"
+      expect(proj._project.repo).to eq("pc1")
+    end
+  end
 end


### PR DESCRIPTION
In order to ship to alternate repositories, the initial packaging layout
must first match the layout expected by packaging. This commit adds a
target_repo method to the vanagon DSL to allow this. When set the built
artifacts will be laid out with the alternate repo in the same location
as currently done in packaging.
