### PR TITLE
no-extract-for-git

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -62,7 +62,7 @@ class Vanagon
       @source = Vanagon::Component::Source.source(@url, @options, workdir)
       @source.fetch
       @source.verify
-      @extract_with = @source.extract(@platform.tar)
+      @extract_with = @source.extract(@platform.tar) if @source.respond_to?(extract)
       @dirname = @source.dirname
 
       # Git based sources probably won't set the version, so we load it if it hasn't been already set

--- a/lib/vanagon/component/source/git.rb
+++ b/lib/vanagon/component/source/git.rb
@@ -46,15 +46,6 @@ class Vanagon
         def dirname
           File.basename(@url).sub(/\.git/, '')
         end
-
-        # The command to extract the source. For git, it is already unpacked,
-        # no need to extract it further.
-        #
-        # @return [nil]
-        def extract
-          # Nothing to extract
-          return nil
-        end
       end
     end
   end


### PR DESCRIPTION
This allows projects with git-based components to work with vanagon. This was broken by #70.
