### PR TITLE
(maint) RPM %preun should only stop services on uninstall

### DIFF
--- a/templates/rpm/project.spec.erb
+++ b/templates/rpm/project.spec.erb
@@ -125,11 +125,7 @@ install -d %{buildroot}
       %systemd_post <%= service.name %>.service
     <%- end -%>
   <%- elsif @platform.servicetype == "sysv" -%>
-    <%- if @platform.is_sles? -%>
-      chkconfig --add <%= service.name %> >/dev/null 2>&1 || :
-    <%- else -%>
-      chkconfig --add <%= service.name %>
-    <%- end -%>
+    chkconfig --add <%= service.name %> >/dev/null 2>&1 || :
   <%- end -%>
 <%- end -%>
 
@@ -145,7 +141,7 @@ install -d %{buildroot}
     <%- end -%>
   <%- elsif @platform.servicetype == "sysv" -%>
     if [ $1 -ge 1 ]; then
-      /sbin/service <%= service.name %> condrestart
+      /sbin/service <%= service.name %> condrestart || :
     fi
   <%- end -%>
 
@@ -163,8 +159,8 @@ install -d %{buildroot}
     <%- end -%>
   <%- elsif @platform.servicetype == "sysv" -%>
     if [ $1 = 0 ]; then
-      /sbin/service <%= service.name %> stop >/dev/null 2>&1
-      chkconfig --del <%= service.name %>
+      /sbin/service <%= service.name %> stop >/dev/null 2>&1 || :
+      chkconfig --del <%= service.name %> || :
     fi
   <%- end -%>
 <%- end -%>


### PR DESCRIPTION
Currently the RPM %preun stops and unregisters the services
unconditionally. This is undesirable for package upgrades.

This adds a condition to only stop and unregister services on
package uninstall.
