### PR TITLE
(RE-4422) Allow AIX package installation

### DIFF
--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -154,6 +154,28 @@ class Vanagon
         @platform.codename = name
       end
 
+      # Allow package installation on AIX.
+      #   Since AIX doesn't have network dependency resolution, we'll just use
+      #   rpm. This method basically just accepts a mirror and then the
+      #   complete RPM filenames to install. If the package requires other
+      #   packages, you should specificy them as an array. Otherwise you can
+      #   install a signle or multiple packages at a time.
+      #
+      # @param mirror [String]  The url where you have your AIX rpm packages
+      #   (e.g. http://int-resources.corp.puppetlabs.net/AIX_MIRROR)
+      # @param packages [String or Array] Single string or list of packages to install
+      def aix_package(mirror, packages)
+        installation_string = ""
+        if packages.respond_to? :each
+          packages.each do |pkg|
+            installation_string << " " +  mirror + '/' +  pkg
+          end
+          self.provision_with "rpm -Uvh --replacepkgs #{installation_string}"
+        else
+          self.provision_with "rpm -Uvh --replacepkgs #{mirror}/#{packages}"
+        end
+      end
+
       # Helper to setup a apt repository on a target system
       #
       # @param definition [String] the repo setup URI or DEB file


### PR DESCRIPTION
This commit adds a method to allow rpm installation on AIX platforms.

Since AIX doesn't have network dependency resolution, we'll just use
rpm. This method basically just accepts a mirror and then the complete
RPM filenames to install. If the package requires other packages, you
should specificy them as an array. Otherwise you can install a signle or
multiple packages at a time.

Example usage in a platform definition file:

```
 plat.aix_package('http://int-resources.corp.puppetlabs.net/AIX_MIRROR/',\
   [ 'mktemp-1.7-1.aix5.1.ppc.rpm' ,'cpio-2.5-1.aix5.1.ppc.rpm'  ] )
```
