### PR TITLE
[needs test] (RE-4254) Fix yum_repo helper for EL5

### DIFF
--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -174,7 +174,15 @@ class Vanagon
           self.provision_with "curl -o '/etc/yum.repos.d/#{reponame}' '#{definition}'"
         else ( definition =~ /rpm$/ )
           # repo definition is an rpm (like puppetlabs-release)
-          self.provision_with "yum localinstall -y '#{definition}'"
+          if @platform.os_version.to_i < 6
+            # This can likely be done with just rpm itself (minus curl) however
+            # with a http_proxy curl has many more options avavailable for
+            # usage than rpm raw does. So for the most compatibility, we have
+            # chosen curl.
+            self.provision_with "curl -o local.rpm '#{definition}'; rpm -Uvh local.rpm; rm -f local.rpm"
+          else
+            self.provision_with "yum localinstall -y '#{definition}'"
+          end
         end
       end
 


### PR DESCRIPTION
When using EL5, the yum_repo helper doesn't work against an rpm target
because yum is just too darn old to do a yum localinstall against an
http target. You must first download the rpm, then install it.

This could have been implemented with just a raw call to rpm, but since
curl has a better ability to work with http_proxy environment variables,
and a curlrc, the safer thing seems to be to download the package,
install it and then remove it. This is also how the helpers for zypper
and apt are implemented, so for congruity, we'll keep it that way.
