### PR TITLE
(RE-5375) Install should be a platform option

### DIFF
--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -191,7 +191,7 @@ class Vanagon
       # @param owner  [String] owner of the file
       # @param group  [String] group owner of the file
       def install_file(source, target, mode: '0644', owner: nil, group:  nil )
-        @component.install << "install -d '#{File.dirname(target)}'"
+        @component.install << "#{@component.platform.install} -d '#{File.dirname(target)}'"
         @component.install << "cp -p '#{source}' '#{target}'"
         @component.files << Vanagon::Common::Pathname.new(target, mode, owner, group)
       end
@@ -224,7 +224,7 @@ class Vanagon
       # @param source [String] path to the file to symlink
       # @param target [String] path to the desired symlink
       def link(source, target)
-        @component.install << "install -d '#{File.dirname(target)}'"
+        @component.install << "#{@component.platform.install} -d '#{File.dirname(target)}'"
         @component.install << "ln -s '#{source}' '#{target}'"
       end
 

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -5,7 +5,7 @@ class Vanagon
     attr_accessor :make, :servicedir, :defaultdir, :provisioning, :num_cores, :tar
     attr_accessor :build_dependencies, :name, :vcloud_name, :cflags, :ldflags, :settings
     attr_accessor :servicetype, :patch, :architecture, :codename, :os_name, :os_version
-    attr_accessor :docker_image, :ssh_port, :rpmbuild
+    attr_accessor :docker_image, :ssh_port, :rpmbuild, :install
 
     # Platform names currently contain some information about the platform. Fields
     # within the name are delimited by the '-' character, and this regex can be used to
@@ -99,6 +99,7 @@ class Vanagon
       @architecture = architecture
       @ssh_port = 22
       @provisioning = []
+      @install ||= "install"
     end
 
     # This allows instance variables to be accessed using the hash lookup syntax

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -90,6 +90,12 @@ class Vanagon
         @platform.rpmbuild = rpmbuild_cmd
       end
 
+      # Set the path to the install command
+      # @param install_cmd [String] Full path to install with arguments to be used by default
+      def install(install_cmd)
+        @platform.install = install_cmd
+      end
+
       # Set the path to patch for the platform
       #
       # @param patch_cmd [String] Full path to the patch command for the platform

--- a/lib/vanagon/platform/rpm.rb
+++ b/lib/vanagon/platform/rpm.rb
@@ -66,6 +66,7 @@ class Vanagon
         @num_cores = "/bin/grep -c 'processor' /proc/cpuinfo"
         if is_aix?
           @num_cores = "lsdev -Cc processor |wc -l"
+          @install = "/opt/freeware/bin/install"
         end
         @rpmbuild = "/usr/bin/rpmbuild"
         super(name)


### PR DESCRIPTION
Since we rely on GNU specific behavior for install, we need to be able
to specify which install to use. This patch adds an install method to
the platform dsl. It defaults to "install" but on AIX it defaults to
/opt/freeware/bin/install, since that's GNU install.
