### PR TITLE
(maint) Use -p in mktemp calls to avoid hitting /tmp

### DIFF
--- a/lib/vanagon/engine/base.rb
+++ b/lib/vanagon/engine/base.rb
@@ -48,7 +48,7 @@ class Vanagon
       end
 
       def get_remote_workdir
-        @remote_workdir ||= dispatch("mktemp -d 2>/dev/null || mktemp -d -t 'tmp'", true)
+        @remote_workdir ||= dispatch("mktemp -d -p /var/tmp 2>/dev/null || mktemp -d -p /var/tmp -t 'tmp'", true)
       end
 
       def ship_workdir(workdir)

--- a/templates/Makefile.erb
+++ b/templates/Makefile.erb
@@ -1,6 +1,6 @@
 <% dirnames = get_directories.map {|d| d.path } %>
 
-tempdir := $(shell mktemp -d 2>/dev/null || mktemp -d -t 'tmp')
+tempdir := $(shell mktemp -d -p /var/tmp 2>/dev/null || mktemp -d -p /var/tmp -t 'tmp')
 
 all: <%= package_name %>
 


### PR DESCRIPTION
Many platforms have defaults that allocate a small amount of disk to
/tmp, which can easily fill up during package builds. This commit avoids
that problem by adding `-p /var/tmp` to mktemp calls so that builds are
done in /var which generally has more space than /tmp.
