### PR TITLE
(RE-4363) rpm -bb on AIX needs to use GNU tar.

### DIFF
--- a/lib/vanagon/platform/rpm.rb
+++ b/lib/vanagon/platform/rpm.rb
@@ -14,7 +14,7 @@ class Vanagon
         "cp #{project.name}-#{project.version}.tar.gz $(tempdir)/rpmbuild/SOURCES",
         "cp file-list-for-rpm $(tempdir)/rpmbuild/SOURCES",
         "cp #{project.name}.spec $(tempdir)/rpmbuild/SPECS",
-        "#{@rpmbuild} -bb #{rpm_defines} $(tempdir)/rpmbuild/SPECS/#{project.name}.spec",
+        "PATH=/opt/freeware/bin:$$PATH #{@rpmbuild} -bb #{rpm_defines} $(tempdir)/rpmbuild/SPECS/#{project.name}.spec",
         "mkdir -p output/#{target_dir}",
         "cp $(tempdir)/rpmbuild/*RPMS/**/*.rpm ./output/#{target_dir}"]
       end


### PR DESCRIPTION
rpm -bb assumes that you're using a GNU compatible tar when extracting
source. We'll need to preface calls to rpm to ensure that GNU tar is in
the path during the rpm creation.
