### PR TITLE
(maint) Update devkit for recent makefile changes

### DIFF
--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -97,7 +97,7 @@ class Vanagon
         @project.make_makefile(@workdir)
         # Builds only the project, skipping packaging into an artifact.
         @engine.ship_workdir(@workdir)
-        @engine.dispatch("#{@platform.make} #{@project.name}")
+        @engine.dispatch("#{@platform.make} #{@project.name}-project")
       rescue => e
         puts e
         puts e.backtrace.join("\n")


### PR DESCRIPTION
A recent change to vanagon updated the makefile to allow components and
projects to share the same name without having 2 targets with the same
name in the makefile. This unfortunately broke the devkit workflow,
which assumes a target with the name of the project will exist in the
makefile. This commit updates the call to make to correspond to the
changes made, appending '-project' to the target.
