### PR TITLE
(RE-5288) Only define %dist on not AIX

### DIFF
--- a/lib/vanagon/platform/rpm.rb
+++ b/lib/vanagon/platform/rpm.rb
@@ -48,7 +48,9 @@ class Vanagon
         defines =  %Q{--define '_topdir $(tempdir)/rpmbuild' }
         # RPM doesn't allow dashes in the os_name. This was added to
         # convert cisco-wrlinux to cisco_wrlinux
-        defines << %Q{--define 'dist .#{@os_name.gsub('-','_')}#{@os_version}' }
+        unless is_aix?
+          defines << %Q{--define 'dist .#{@os_name.gsub('-','_')}#{@os_version}' }
+        end
         defines
       end
 


### PR DESCRIPTION
AIX uses %{os} as the dist tag by default so there is no reason to
define dist, and if you do you get something like .aix7.1.aix.7.1 as the
dist which is non-desired.

This commit simply skips defining dist if it's on AIX.
