### PR TITLE
(RE-5307) Fix service reference in debian systemd templates

### DIFF
--- a/templates/deb/postinst.erb
+++ b/templates/deb/postinst.erb
@@ -5,9 +5,9 @@
   #
   <%- if @platform.servicetype == "systemd" -%>
 if [ -z "$2" ]; then
-  systemctl enable <%= service %>.service >/dev/null || :
+  systemctl enable <%= service.name %>.service >/dev/null || :
 else
-  systemctl try-restart <%= service %>.service >/dev/null || :
+  systemctl try-restart <%= service.name %>.service >/dev/null || :
 fi
   <%- elsif @platform.servicetype == "sysv" -%>
 if [ -x "<%= service.service_file %>" ]; then

--- a/templates/deb/prerm.erb
+++ b/templates/deb/prerm.erb
@@ -5,8 +5,8 @@
   #
   <%- if @platform.servicetype == "systemd" -%>
 if [ "$1" = remove ]; then
-  systemctl --no-reload disable <%= service %>.service > /dev/null 2>&1 || :
-  systemctl stop <%= service %>.service > /dev/null 2>&1 || :
+  systemctl --no-reload disable <%= service.name %>.service > /dev/null 2>&1 || :
+  systemctl stop <%= service.name %>.service > /dev/null 2>&1 || :
 fi
 
   <%- elsif @platform.servicetype == "sysv" -%>


### PR DESCRIPTION
Previously the systemd pre and post scripts for debian incorrectly
referenced service and not service.name. The former is an OpenStruct
while the latter is a string, which is what is desired. This commit
corrects that so that debian systemd services will be correctly
handled.
