### PR TITLE
(RE-4491) Debs should work with spaces in filenames

### DIFF
--- a/lib/vanagon/platform/deb.rb
+++ b/lib/vanagon/platform/deb.rb
@@ -13,6 +13,7 @@ class Vanagon
         "cat file-list >> debian/install",
         "cp -pr debian $(tempdir)/#{project.name}-#{project.version}",
         "gunzip -c #{project.name}-#{project.version}.tar.gz | '#{@tar}' -C '$(tempdir)/#{project.name}-#{project.version}' --strip-components 1 -xf -",
+        "sed -i 's/\ /?/g' $(tempdir)/#{project.name}-#{project.version}/debian/install",
         "(cd $(tempdir)/#{project.name}-#{project.version}; debuild --no-lintian -uc -us)",
         "cp $(tempdir)/*.deb ./output/#{target_dir}"]
       end


### PR DESCRIPTION
Until this fix, vanagon was unable to build debian packages containing
files with spaces in the name/path of the file.

This has been a bug open with debian since 2003. Yay!

As per https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=198507#52 there
is a work-around by just subbing out spaces for ? and letting dh_install
do a pattern match on that instead. This commit just runs some sed on
the debian install file to change that out.

Debian, I still hate you.
