### PR TITLE
(RE-4594) Fall back to older `find` syntax 

### DIFF
--- a/templates/Makefile.erb
+++ b/templates/Makefile.erb
@@ -11,14 +11,14 @@ file-list-before-build:
 <%- if dirnames.empty? -%>
 	touch file-list-before-build
 <%- else -%>
-	find -L <%= dirnames.join(' ') %> -type f | sort > file-list-before-build
+	(find -L <%= dirnames.join(' ') %> -type f 2>/dev/null || find <%= dirnames.join(' ') %> -follow -type f) | sort > file-list-after-build
 <%- end -%>
 
 file-list-after-build: <%= @components.map {|comp| comp.name }.join(" ") %>
 <%- if dirnames.empty? -%>
 	touch file-list-after-build
 <%- else -%>
-	find -L <%= dirnames.join(' ') %> -type f | sort > file-list-after-build
+	(find -L <%= dirnames.join(' ') %> -type f 2>/dev/null || find <%= dirnames.join(' ') %> -follow -type f) | sort > file-list-after-build
 <%- end -%>
 
 <%= @name %>-<%= @version %>.tar.gz: file-list


### PR DESCRIPTION
Currently, `find -L` fails when run on el4. On this platform, we only
have find 4.1 available, which doesn't support the newer `-L` flag. When
we try to pass in this flag to find, it fails, and subsequently vanagon
builds an empty package for el4. This commit updates vanagon to fall
back to the old find syntax to allow us to deal with symlinks on el4 and
other systems that only have old versions of find available
