### PR TITLE
(maint) Allow application of multiple patches

### DIFF
--- a/templates/Makefile.erb
+++ b/templates/Makefile.erb
@@ -47,9 +47,10 @@ file-list: <%= dirnames.join(' ') %> <%= @name %>-project
 	<%- unless comp.patches.empty? -%>
 		cd <%= comp.dirname %>; \
 		<%- comp.patches.each do |patch| -%>
-			<%= @platform.patch %> -p1 < ../patches/<%= File.basename(patch) %>
+			<%= @platform.patch %> -p1 < ../patches/<%= File.basename(patch) %>; \
 		<%- end -%>
 	<%- end -%>
+	
 	touch <%= comp.name %>-patch
 
 <%= comp.name %>-configure: <%= comp.name %>-patch


### PR DESCRIPTION
The way the patch application was written, it correctly apply the first
patch before leaving the cd block and ascending to the parent directory,
at which point any subsequent patch applications would fail miserably.
This commit corrects that by ensuring that the patch applications all
happen within the context of the cd.
