### PR TITLE
(RE-4550) Reverse rsync_from arguments

### DIFF
--- a/lib/vanagon/engine/base.rb
+++ b/lib/vanagon/engine/base.rb
@@ -57,7 +57,7 @@ class Vanagon
 
       def retrieve_built_artifact
         FileUtils.mkdir_p("output")
-        Vanagon::Utilities.rsync_from("output/*", "#{@target_user}@#{@target}", "#{@remote_workdir}/output", @platform.ssh_port)
+        Vanagon::Utilities.rsync_from("#{@remote_workdir}/output/*", "#{@target_user}@#{@target}", "output", @platform.ssh_port)
       end
 
       # Ensures that the platform defines the attributes that the engine needs to function.


### PR DESCRIPTION
In the previous PR to add remote build root support for vanagon, the
retrieval arguments were reversed. This broke because there would be no
output directory in root's home to rsync from. This commit fixes that to
reference output on the remote end from under the workdir.
