### PR TITLE
(maint) Allow rpmbuild command to be specified per platform

### DIFF
--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -5,7 +5,7 @@ class Vanagon
     attr_accessor :make, :servicedir, :defaultdir, :provisioning, :num_cores, :tar
     attr_accessor :build_dependencies, :name, :vcloud_name, :cflags, :ldflags, :settings
     attr_accessor :servicetype, :patch, :architecture, :codename, :os_name, :os_version
-    attr_accessor :docker_image, :ssh_port
+    attr_accessor :docker_image, :ssh_port, :rpmbuild
 
     # Platform names currently contain some information about the platform. Fields
     # within the name are delimited by the '-' character, and this regex can be used to

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -70,6 +70,13 @@ class Vanagon
         @platform.tar = tar_cmd
       end
 
+      # Set the path to rpmbuild for the platform
+      #
+      # @param rpmbuild_cmd [String] Full path to rpmbuild with arguments to be used by default
+      def rpmbuild(rpmbuild_cmd)
+        @platform.rpmbuild = rpmbuild_cmd
+      end
+
       # Set the path to patch for the platform
       #
       # @param patch_cmd [String] Full path to the patch command for the platform

--- a/lib/vanagon/platform/rpm.rb
+++ b/lib/vanagon/platform/rpm.rb
@@ -14,7 +14,7 @@ class Vanagon
         "cp #{project.name}-#{project.version}.tar.gz $(tempdir)/rpmbuild/SOURCES",
         "cp file-list-for-rpm $(tempdir)/rpmbuild/SOURCES",
         "cp #{project.name}.spec $(tempdir)/rpmbuild/SPECS",
-        "rpmbuild -bb #{rpm_defines} $(tempdir)/rpmbuild/SPECS/#{project.name}.spec",
+        "#{@rpmbuild} -bb #{rpm_defines} $(tempdir)/rpmbuild/SPECS/#{project.name}.spec",
         "mkdir -p output/#{target_dir}",
         "cp $(tempdir)/rpmbuild/*RPMS/**/*.rpm ./output/#{target_dir}"]
       end
@@ -60,6 +60,7 @@ class Vanagon
         @tar = "tar"
         @patch = "/usr/bin/patch"
         @num_cores = "/bin/grep -c 'processor' /proc/cpuinfo"
+        @rpmbuild = "/usr/bin/rpmbuild"
         super(name)
       end
     end


### PR DESCRIPTION
You'd think that rpmbuild works the same on all platforms, well you'd
pretty much be right unless you time-travelled to 1999 and fork RPM and
put it on AIX. Then you have to go back to the days when rpm was only
one command you just passed '-bb' to rpm to build stuff. It's like
RHEL3, but worse.

This commit just plumbs the ability to specify rpmbuild command with
arguments and sets a sane default for all platforms. You'll need to
specify the AIX rpmbuild command inside its platform definition.
