### PR TITLE
(maint) Allow vanagon to build multiple platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,17 @@ The name of the platform to build against, and a file named
 \<platform\_name\>.rb must be present in configs/platforms in the working
 directory.
 
+Platform can also be a comma separated list of platforms such as platform1,platform2.
+
 ##### target host [optional]
 Target host is an optional argument to override the host selection. Instead of using
 a vm collected from the pooler, the build will attempt to ssh to target as the
 root user.
+
+If building on multiple platforms, multiple targets can also be specified using
+a comma separated list such as host1,host2. If less targets are specified than
+platforms, the default engine (the pooler) will be used for platforms without a
+target. If more targets are specified than platforms, the extra will be ignored.
 
 #### Flagged arguments (can be anywhere in the command)
 

--- a/bin/build
+++ b/bin/build
@@ -6,18 +6,28 @@ optparse = Vanagon::OptParse.new("#{File.basename(__FILE__)} <project-name> <pla
 options = optparse.parse! ARGV
 
 project = ARGV[0]
-platform = ARGV[1]
-target = ARGV[2]
+platforms = ARGV[1]
+targets = ARGV[2]
 
-if project.nil? or platform.nil?
+if project.nil? or platforms.nil?
   warn "project and platform are both required arguments."
   puts optparse
   exit 1
 end
 
-artifact = Vanagon::Driver.new(platform, project, options.merge({:target => target}))
+platform_list = platforms.split(',')
+if targets
+  target_list = targets.split(',')
+else
+  target_list = []
+end
 
-artifact.verbose = true if options[:verbose]
-artifact.preserve = true if options[:preserve]
+platform_list.zip(target_list).each do |pair|
+  platform, target = pair
+  artifact = Vanagon::Driver.new(platform, project, options.merge({:target => target}))
 
-artifact.run
+  artifact.verbose = true if options[:verbose]
+  artifact.preserve = true if options[:preserve]
+
+  artifact.run
+end


### PR DESCRIPTION
Previously vanagon builds were limited to a single platform. This commit
changes that, by allowing multiple platforms to be specified on the
command line in a comma separated list. This means if specifying vm
targets for those platforms, they must also be comma separated. For
example, `bundle exec build project debian-6-i386,debian-6-amd64` now
will build project for debian 6 i386, followed by amd64.
