### PR TITLE
(RE-4257) Add more verbose output for component source fetching

### DIFF
--- a/lib/vanagon/component/source/git.rb
+++ b/lib/vanagon/component/source/git.rb
@@ -25,6 +25,7 @@ class Vanagon
         # and check out the ref. Also sets the version if there is a git tag as
         # a side effect.
         def fetch
+          puts "Cloning ref '#{@ref}' from url '#{@url}'"
           Dir.chdir(@workdir) do
             git('clone', @url)
             Dir.chdir(dirname) do

--- a/lib/vanagon/component/source/http.rb
+++ b/lib/vanagon/component/source/http.rb
@@ -48,6 +48,7 @@ class Vanagon
         def download
           uri = URI.parse(@url)
           target_file = File.basename(uri.path)
+          puts "Downloading file '#{target_file}' from url '#{@url}'"
 
           case uri.scheme
           when 'http', 'https'


### PR DESCRIPTION
Previously when fetching a git source you would need to guess as to what
the ref was and would have no idea what url was being cloned. This
commit adds some basic notifications to the build of what url is being
fetched, and what ref for git, or what file for http sources.
