### PR TITLE
(RE-4097) Explicitly call bash

### DIFF
--- a/lib/vanagon/platform/rpm.rb
+++ b/lib/vanagon/platform/rpm.rb
@@ -10,7 +10,7 @@ class Vanagon
       # @return [Array] list of commands required to build an rpm package for the given project from a tarball
       def generate_package(project)
         target_dir = project.repo ? output_dir(project.repo) : output_dir
-        ["mkdir -p $(tempdir)/rpmbuild/{SOURCES,SPECS,BUILD,RPMS,SRPMS}",
+        ["bash -c 'mkdir -p $(tempdir)/rpmbuild/{SOURCES,SPECS,BUILD,RPMS,SRPMS}'",
         "cp #{project.name}-#{project.version}.tar.gz $(tempdir)/rpmbuild/SOURCES",
         "cp file-list-for-rpm $(tempdir)/rpmbuild/SOURCES",
         "cp #{project.name}.spec $(tempdir)/rpmbuild/SPECS",


### PR DESCRIPTION
Shell expansions works differently in different shells. Prior to this
commit, there was an implied assumption that when executing remote
commands over ssh, bash (or something bash compatible) would be the
shell. That doesn't hold true on traditional unix where sh or ksh is the
default shell when executing remote commands over ssh.

This commit changes the call to be 'bash -c' and then the command,
rather than just assuming bash.
