### PR TITLE
(maint) mktemp on osx is special

### DIFF
--- a/lib/vanagon/engine/base.rb
+++ b/lib/vanagon/engine/base.rb
@@ -48,7 +48,7 @@ class Vanagon
       end
 
       def get_remote_workdir
-        @remote_workdir ||= dispatch("mktemp -d -p /var/tmp 2>/dev/null || mktemp -d -p /var/tmp -t 'tmp'", true)
+        @remote_workdir ||= dispatch("mktemp -d -p /var/tmp 2>/dev/null || mktemp -d -t 'tmp'", true)
       end
 
       def ship_workdir(workdir)

--- a/templates/Makefile.erb
+++ b/templates/Makefile.erb
@@ -1,6 +1,6 @@
 <% dirnames = get_directories.map {|d| d.path } %>
 
-tempdir := $(shell mktemp -d -p /var/tmp 2>/dev/null || mktemp -d -p /var/tmp -t 'tmp')
+tempdir := $(shell mktemp -d -p /var/tmp 2>/dev/null || mktemp -d -t 'tmp')
 
 all: <%= package_name %>
 


### PR DESCRIPTION
-p had been added to mktemp calls to avoid hitting /tmp, but mktemp on
osx is special in a number of ways and doesn't have a -p.
