### PR TITLE
(RE-4895) Pass architecture to rpm build command

### DIFF
--- a/lib/vanagon/platform/rpm.rb
+++ b/lib/vanagon/platform/rpm.rb
@@ -46,7 +46,7 @@ class Vanagon
 
       def rpm_defines
         defines =  %Q{--define '_topdir $(tempdir)/rpmbuild' }
-        defines << %Q{--define 'dist .#{os_name}#{os_version}' }
+        defines << %Q{--define 'dist .#{@os_name}#{@os_version}' }
         defines
       end
 


### PR DESCRIPTION
For consistency in how we build our rpms, this commit passes the
--target option with the architecture of the platform to the rpm build
command. This ensures that when we ask for an i386 build, we don't get
i586 or i686. This aids in external consumers of our packages.
