### PR TITLE
(RE-2542) shipping staging automation for osx

### DIFF
--- a/lib/vanagon/platform/osx.rb
+++ b/lib/vanagon/platform/osx.rb
@@ -71,7 +71,7 @@ class Vanagon
       #
       # @return [String] relative path to where osx packages should be staged
       def output_dir(target_repo = "")
-        File.join("osx", target_repo)
+        File.join("apple", target_repo)
       end
 
       # Constructor. Sets up some defaults for the osx platform and calls the parent constructor


### PR DESCRIPTION
This commit updates the output_dir for osx to match what we use within
the packaging repo.
