### PR TITLE
(maint) fix typo

### DIFF
--- a/templates/Makefile.erb
+++ b/templates/Makefile.erb
@@ -11,7 +11,7 @@ file-list-before-build:
 <%- if dirnames.empty? -%>
 	touch file-list-before-build
 <%- else -%>
-	(find -L <%= dirnames.join(' ') %> -type f 2>/dev/null || find <%= dirnames.join(' ') %> -follow -type f) | sort > file-list-after-build
+	(find -L <%= dirnames.join(' ') %> -type f 2>/dev/null || find <%= dirnames.join(' ') %> -follow -type f) | sort > file-list-before-build
 <%- end -%>
 
 file-list-after-build: <%= @components.map {|comp| comp.name }.join(" ") %>


### PR DESCRIPTION
Copy pasta error, this needs to be 'before', not 'after'
