### PR TITLE
(maint) Break out tar to be specified in the platform definition

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -62,7 +62,7 @@ class Vanagon
       @source = Vanagon::Component::Source.source(@url, @options, workdir)
       @source.fetch
       @source.verify
-      @extract_with = @source.extract
+      @extract_with = @source.extract(@platform.tar)
       @dirname = @source.dirname
 
       # Git based sources probably won't set the version, so we load it if it hasn't been already set

--- a/lib/vanagon/component/source/http.rb
+++ b/lib/vanagon/component/source/http.rb
@@ -88,12 +88,13 @@ class Vanagon
 
         # Gets the command to extract the archive given if needed (uses @extension)
         #
+        # @param tar [String] the tar command to use
         # @return [String, nil] command to extract the source
         # @raise [RuntimeError] an exception is raised if there is no known extraction method for @extension
-        def extract
+        def extract(tar)
           case @extension
           when '.tar.gz', '.tgz'
-            return "gunzip -c '#{@file}' | tar xf -"
+            return "gunzip -c '#{@file}' | '#{tar}' xf -"
           when '.gem', '.ru', '.txt', '.conf', '.ini', '.gpg'
             # Don't need to unpack gems, ru, txt, conf, ini, gpg
             return nil

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -2,7 +2,7 @@ require 'vanagon/platform/dsl'
 
 class Vanagon
   class Platform
-    attr_accessor :make, :servicedir, :defaultdir, :provisioning, :num_cores
+    attr_accessor :make, :servicedir, :defaultdir, :provisioning, :num_cores, :tar
     attr_accessor :build_dependencies, :name, :vcloud_name, :cflags, :ldflags, :settings
     attr_accessor :servicetype, :patch, :architecture, :codename, :os_name, :os_version
     attr_accessor :docker_image, :ssh_port

--- a/lib/vanagon/platform/deb.rb
+++ b/lib/vanagon/platform/deb.rb
@@ -12,7 +12,7 @@ class Vanagon
         "cp #{project.name}-#{project.version}.tar.gz $(tempdir)/#{project.name}_#{project.version}.orig.tar.gz",
         "cat file-list >> debian/install",
         "cp -pr debian $(tempdir)/#{project.name}-#{project.version}",
-        "gunzip -c #{project.name}-#{project.version}.tar.gz | tar -C '$(tempdir)/#{project.name}-#{project.version}' --strip-components 1 -xf -",
+        "gunzip -c #{project.name}-#{project.version}.tar.gz | '#{@tar}' -C '$(tempdir)/#{project.name}-#{project.version}' --strip-components 1 -xf -",
         "(cd $(tempdir)/#{project.name}-#{project.version}; debuild --no-lintian -uc -us)",
         "cp $(tempdir)/*.deb ./output/#{target_dir}"]
       end
@@ -60,6 +60,7 @@ class Vanagon
       def initialize(name)
         @name = name
         @make = "/usr/bin/make"
+        @tar = "tar"
         @patch = "/usr/bin/patch"
         @num_cores = "/usr/bin/nproc"
         super(name)

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -63,6 +63,13 @@ class Vanagon
         @platform.make = make_cmd
       end
 
+      # Set the path to tar for the platform
+      #
+      # @param tar [String] Full path to the tar command for the platform
+      def tar(tar_cmd)
+        @platform.tar = tar_cmd
+      end
+
       # Set the path to patch for the platform
       #
       # @param patch_cmd [String] Full path to the patch command for the platform

--- a/lib/vanagon/platform/rpm.rb
+++ b/lib/vanagon/platform/rpm.rb
@@ -57,6 +57,7 @@ class Vanagon
       def initialize(name)
         @name = name
         @make = "/usr/bin/make"
+        @tar = "tar"
         @patch = "/usr/bin/patch"
         @num_cores = "/bin/grep -c 'processor' /proc/cpuinfo"
         super(name)

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -143,8 +143,8 @@ class Vanagon
     def pack_tarball_command
       tar_root = "#{@name}-#{@version}"
       ["mkdir -p '#{tar_root}'",
-       %Q[tar -cf - -T file-list #{get_tarball_files.join(" ")} | ( cd '#{tar_root}/'; tar xfp -)],
-       %Q[tar -cf - #{tar_root}/ | gzip -9c > #{tar_root}.tar.gz]].join("\n\t")
+       %Q['#{@platform.tar}' -cf - -T file-list #{get_tarball_files.join(" ")} | ( cd '#{tar_root}/'; '#{@platform.tar}' xfp -)],
+       %Q['#{@platform.tar}' -cf - #{tar_root}/ | gzip -9c > #{tar_root}.tar.gz]].join("\n\t")
     end
 
     # Evaluates the makefile template and writes the contents to the workdir


### PR DESCRIPTION
Tar was hard-coded as 'tar' in some spots. I'd like to be able to
specify tar for platform that have multiple options (BSD Tar and/or GNU
tar). This mostly matters for traditional UNIX systems.
