### PR TITLE
(RE-5380) Add a changelog to vanagon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
+
+## [Unreleased]
+### Added
+- Added a CHANGELOG.md to track high level user facing changes
+
+## Versions <= 0.3.9 do not have a change log entry
+
+[Unreleased]: https://github.com/puppetlabs/vanagon/compare/0.3.9...HEAD


### PR DESCRIPTION
In order to allow consumers of vanagon to decide if they want to opt
into a new release of vanagon, it should have a change log to show what
has changed between versions. This commit adds a change log formatted
according to http://keepachangelog.com/. It only includes new entries
and does not attempt to recreate past versions' change logs.
