### PR TITLE
(RE-4381) Update rpm spec to not run python byte compile

### DIFF
--- a/templates/rpm/project.spec.erb
+++ b/templates/rpm/project.spec.erb
@@ -1,5 +1,9 @@
 %global debug_package %{nil}
 
+# Turn off the brp-python-bytecompile script
+%global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
+#
+
 Name:           <%= @name %>
 Version:        <%= @version %>
 Release:        1%{?dist}


### PR DESCRIPTION
Prior to this commit, we were adhering to the normal RPM convention of
letting the package byte-compile python files for optimizations at
runtime. This isn't a terrible idea, however it is incompatible with the
way vanagon calculates file-lists and deltas to see what should be
included in the package.

This patch simply disables the call to the python-byte-compile brp
script.
