### PR TITLE
(RE-4097) Install command needs to be GNU compatible

### DIFF
--- a/templates/rpm/project.spec.erb
+++ b/templates/rpm/project.spec.erb
@@ -63,6 +63,7 @@ Contains the following components:
 %clean
 
 %install
+test -d /opt/freeware/bin && export PATH="/opt/freeware/bin:${PATH}"
 rm -rf %{buildroot}
 install -d %{buildroot}
 


### PR DESCRIPTION
We assume that the install command is GNU compatible in the RPM spec
file template. Sadly, not all install commands are GNU compatible. Since
ginstall is normally available in an alternate PATH on traditional UNIX,
this commit uses that.

This commit adds a line to the spec file to modify PATH if the directory
/opt/freeware/bin is found, prepend that to $PATH. This should make the
%install section of the spec file favor GNU compatible install, while
having minmal side effects elsewhere.
