### PR TITLE
(RE-4195) Allow project and component to share same name

### DIFF
--- a/templates/Makefile.erb
+++ b/templates/Makefile.erb
@@ -24,7 +24,7 @@ file-list-after-build: <%= @components.map {|comp| comp.name }.join(" ") %>
 <%= @name %>-<%= @version %>.tar.gz: file-list
 	<%= pack_tarball_command %>
 
-file-list: <%= dirnames.join(' ') %> <%= @name %>
+file-list: <%= dirnames.join(' ') %> <%= @name %>-project
 	comm -23 file-list-after-build file-list-before-build > file-list
 	comm -23 file-list-after-build file-list-before-build | sed -e 's/\(^.*\s.*$$\)/"\1"/g' > file-list-for-rpm
 
@@ -33,8 +33,8 @@ file-list: <%= dirnames.join(' ') %> <%= @name %>
 	mkdir -p <%= dir %>
 <%- end %>
 
-<%= @name %>: file-list-after-build
-	touch <%= @name %>
+<%= @name %>-project: file-list-after-build
+	touch <%= @name %>-project
 
 <%- @components.each do |comp| -%>
 <%= comp.name %>: <%= list_component_dependencies(comp).join(" ") %> <%= comp.name %>-install


### PR DESCRIPTION
Previously if a project and a component shared the same name there would
be two targets in the makefile with the same name, which would break
awesomely in some cases. This commit avoids that problem by adding a
-project suffix to the project named target to avoid that ambiguity.
