### PR TITLE
(RE-5390) Install bill-of-materials into docdir on solaris/osx

### DIFF
--- a/lib/vanagon/platform/osx.rb
+++ b/lib/vanagon/platform/osx.rb
@@ -16,6 +16,11 @@ class Vanagon
          "if [ -d resources/osx/productbuild ] ; then cp -r resources/osx/productbuild/* $(tempdir)/osx/build/; fi",
          # Unpack the project
          "gunzip -c #{project.name}-#{project.version}.tar.gz | '#{@tar}' -C '$(tempdir)/osx/build/root/#{project.name}-#{project.version}' --strip-components 1 -xf -",
+
+         # Move bill-of-materials into a docdir
+         "mkdir -p $(tempdir)/osx/build/root/#{project.name}-#{project.version}/usr/share/doc/#{project.name}",
+         "mv $(tempdir)/osx/build/root/#{project.name}-#{project.version}/bill-of-materials $(tempdir)/osx/build/root/#{project.name}-#{project.version}/usr/share/doc/#{project.name}/bill-of-materials",
+
          # Package the project
          "(cd $(tempdir)/osx/build/; #{@pkgbuild} --root root/#{project.name}-#{project.version} \
           --scripts $(tempdir)/osx/build/scripts \

--- a/lib/vanagon/platform/solaris_10.rb
+++ b/lib/vanagon/platform/solaris_10.rb
@@ -18,6 +18,11 @@ class Vanagon
 
           # Unpack the project and stage the packaging artifacts
           "gunzip -c #{name_and_version}.tar.gz | '#{@tar}' -C '$(tempdir)' -xf -",
+
+          # Move bill-of-materials into a docdir
+          "mkdir -p $(tempdir)/#{name_and_version}/usr/share/doc/#{project.name}",
+          "mv $(tempdir)/#{name_and_version}/bill-of-materials $(tempdir)/#{name_and_version}/usr/share/doc/#{project.name}/bill-of-materials",
+
           "rm #{name_and_version}.tar.gz",
           "cp -r packaging $(tempdir)/",
 

--- a/templates/solaris/11/p5m.erb
+++ b/templates/solaris/11/p5m.erb
@@ -28,6 +28,9 @@ depend fmri=pkg:/<%= requirement %> type=require
 <transform file path=(var|lib)/svc/manifest/.*\.xml$ -> default restart_fmri svc:/system/manifest-import:default>
 <%- end -%>
 
+# Move the bill-of-materials into a docdir for the package to avoid conflicts
+<transform file path=bill-of-materials$ -> set path usr/share/doc/<%= @name %>/bill-of-materials>
+
 <%- get_configfiles.each do |config| -%>
 # Preserve the old conf file on upgrade
 <transform file path=<%= strip_and_escape(config.path) %>$ -> add preserve renamenew>


### PR DESCRIPTION
Previously, because of how solaris and osx packages are generated, the
bill-of-materials was just dropped into /. This creates a conflict when
more than one vanagon based package is installed (at least on solaris
11, solaris 10 doesn't really care). This commit remedies that by moving
the bill of materials into /usr/share/doc/$project_name, the standard
docdir location.
