### PR TITLE
(maint) Only run platform provisioning if set

### DIFF
--- a/lib/vanagon/engine/base.rb
+++ b/lib/vanagon/engine/base.rb
@@ -32,8 +32,10 @@ class Vanagon
       # Applies the steps needed to extend the system to build packages against
       # the target system
       def setup
-        script = @platform.provisioning.join(' ; ')
-        dispatch(script)
+        unless @platform.provisioning.empty?
+          script = @platform.provisioning.join(' ; ')
+          dispatch(script)
+        end
       end
 
       # This method will take care of validation and target selection all at


### PR DESCRIPTION
If platform provisioning is empty, the ssh call to the host will have no
command to execute, which will leave the ssh session open. The build
won't proceed, which is unfortunate. This commit addresses that by only
running the provisioning script if it has content.
