### PR TITLE
(RE-4958) Include directories in the rpm-file-list

### DIFF
--- a/templates/rpm/project.spec.erb
+++ b/templates/rpm/project.spec.erb
@@ -90,6 +90,14 @@ install -d %{buildroot}
   cp -p <%= file %> %{buildroot}/<%= File.dirname(file) %>
 <%- end -%>
 
+# Generate a list of directories and append it to the file list. RPMv4
+# automatically does this implicitly, but RPMv5 is more strict and you
+# need to list the dirs for them to be packaged properly.
+<%- get_directories.map {|d| "%{buildroot}#{d.path}"}.each do |dir| -%>
+  find <%= dir %> -type d | sed -e "s#%{buildroot}##" >> dir-list-rpm
+<%- end -%>
+cat dir-list-rpm | uniq >> %{SOURCE1}
+
 %pre
 <%- if @user -%>
 # Add our user and group


### PR DESCRIPTION
RPMv5 is more strict about specifying directories to be packaged.

This has been tested by trying to install the resultant package into the nxos development environment as well as a 9k switch. There are still two dependency errors that occur, but they're due to the fact that Cisco is missing packages that own /usr/doc and /etc/pki/tls/certs/ca-bundle.crt, not due to the packaging missing directories that it should ship with. This issue has been reported to Cisco.
