### PR TITLE
(RE-4606) Add support for environment overrides in components

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -6,7 +6,7 @@ class Vanagon
     attr_accessor :name, :version, :source, :url, :configure, :build, :install
     attr_accessor :environment, :extract_with, :dirname, :build_requires
     attr_accessor :settings, :platform, :files, :patches, :requires, :service, :options
-    attr_accessor :configfiles, :directories, :replaces, :provides, :cleanup_source
+    attr_accessor :configfiles, :directories, :replaces, :provides, :cleanup_source, :environment
 
     # Loads a given component from the configdir
     #
@@ -51,6 +51,7 @@ class Vanagon
       @directories = []
       @replaces = []
       @provides = []
+      @environment = {}
     end
 
     # Fetches the primary source for the component. As a side effect, also sets
@@ -78,6 +79,19 @@ class Vanagon
         patchdir = File.join(workdir, "patches")
         FileUtils.mkdir_p(patchdir)
         FileUtils.cp(@patches, patchdir)
+      end
+    end
+
+    # Prints the environment in a way suitable for use in a Makefile
+    # or shell script.
+    #
+    # @return [String] environment suitable for inclusion in a Makefile
+    def get_environment
+      unless @environment.empty?
+        env = @environment.map { |key, value| %Q[#{key}="#{value}"] }
+        "export #{env.join(' ')}"
+      else
+        ":"
       end
     end
   end

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -261,6 +261,14 @@ class Vanagon
       def directory(dir, mode: nil, owner: nil, group: nil)
         @component.directories << Vanagon::Common::Pathname.new(dir, mode, owner, group)
       end
+
+      # Adds a set of environment overrides to the environment for a component.
+      # This environment is included in the configure, build and install steps.
+      #
+      # @param env [Hash] mapping of keys to values to add to the environment for the component
+      def environment(env)
+        @component.environment.merge!(env)
+      end
     end
   end
 end

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -332,6 +332,22 @@ end" }
     end
   end
 
+  describe '#environment' do
+    it 'adds an override to the environment for a component' do
+      comp = Vanagon::Component::DSL.new('env-test', {}, {})
+      comp.environment({'PATH' => '/usr/local/bin'})
+      expect(comp._component.environment).to eq({'PATH' => '/usr/local/bin'})
+    end
+
+    it 'merges against the existing environment' do
+      comp = Vanagon::Component::DSL.new('env-test', {}, {})
+      comp.environment({'PATH' => '/usr/local/bin'})
+      comp.environment({'PATH' => '/usr/bin'})
+      comp.environment({'CFLAGS' => '-I /usr/local/bin'})
+      expect(comp._component.environment).to eq({'PATH' => '/usr/bin', 'CFLAGS' => '-I /usr/local/bin'})
+    end
+  end
+
   describe '#directory' do
     it 'adds a directory with the desired path to the directory collection for the component' do
       comp = Vanagon::Component::DSL.new('directory-test', {}, {})

--- a/spec/lib/vanagon/component_spec.rb
+++ b/spec/lib/vanagon/component_spec.rb
@@ -1,0 +1,22 @@
+require 'vanagon/component'
+
+describe "Vanagon::Component" do
+  describe "#get_environment" do
+    it "returns a makefile compatible environment" do
+      comp = Vanagon::Component.new('env-test', {}, {})
+      comp.environment = {'PATH' => '/usr/local/bin'}
+      expect(comp.get_environment).to eq('export PATH="/usr/local/bin"')
+    end
+
+    it 'merges against the existing environment' do
+      comp = Vanagon::Component.new('env-test', {}, {})
+      comp.environment = {'PATH' => '/usr/bin', 'CFLAGS' => '-I /usr/local/bin'}
+      expect(comp.get_environment).to eq('export PATH="/usr/bin" CFLAGS="-I /usr/local/bin"')
+    end
+
+    it 'returns : for an empty environment' do
+      comp = Vanagon::Component.new('env-test', {}, {})
+      expect(comp.get_environment).to eq(':')
+    end
+  end
+end

--- a/templates/Makefile.erb
+++ b/templates/Makefile.erb
@@ -73,6 +73,7 @@ cleanup-components: <%= @components.map {|comp| "#{comp.name}-cleanup" }.join(" 
 <%= comp.name %>-configure: <%= comp.name %>-patch
 	<%- unless comp.configure.empty? -%>
 	cd <%= comp.dirname %> && \
+	<%= comp.get_environment %> && \
 	<%= comp.configure.join(" && \\\n\t") %>
 	<%- end -%>
 	touch <%= comp.name %>-configure
@@ -80,6 +81,7 @@ cleanup-components: <%= @components.map {|comp| "#{comp.name}-cleanup" }.join(" 
 <%= comp.name %>-build: <%= comp.name %>-configure
 	<%- unless comp.build.empty? -%>
 	cd <%= comp.dirname %> && \
+	<%= comp.get_environment %> && \
 	<%= comp.build.join(" && \\\n\t") %>
 	<%- end -%>
 	touch <%= comp.name %>-build
@@ -87,6 +89,7 @@ cleanup-components: <%= @components.map {|comp| "#{comp.name}-cleanup" }.join(" 
 <%= comp.name %>-install: <%= comp.name %>-build
 	<%- unless comp.install.empty? -%>
 	cd <%= comp.dirname %> && \
+	<%= comp.get_environment %> && \
 	<%= comp.install.join(" && \\\n\t") %>
 	<%- end -%>
 	touch <%= comp.name %>-install


### PR DESCRIPTION
Currently, in vanagon projects, if a specific environment is required
for a component, the convention is to prepend the configure, build and
install steps with the environment variables. This repetition is
undesirable, so this commit implements an environment component dsl
method which takes a hash and exports each key/value pair in the
Makefile template for configure, build and install.
