### PR TITLE
(RE-3937) Add SWIX package support for EOS

### DIFF
--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -1,5 +1,6 @@
 require 'vanagon/platform/deb'
 require 'vanagon/platform/rpm'
+require 'vanagon/platform/swix'
 require 'vanagon/platform/osx'
 require 'vanagon/platform/solaris_10'
 require 'vanagon/platform/solaris_11'
@@ -23,10 +24,12 @@ class Vanagon
       # @param block [Proc] DSL definition of the platform to call
       def platform(name, &block)
         @platform = case name
-                    when /^(el|fedora|sles|eos|nxos|aix)-/
+                    when /^(el|fedora|sles|nxos|aix)-/
                       Vanagon::Platform::RPM.new(@name)
                     when /^(debian|ubuntu|cumulus)-/
                       Vanagon::Platform::DEB.new(@name)
+                    when /^eos-/
+                      Vanagon::Platform::RPM::Swix.new(@name)
                     when /^osx-/
                       Vanagon::Platform::OSX.new(@name)
                     when /^solaris-10/

--- a/lib/vanagon/platform/swix.rb
+++ b/lib/vanagon/platform/swix.rb
@@ -1,0 +1,35 @@
+class Vanagon
+  class Platform
+    class RPM
+      class Swix < Vanagon::Platform::RPM
+        # The specific bits used to generate an SWIX package for a given project
+        #
+        # @param project [Vanagon::Project] project to build a SWIX package of
+        # @return [Array] list of commands required to build the SWIX package
+        # for the given project from an rpm
+        def generate_package(project)
+          target_dir = project.repo ? output_dir(project.repo) : output_dir
+
+          commands = super(project)
+          pkgname_swix = package_name(project)
+          pkgname_rpm = pkgname_swix.sub(/swix$/, 'rpm')
+          commands += ["echo 'format: 1' > ./output/#{target_dir}/manifest.txt",
+          "echo \"primaryRPM: #{pkgname_rpm}\" >> ./output/#{target_dir}/manifest.txt",
+          "echo #{pkgname_rpm}-sha1: `sha1sum ./output/#{target_dir}/#{pkgname_rpm}`",
+          "cd ./output/#{target_dir}/ && zip #{pkgname_swix} manifest.txt #{pkgname_rpm}",
+          "rm ./output/#{target_dir}/manifest.txt ./output/#{target_dir}/#{pkgname_rpm}"]
+
+          commands
+        end
+
+        # Method to derive the package name for the project
+        #
+        # @param project [Vanagon::Project] project to name
+        # @return [String] name of the SWIX package for this project
+        def package_name(project)
+          "#{project.name}-#{project.version}-1.#{os_name}#{os_version}.#{project.noarch ? 'noarch' : @architecture}.swix"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
SWIX support is a subclass of RPM, in that an RPM package is still
generated but then paired with a manifest.txt file which are then
zip compressed into a .swix file.
