### PR TITLE
(RE-5032,5089) OSX pre post install script tweaks

### DIFF
--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -198,7 +198,7 @@ class Vanagon
       # @param file [String] name of the configfile
       def configfile(file)
         # I AM SO SORRY
-        if @component.platform.name =~ /solaris-10/
+        if @component.platform.name =~ /solaris-10|osx/
           @component.install << "mv '#{file}' '#{file}.pristine'"
           @component.configfiles << Vanagon::Common::Pathname.new("#{file}.pristine")
         else

--- a/templates/osx/postinstall.erb
+++ b/templates/osx/postinstall.erb
@@ -1,7 +1,22 @@
 #!/bin/bash
 
-<%- get_services.each do |service| -%>
-if [ -f "<%= service.service_file %>" ]; then
-  /bin/launchctl load -F "<%= service.service_file %>"
+foundpkg=`/usr/sbin/pkgutil --volume "$3" --pkgs=<%= @identifier-%>.<%= @name -%>`
+
+# Move any new configfiles into place
+<%- get_configfiles.each do |config|
+dest_file = config.path.gsub(/\.pristine$/, '') -%>
+
+if [ -f "<%= dest_file %>" ]; then
+  echo "Detected file at '<%= dest_file %>'; updated file at '<%= config.path %>'."
+else
+  mv '<%= config.path %>' '<%= dest_file %>'
 fi
 <%- end -%>
+
+# If we appear to be in an upgrade load services.
+
+if [ -n "$foundpkg" ]; then
+<%- get_services.each do |service| -%>
+  /bin/launchctl load -F "<%= service.service_file %>"
+<%- end -%>
+fi

--- a/templates/osx/preinstall.erb
+++ b/templates/osx/preinstall.erb
@@ -1,7 +1,13 @@
 #!/bin/bash
 
+# If we appear to be in an upgrade unload services.
+
+foundpkg=`/usr/sbin/pkgutil --volume "$3" --pkgs=<%= @identifier-%>.<%= @name -%>`
+
+if [ -n "$foundpkg" ]; then
 <%- get_services.each do |service| -%>
-if /bin/launchctl list "<%= service.name %>" &> /dev/null; then
-  /bin/launchctl unload "<%= service.service_file %>"
-fi
+  if /bin/launchctl list "<%= service.name %>" &> /dev/null; then
+    /bin/launchctl unload "<%= service.service_file %>"
+  fi
 <%- end -%>
+fi


### PR DESCRIPTION
This commit addresses :
- osx puppet-agent clobbers config files if they already exist

Using the same logic as Solaris 10, we append a "pristine" suffix to
config files and only move them into place if they do not exist.
- puppet and mco should not be started after osx puppet-agent install

Currently, the puppet-agent installer starts both puppet and mco post
install.  This isn't the desired behavior.  The new behavior only starts
the processes if it detects we're upgrading ( by checking for the existence of the package receipt ).
