### PR TITLE
(maint) Fix devkit drift

### DIFF
--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -105,7 +105,7 @@ class Vanagon
         @project.make_bill_of_materials(@workdir)
         # Builds only the project, skipping packaging into an artifact.
         @engine.ship_workdir(@workdir)
-        @engine.dispatch("(cd #{@target.remote_workdir}; #{@platform.make} #{@project.name}-project)")
+        @engine.dispatch("(cd #{@engine.remote_workdir}; #{@platform.make} #{@project.name}-project)")
       rescue => e
         puts e
         puts e.backtrace.join("\n")


### PR DESCRIPTION
remote_workdir moved from target to engine, and wasn't updated for
devkit.
