### PR TITLE
(RE-3978) Set known hosts file to /dev/null

### DIFF
--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -192,6 +192,7 @@ class Vanagon
       ssh = find_program_on_path('ssh')
       args = ENV['VANAGON_SSH_KEY'] ? " -i #{ENV['VANAGON_SSH_KEY']}" : ""
       args << " -p #{port} "
+      args << " -o UserKnownHostsFile=/dev/null"
       args << " -o StrictHostKeyChecking=no"
       return ssh + args
     end

--- a/spec/lib/vanagon/utilities_spec.rb
+++ b/spec/lib/vanagon/utilities_spec.rb
@@ -112,6 +112,11 @@ describe "Vanagon::Utilities" do
       expect(Vanagon::Utilities).to receive(:find_program_on_path).with('ssh').and_return('/tmp/ssh')
       expect(Vanagon::Utilities.ssh_command).to include('-o StrictHostKeyChecking=no')
     end
+
+    it 'sets known hosts file to /dev/null' do
+      expect(Vanagon::Utilities).to receive(:find_program_on_path).with('ssh').and_return('/tmp/ssh')
+      expect(Vanagon::Utilities.ssh_command).to include('-o UserKnownHostsFile=/dev/null')
+    end
   end
 
   describe '#retry_with_timeout' do


### PR DESCRIPTION
When using the pooler, over a long enough time period, a host will be
provisioned with the same ip, but a different hostname (or vice versa).
This causes ssh and rsync to present an interactive prompt, which can
break automated builds. This commit adds an option to all ssh and rsync
calls to set the known hosts file to /dev/null to avoid this problem.
/dev/null will never have any hosts listed or stored.
