### PR TITLE
(RE-4897) Use correct dist macro definition in rpm_defines

### DIFF
--- a/lib/vanagon/platform/rpm.rb
+++ b/lib/vanagon/platform/rpm.rb
@@ -46,7 +46,7 @@ class Vanagon
 
       def rpm_defines
         defines =  %Q{--define '_topdir $(tempdir)/rpmbuild' }
-        defines << %Q{--define "%dist .#{os_name}#{os_version}" }
+        defines << %Q{--define 'dist .#{os_name}#{os_version}' }
         defines
       end
 


### PR DESCRIPTION
Previously we incorrectly specified the dist macro. All --defines passed
along the command line are accessed using % in the spec file, but
defined without it on the command line. This commit removes the % so
that the dist macro can be correctly defined for platforms that don't
already have it available (el4, el5, sles10).
