### PR TITLE
(RE-3460) Stop using .lan addresses

### DIFF
--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -195,7 +195,7 @@ class Vanagon
       # @param definition [String] the repo setup file, must be a valid uri, fetched with curl
       # @param gpg_key [String] optional gpg key to be fetched via curl and installed
       def apt_repo(definition, gpg_key = nil)
-        # i.e., definition = http://builds.puppetlabs.lan/puppet-agent/0.2.1/repo_configs/deb/pl-puppet-agent-0.2.1-wheezy.list
+        # i.e., definition = http://builds.delivery.puppetlabs.net/puppet-agent/0.2.1/repo_configs/deb/pl-puppet-agent-0.2.1-wheezy.list
         # parse the definition and gpg_key if set to ensure they are both valid URIs
         definition = URI.parse definition
         gpg_key = URI.parse gpg_key if gpg_key

--- a/spec/lib/vanagon/platform/dsl_spec.rb
+++ b/spec/lib/vanagon/platform/dsl_spec.rb
@@ -7,14 +7,14 @@ describe 'Vanagon::Platform::DSL' do
   let (:sles_platform_block)   { "platform 'sles-test-fixture'   do |plat| end" }
   let (:nxos_5_platform_block) { "platform 'nxos-5-fixture'      do |plat| end" }
 
-  let(:apt_definition) { "http://builds.puppetlabs.lan/puppet-agent/0.2.1/repo_configs/deb/pl-puppet-agent-0.2.1-wheezy" }
-  let(:apt_definition_deb) { "http://builds.puppetlabs.lan/puppet-agent/0.2.1/repo_configs/deb/pl-puppet-agent-0.2.1-wheezy.deb" }
+  let(:apt_definition) { "http://builds.delivery.puppetlabs.net/puppet-agent/0.2.1/repo_configs/deb/pl-puppet-agent-0.2.1-wheezy" }
+  let(:apt_definition_deb) { "http://builds.delivery.puppetlabs.net/puppet-agent/0.2.1/repo_configs/deb/pl-puppet-agent-0.2.1-wheezy.deb" }
   let(:apt_definition_gpg) { "http://pl-build-tools.delivery.puppetlabs.net/debian/keyring.gpg" }
-  let(:el_definition) { "http://builds.puppetlabs.lan/puppet-agent/0.2.1/repo_configs/rpm/pl-puppet-agent-0.2.1-el-7-x86_64" }
-  let(:el_definition_rpm) { "http://builds.puppetlabs.lan/puppet-agent/0.2.1/repo_configs/rpm/pl-puppet-agent-0.2.1-release.rpm" }
-  let(:sles_definition) { "http://builds.puppetlabs.lan/puppet-agent/0.2.2/repo_configs/rpm/pl-puppet-agent-0.2.2-sles-12-x86_64" }
-  let(:sles_definition_rpm) { "http://builds.puppetlabs.lan/puppet-agent/0.2.1/repo_configs/rpm/pl-puppet-agent-0.2.1-release.rpm" }
-  let(:nxos_definition) { "http://builds.puppetlabs.lan/puppet-agent/0.2.1/repo_configs/rpm/pl-puppet-agent-0.2.1-nxos-5-x86_64.repo" }
+  let(:el_definition) { "http://builds.delivery.puppetlabs.net/puppet-agent/0.2.1/repo_configs/rpm/pl-puppet-agent-0.2.1-el-7-x86_64" }
+  let(:el_definition_rpm) { "http://builds.delivery.puppetlabs.net/puppet-agent/0.2.1/repo_configs/rpm/pl-puppet-agent-0.2.1-release.rpm" }
+  let(:sles_definition) { "http://builds.delivery.puppetlabs.net/puppet-agent/0.2.2/repo_configs/rpm/pl-puppet-agent-0.2.2-sles-12-x86_64" }
+  let(:sles_definition_rpm) { "http://builds.delivery.puppetlabs.net/puppet-agent/0.2.1/repo_configs/rpm/pl-puppet-agent-0.2.1-release.rpm" }
+  let(:nxos_definition) { "http://builds.delivery.puppetlabs.net/puppet-agent/0.2.1/repo_configs/rpm/pl-puppet-agent-0.2.1-nxos-5-x86_64.repo" }
 
   let(:hex_value) { "906264d248061b0edb1a576cc9c8f6c7" }
 


### PR DESCRIPTION
We've been asked to stop using puppetlabs.lan addresses, so I've swapped
them for the preferred names/URIS.
