### PR TITLE
(maint) Update solaris 10 patch and num_cores

### DIFF
--- a/lib/vanagon/platform/solaris_10.rb
+++ b/lib/vanagon/platform/solaris_10.rb
@@ -159,9 +159,9 @@ class Vanagon
         @name = name
         @make = "/opt/csw/bin/gmake"
         @tar = "/usr/sfw/bin/gtar"
-        @patch = "/opt/csw/bin/gpatch"
+        @patch = "/usr/bin/gpatch"
         # solaris 10
-        @num_cores = "/usr/bin/kstat cpu_info | /usr/xpg4/bin/grep -E '[[:space:]]+core_id[[:space:]]' | wc -l"
+        @num_cores = "/usr/bin/kstat cpu_info | awk '{print $1}' | grep '^core_id$' | wc -l"
         super(name)
       end
     end


### PR DESCRIPTION
Previously the default patch depended on opencsw and the default
num_cores depended on a non-standard grep installation. This commit
updates the patch to use /usr/bin/gpatch (which depends on an optional
SUN solaris package), and num_cores to use standard grep combined with
awk.
