### PR TITLE
(RE-4423) Add number of cores for AIX

### DIFF
--- a/lib/vanagon/platform/rpm.rb
+++ b/lib/vanagon/platform/rpm.rb
@@ -60,6 +60,9 @@ class Vanagon
         @tar = "tar"
         @patch = "/usr/bin/patch"
         @num_cores = "/bin/grep -c 'processor' /proc/cpuinfo"
+        if is_aix?
+          @num_cores = "lsdev -Cc processor |wc -l"
+        end
         @rpmbuild = "/usr/bin/rpmbuild"
         super(name)
       end


### PR DESCRIPTION
Prior to this patch, the num_cores method blew up on AIX since it was
tracing /proc like it was a linux box. This change simply instructs
vanagon to use a different command set when the platform is aix.
