### PR TITLE
(RE-4547) Replace more ; with && for failure propagation

### DIFF
--- a/templates/Makefile.erb
+++ b/templates/Makefile.erb
@@ -71,18 +71,24 @@ cleanup-components: <%= @components.map {|comp| "#{comp.name}-cleanup" }.join(" 
 	touch <%= comp.name %>-patch
 
 <%= comp.name %>-configure: <%= comp.name %>-patch
+	<%- unless comp.configure.empty? -%>
 	cd <%= comp.dirname %> && \
 	<%= comp.configure.join(" && \\\n\t") %>
+	<%- end -%>
 	touch <%= comp.name %>-configure
 
 <%= comp.name %>-build: <%= comp.name %>-configure
+	<%- unless comp.build.empty? -%>
 	cd <%= comp.dirname %> && \
 	<%= comp.build.join(" && \\\n\t") %>
+	<%- end -%>
 	touch <%= comp.name %>-build
 
 <%= comp.name %>-install: <%= comp.name %>-build
+	<%- unless comp.install.empty? -%>
 	cd <%= comp.dirname %> && \
 	<%= comp.install.join(" && \\\n\t") %>
+	<%- end -%>
 	touch <%= comp.name %>-install
 
 <%= comp.name %>-clean:


### PR DESCRIPTION
This commit updates the Makefile template to replace more uses of `;`
with `&&`. In this case the directory changes that happen during
configure, build and install are being updated. Also this ensures that
failed patch applications will fail the build.
