### PR TITLE
(RE-4860) Add write_version_file method to Project DSL

### DIFF
--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -10,7 +10,7 @@ class Vanagon
     attr_accessor :components, :settings, :platform, :configdir, :name
     attr_accessor :version, :directories, :license, :description, :vendor
     attr_accessor :homepage, :requires, :user, :repo, :noarch, :identifier
-    attr_accessor :cleanup
+    attr_accessor :cleanup, :version_file
 
     # Loads a given project from the configdir
     #
@@ -69,7 +69,10 @@ class Vanagon
     #
     # @return [Array] array of files installed by components of the project
     def get_files
-      @components.map {|comp| comp.files }.flatten
+      files = []
+      files.push @version_file if @version_file
+      files.push @components.map {|comp| comp.files }.flatten
+      files.flatten
     end
 
     # Collects all of the requires for both the project and its components

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -177,6 +177,12 @@ class Vanagon
       def cleanup_during_build
         @project.cleanup = true
       end
+
+      # This method will write the projects version to a designated file during package creation
+      # @param target [String] a full path to the version file for the project
+      def write_version_file(target)
+        @project.version_file = Vanagon::Common::Pathname.new(target)
+      end
     end
   end
 end

--- a/spec/lib/vanagon/project/dsl_spec.rb
+++ b/spec/lib/vanagon/project/dsl_spec.rb
@@ -79,6 +79,17 @@ end" }
     end
   end
 
+  describe "#write_version_file" do
+    let(:version_file) { '/opt/puppetlabs/puppet/VERSION' }
+
+    it 'sets version_file for the project' do
+      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj.instance_eval(project_block)
+      proj.write_version_file(version_file)
+      expect(proj._project.version_file.path).to eq(version_file)
+    end
+  end
+
   describe "#component" do
     let(:project_block) {
 "project 'test-fixture' do |proj|

--- a/templates/Makefile.erb
+++ b/templates/Makefile.erb
@@ -24,9 +24,14 @@ file-list-after-build: <%= @components.map {|comp| comp.name }.join(" ") %>
 <%= @name %>-<%= @version %>.tar.gz: file-list <%= @cleanup ? 'cleanup-components' : '' %>
 	<%= pack_tarball_command %>
 
-file-list: <%= dirnames.join(' ') %> <%= @name %>-project
+file-list: <%= dirnames.join(' ') %> <%= @name %>-project <%= @version_file ? @version_file.path : '' %>
 	comm -23 file-list-after-build file-list-before-build > file-list
 	comm -23 file-list-after-build file-list-before-build | sed -e 's/\(^.*\s.*$$\)/"\1"/g' > file-list-for-rpm
+
+<%- if @version_file -%>
+<%= @version_file.path %>:
+	echo <%= @version %> > '<%= @version_file.path %>'
+<%- end -%>
 
 <%- dirnames.each do |dir| -%>
 <%= dir %>:


### PR DESCRIPTION
This commit adds a simple method to the project DSL to facilitate
writing out the version of the project to a file in the package
generated by vanagon. The makefile is also updated with a conditional
target to do the work if the attribute is set. Oh and there are tests.
