### PR TITLE
(RE-5113) Add cisco-wrlinux platform

### DIFF
--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -143,7 +143,7 @@ class Vanagon
     #
     # @return [true, false] true if it is a redhat variety or uses rpm under the hood, false otherwise
     def is_rpm?
-      return !!@name.match(/^(el|fedora|eos|nxos|sles)-.*$/)
+      return !!@name.match(/^(el|fedora|eos|nxos|cisco-wrlinux|sles)-.*$/)
     end
 
     # Utility matcher to determine is the platform is an enterprise linux variety
@@ -183,9 +183,18 @@ class Vanagon
 
     # Utility matcher to determine is the platform is an nxos variety
     #
-    # @return [true, false] true if it is an eos variety, false otherwise
+    # @return [true, false] true if it is an nxos variety, false otherwise
     def is_nxos?
       return !!@name.match(/^nxos-.*$/)
+    end
+
+    # Utility matcher to determine is the platform is a cisco-wrlinux
+    # variety
+    #
+    # @return [true, false] true if it is a cisco-wrlinux variety, false
+    # otherwise
+    def is_cisco_wrlinux?
+      return !!@name.match(/^cisco-wrlinux-.*$/)
     end
 
     # Utility matcher to determine is the platform is an osx variety

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -24,7 +24,7 @@ class Vanagon
       # @param block [Proc] DSL definition of the platform to call
       def platform(name, &block)
         @platform = case name
-                    when /^(el|fedora|sles|nxos|aix)-/
+                    when /^(el|fedora|sles|nxos|cisco-wrlinux|aix)-/
                       Vanagon::Platform::RPM.new(@name)
                     when /^(debian|ubuntu|cumulus)-/
                       Vanagon::Platform::DEB.new(@name)
@@ -243,7 +243,7 @@ class Vanagon
           else
             reponame = "#{SecureRandom.hex}-#{File.basename(definition.path)}"
             reponame = "#{reponame}.repo"  if File.extname(reponame) != '.repo'
-            if @platform.is_nxos?
+            if @platform.is_nxos? or @platform.is_cisco_wrlinux?
               self.provision_with "curl -o '/etc/yum/repos.d/#{reponame}' '#{definition}'"
             else
               self.provision_with "curl -o '/etc/yum.repos.d/#{reponame}' '#{definition}'"

--- a/lib/vanagon/platform/rpm.rb
+++ b/lib/vanagon/platform/rpm.rb
@@ -46,7 +46,9 @@ class Vanagon
 
       def rpm_defines
         defines =  %Q{--define '_topdir $(tempdir)/rpmbuild' }
-        defines << %Q{--define 'dist .#{@os_name}#{@os_version}' }
+        # RPM doesn't allow dashes in the os_name. This was added to
+        # convert cisco-wrlinux to cisco_wrlinux
+        defines << %Q{--define 'dist .#{@os_name.gsub('-','_')}#{@os_version}' }
         defines
       end
 


### PR DESCRIPTION
We'll eventually remove the nxos platform once everything in
the puppet agent dependency chain is working as cisco-wrlinux.

Tested and working to build pl-gcc in a modified pl-build-tools repo that I'll be submitting another PR for shortly.
