### PR TITLE
(RE-3961) Add support for secondary sources to components

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -7,6 +7,7 @@ class Vanagon
     attr_accessor :environment, :extract_with, :dirname, :build_requires
     attr_accessor :settings, :platform, :files, :patches, :requires, :service, :options
     attr_accessor :configfiles, :directories, :replaces, :provides, :cleanup_source, :environment
+    attr_accessor :sources
 
     # Loads a given component from the configdir
     #
@@ -52,6 +53,7 @@ class Vanagon
       @replaces = []
       @provides = []
       @environment = {}
+      @sources = []
     end
 
     # Fetches the primary source for the component. As a side effect, also sets
@@ -69,6 +71,18 @@ class Vanagon
 
       # Git based sources probably won't set the version, so we load it if it hasn't been already set
       @version ||= @source.version
+    end
+
+
+    # Fetches secondary sources for the component. These are just dumped into the workdir currently.
+    #
+    # @param workdir [String] working directory to put the source into
+    def get_sources(workdir)
+      @sources.each do |source|
+        cur_source = Vanagon::Component::Source.source(source.url, {:ref => source.ref, :sum => source.sum}, workdir)
+        cur_source.fetch
+        cur_source.verify
+      end
     end
 
     # Fetches patches if any are provided for the project.

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -256,6 +256,15 @@ class Vanagon
         @component.options[:ref] = the_ref
       end
 
+      # This will add a source to the project and put it in the workdir alongside the other sources
+      #
+      # @param url [String] url of the source
+      # @param ref [String] Used for git sources, must be a git ref of some sort
+      # @param sum [String] sum used to validate http and file sources
+      def add_source(url, ref: nil, sum: nil)
+        @component.sources << OpenStruct.new(:url => url, :ref => ref, :sum => sum)
+      end
+
       # Adds a directory to the list of directories provided by the project, to be included in any packages of the project
       #
       # @param dir [String] directory to add to the project

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -61,6 +61,8 @@ class Vanagon
     def fetch_sources(workdir)
       @components.each do |component|
         component.get_source(workdir)
+        # Fetch secondary sources
+        component.get_sources(workdir)
         component.get_patches(workdir)
       end
     end


### PR DESCRIPTION
Previously vanagon components were limited to exactly one source. This
commit changes that by adding a new add_source dsl method which can add
more sources to a component. Secondary sources are not automatically
unpacked, and will merely be placed in the workdir.
