### PR TITLE
(RE-5004) Silence chkconfig in RPM %post

### DIFF
--- a/templates/rpm/project.spec.erb
+++ b/templates/rpm/project.spec.erb
@@ -108,7 +108,11 @@ install -d %{buildroot}
       %systemd_post <%= service.name %>.service
     <%- end -%>
   <%- elsif @platform.servicetype == "sysv" -%>
-    chkconfig --add <%= service.name %>
+    <%- if @platform.is_sles? -%>
+      chkconfig --add <%= service.name %> >/dev/null 2>&1 || :
+    <%- else -%>
+      chkconfig --add <%= service.name %>
+    <%- end -%>
   <%- end -%>
 <%- end -%>
 


### PR DESCRIPTION
Prior to this commit, upgrading a SLES11 agent
to AIO puppet-agent would fail with service
"already provided" errors for puppet and
mcollective.

This commit updates Vanagon's RPM %post
so the chkconfig call runs silently and
exits with a successful return code.
