### PR TITLE
(RE-4374) Add noarch project dsl method

### DIFF
--- a/lib/vanagon/platform/deb.rb
+++ b/lib/vanagon/platform/deb.rb
@@ -42,7 +42,7 @@ class Vanagon
       # @param project [Vanagon::Project] project to name
       # @return [String] name of the debian package for this project
       def package_name(project)
-        "#{project.name}_#{project.version}-1#{@codename}_#{@architecture}.deb"
+        "#{project.name}_#{project.version}-1#{@codename}_#{project.noarch ? 'all' : @architecture}.deb"
       end
 
       # Get the expected output dir for the debian packages. This allows us to

--- a/lib/vanagon/platform/rpm.rb
+++ b/lib/vanagon/platform/rpm.rb
@@ -33,7 +33,7 @@ class Vanagon
       # @param project [Vanagon::Project] project to name
       # @return [String] name of the rpm package for this project
       def package_name(project)
-        "#{project.name}-#{project.version}-1.#{@architecture}.rpm"
+        "#{project.name}-#{project.version}-1.#{project.noarch ? 'noarch' : @architecture}.rpm"
       end
 
       # Get the expected output dir for the rpm packages. This allows us to

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -9,7 +9,7 @@ class Vanagon
     include Vanagon::Utilities
     attr_accessor :components, :settings, :platform, :configdir, :name
     attr_accessor :version, :directories, :license, :description, :vendor
-    attr_accessor :homepage, :requires, :user, :repo
+    attr_accessor :homepage, :requires, :user, :repo, :noarch
 
     # Loads a given project from the configdir
     #

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -151,6 +151,11 @@ class Vanagon
       def target_repo(repo)
         @project.repo = repo
       end
+
+      # Sets the project to be architecture independent, or noarch
+      def noarch
+        @project.noarch = true
+      end
     end
   end
 end

--- a/spec/lib/vanagon/project/dsl_spec.rb
+++ b/spec/lib/vanagon/project/dsl_spec.rb
@@ -45,4 +45,13 @@ end" }
       expect(proj._project.repo).to eq("pc1")
     end
   end
+
+  describe '#noarch' do
+    it 'sets noarch on the project to true' do
+      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj.instance_eval(project_block)
+      proj.noarch
+      expect(proj._project.noarch).to eq(true)
+    end
+  end
 end

--- a/templates/deb/control.erb
+++ b/templates/deb/control.erb
@@ -7,7 +7,7 @@ Standards-Version: 3.9.1
 Homepage: <%= @homepage %>
 
 Package: <%= @name %>
-Architecture: any
+Architecture: <%= @noarch ? 'all' : 'any' %>
 Section: admin
 Priority: optional
 Replaces: <%= get_replaces.map { |replace| "#{replace.replacement} #{replace.version ? "(<< #{replace.version})" : ""}" }.join(", ") %>

--- a/templates/rpm/project.spec.erb
+++ b/templates/rpm/project.spec.erb
@@ -10,6 +10,9 @@ Group:          System Environment/Base
 URL:            <%= @homepage %>
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+<% if @noarch -%>
+BuildArch:      noarch
+<% end -%>
 
 Source0:        %{name}-%{version}.tar.gz
 Source1:        file-list-for-rpm


### PR DESCRIPTION
Previously vanagon assumed all projects would be arch specific. This is
not the case, so this commit adds a noarch dsl method to vanagon
projects where they can declare that they are noarch. Noarch package
templates have the correct bits set to trigger noarch builds and the
expected package names are updated as well.
