### PR TITLE
(maint) Prevent duplicate entries from file-lists

### DIFF
--- a/templates/Makefile.erb
+++ b/templates/Makefile.erb
@@ -13,14 +13,14 @@ file-list-before-build:
 <%- if dirnames.empty? -%>
 	touch file-list-before-build
 <%- else -%>
-	(find -L <%= dirnames.join(' ') %> -type f 2>/dev/null || find <%= dirnames.join(' ') %> -follow -type f) | sort > file-list-before-build
+	(find -L <%= dirnames.join(' ') %> -type f 2>/dev/null || find <%= dirnames.join(' ') %> -follow -type f) | sort | uniq > file-list-before-build
 <%- end -%>
 
 file-list-after-build: <%= @components.map {|comp| comp.name }.join(" ") %>
 <%- if dirnames.empty? -%>
 	touch file-list-after-build
 <%- else -%>
-	(find -L <%= dirnames.join(' ') %> -type f 2>/dev/null || find <%= dirnames.join(' ') %> -follow -type f) | sort > file-list-after-build
+	(find -L <%= dirnames.join(' ') %> -type f 2>/dev/null || find <%= dirnames.join(' ') %> -follow -type f) | sort | uniq > file-list-after-build
 <%- end -%>
 
 <%= @name %>-<%= @version %>.tar.gz: file-list <%= @cleanup ? 'cleanup-components' : '' %>


### PR DESCRIPTION
When directories that contain each other are declared in vanagon the
find calls to generate file lists will have 2 copies of any files in the
deepest directory. This causes problems with the tar on el4 which will
prevent a successful package build. This commit works around that
problem by piping the find | sort to uniq. Uniq should be available on
all systems that vanagon currently supports and any unix/linux variety.
