### PR TITLE
(RE-5251) Refresh apt cache upon vanagon build start

### DIFF
--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -200,11 +200,11 @@ class Vanagon
         definition = URI.parse definition
         gpg_key = URI.parse gpg_key if gpg_key
 
-        self.provision_with "apt-get -qq install curl"
+        self.provision_with "apt-get -qq update && apt-get -qq install curl"
         if definition.scheme =~ /^(http|ftp)/
           if File.extname(definition.path) == '.deb'
             # repo definition is an deb (like puppetlabs-release)
-            self.provision_with "curl -o local.deb '#{definition}'; dpkg -i local.deb; rm -f local.deb"
+            self.provision_with "curl -o local.deb '#{definition}' && dpkg -i local.deb; rm -f local.deb"
           else
             reponame = "#{SecureRandom.hex}-#{File.basename(definition.path)}"
             reponame = "#{reponame}.list" if File.extname(reponame) != '.list'

--- a/spec/lib/vanagon/platform/dsl_spec.rb
+++ b/spec/lib/vanagon/platform/dsl_spec.rb
@@ -31,7 +31,7 @@ describe 'Vanagon::Platform::DSL' do
       plat = Vanagon::Platform::DSL.new('debian-test-fixture')
       plat.instance_eval(deb_platform_block)
       plat.apt_repo(apt_definition_deb)
-      expect(plat._platform.provisioning).to include("curl -o local.deb '#{apt_definition_deb}'; dpkg -i local.deb; rm -f local.deb")
+      expect(plat._platform.provisioning).to include("curl -o local.deb '#{apt_definition_deb}' && dpkg -i local.deb; rm -f local.deb")
     end
 
     it "installs a gpg key if given one" do


### PR DESCRIPTION
Prior to this, if the apt cache was stale for a template, vanagon would
fail to install curl, and then move onto to attempting to do other
things. This commit ensures that the apt cache is updated as the first
operation, which should prevent this type of error in the future.
