### PR TITLE
(RE-4610) Enable additional cleanup during builds

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -6,7 +6,7 @@ class Vanagon
     attr_accessor :name, :version, :source, :url, :configure, :build, :install
     attr_accessor :environment, :extract_with, :dirname, :build_requires
     attr_accessor :settings, :platform, :files, :patches, :requires, :service, :options
-    attr_accessor :configfiles, :directories, :replaces, :provides
+    attr_accessor :configfiles, :directories, :replaces, :provides, :cleanup_source
 
     # Loads a given component from the configdir
     #
@@ -63,6 +63,7 @@ class Vanagon
       @source.fetch
       @source.verify
       @extract_with = @source.extract(@platform.tar) if @source.respond_to?(:extract)
+      @cleanup_source = @source.cleanup if @source.respond_to?(:cleanup)
       @dirname = @source.dirname
 
       # Git based sources probably won't set the version, so we load it if it hasn't been already set

--- a/lib/vanagon/component/source/git.rb
+++ b/lib/vanagon/component/source/git.rb
@@ -5,7 +5,7 @@ class Vanagon
     class Source
       class Git
         include Vanagon::Utilities
-        attr_accessor :url, :ref, :workdir, :version
+        attr_accessor :url, :ref, :workdir, :version, :cleanup
 
         # Constructor for the Git source type
         #
@@ -34,6 +34,13 @@ class Vanagon
               @version = git_version
             end
           end
+        end
+
+        # Return the correct incantation to cleanup the source directory for a given source
+        #
+        # @return [String] command to cleanup the source
+        def cleanup
+          "rm -rf #{dirname}"
         end
 
         # There is no md5 to manually verify here, so it is a noop.

--- a/lib/vanagon/component/source/http.rb
+++ b/lib/vanagon/component/source/http.rb
@@ -7,7 +7,7 @@ class Vanagon
     class Source
       class Http
         include Vanagon::Utilities
-        attr_accessor :url, :sum, :file, :extension, :workdir
+        attr_accessor :url, :sum, :file, :extension, :workdir, :cleanup
 
         # Constructor for the Http source type
         #
@@ -101,6 +101,22 @@ class Vanagon
             return nil
           else
             fail "Extraction unimplemented for '#{@extension}' in source '#{@file}'. Please teach me."
+          end
+        end
+
+        # Return the correct incantation to cleanup the source archive and source directory for a given source
+        #
+        # @return [String] command to cleanup the source
+        # @raise [RuntimeError] an exception is raised if there is no known extraction method for @extension
+        def cleanup
+          case @extension
+          when '.tar.gz', '.tgz'
+            return "rm #{@file}; rm -r #{dirname}"
+          when '.gem', '.ru', '.txt', '.conf', '.ini', '.gpg'
+            # Because dirname will be ./ here, we don't want to try to nuke it
+            return "rm #{@file}"
+          else
+            fail "Don't know how to cleanup for '#{@file}' with extension: '#{@extension}'. Please teach me."
           end
         end
 

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -10,6 +10,7 @@ class Vanagon
     attr_accessor :components, :settings, :platform, :configdir, :name
     attr_accessor :version, :directories, :license, :description, :vendor
     attr_accessor :homepage, :requires, :user, :repo, :noarch, :identifier
+    attr_accessor :cleanup
 
     # Loads a given project from the configdir
     #

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -172,6 +172,11 @@ class Vanagon
       def register_rewrite_rule(protocol, rule)
         Vanagon::Component::Source.register_rewrite_rule(protocol, rule)
       end
+
+      # Toggle to apply additional cleanup during the build for space constrained systems
+      def cleanup_during_build
+        @project.cleanup = true
+      end
     end
   end
 end

--- a/spec/lib/vanagon/project/dsl_spec.rb
+++ b/spec/lib/vanagon/project/dsl_spec.rb
@@ -64,6 +64,21 @@ end" }
     end
   end
 
+  describe '#cleanup_during_build' do
+    it 'sets @cleanup to true' do
+      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj.instance_eval(project_block)
+      proj.cleanup_during_build
+      expect(proj._project.cleanup).to eq(true)
+    end
+
+    it 'defaults to nil' do
+      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj.instance_eval(project_block)
+      expect(proj._project.cleanup).to be_nil
+    end
+  end
+
   describe "#component" do
     let(:project_block) {
 "project 'test-fixture' do |proj|

--- a/templates/Makefile.erb
+++ b/templates/Makefile.erb
@@ -21,7 +21,7 @@ file-list-after-build: <%= @components.map {|comp| comp.name }.join(" ") %>
 	(find -L <%= dirnames.join(' ') %> -type f 2>/dev/null || find <%= dirnames.join(' ') %> -follow -type f) | sort > file-list-after-build
 <%- end -%>
 
-<%= @name %>-<%= @version %>.tar.gz: file-list
+<%= @name %>-<%= @version %>.tar.gz: file-list <%= @cleanup ? 'cleanup-components' : '' %>
 	<%= pack_tarball_command %>
 
 file-list: <%= dirnames.join(' ') %> <%= @name %>-project
@@ -33,11 +33,22 @@ file-list: <%= dirnames.join(' ') %> <%= @name %>-project
 	mkdir -p <%= dir %>
 <%- end %>
 
+<%- if @cleanup -%>
+cleanup-components: <%= @components.map {|comp| "#{comp.name}-cleanup" }.join(" ") %>
+	touch cleanup-components
+<%- end -%>
+
 <%= @name %>-project: file-list-after-build
 	touch <%= @name %>-project
 
 <%- @components.each do |comp| -%>
 <%= comp.name %>: <%= list_component_dependencies(comp).join(" ") %> <%= comp.name %>-install
+
+<%- if @cleanup -%>
+<%= comp.name %>-cleanup: <%= comp.name %>-install
+	<%= comp.cleanup_source %>
+	touch <%= comp.name %>-cleanup
+<%- end -%>
 
 <%= comp.name %>-unpack: file-list-before-build
 	<%= comp.extract_with %>


### PR DESCRIPTION
Some projects are large and can fill up the buildroot on systems with a
small amount of disk allocated to tmp. This commit adds a directive
which can be used in project configs to enable a more agressive cleanup
during builds (more agressive than the current nothing). Source archives
are deleted after unpacking, and the unpacked source is deleted after
the project has been fully installed on the system.
