### PR TITLE
(maint) Correct usages of ips_version in solaris 11 packages

### DIFF
--- a/lib/vanagon/platform/solaris_11.rb
+++ b/lib/vanagon/platform/solaris_11.rb
@@ -28,10 +28,10 @@ class Vanagon
           "(cd $(tempdir)/packaging; pkgmogrify -DARCH=`uname -p` #{project.name}.p5m.1 #{project.name}.p5m | pkgfmt > #{project.name}.p5m.2)",
           "pkglint $(tempdir)/packaging/#{project.name}.p5m.2",
           "pkgsend -s 'file://$(tempdir)/repo' publish -d '$(tempdir)/#{name_and_version}' --fmri-in-manifest '$(tempdir)/packaging/#{project.name}.p5m.2'",
-          "pkgrecv -s 'file://$(tempdir)/repo' -a -d 'output/#{target_dir}/#{pkg_name}' '#{project.name}@#{ips_version(project.version)}'",
+          "pkgrecv -s 'file://$(tempdir)/repo' -a -d 'output/#{target_dir}/#{pkg_name}' '#{project.name}@#{ips_version(project.version, project.release)}'",
 
           # Now make sure the package we built isn't totally broken
-          "pkg install -g 'output/#{target_dir}/#{pkg_name}' '#{project.name}@#{ips_version(project.version)}'",
+          "pkg install -g 'output/#{target_dir}/#{pkg_name}' '#{project.name}@#{ips_version(project.version, project.release)}'",
         ]
       end
 

--- a/templates/solaris/11/p5m.erb
+++ b/templates/solaris/11/p5m.erb
@@ -1,4 +1,4 @@
-set name=pkg.fmri value="<%= @name %>@<%= @platform.ips_version(@version) %>"
+set name=pkg.fmri value="<%= @name %>@<%= @platform.ips_version(@version, @release) %>"
 set name=pkg.summary value="<%= @description.lines.first.chomp %>"
 set name=pkg.human-version value="<%= @version %>"
 set name=pkg.description value="<%= @description %>"


### PR DESCRIPTION
When release was added as a required parameter for the ips_version
method, several instances were not updated to pass this extra parameter.
This commit updates all uses of ips_version to pass in release as the
second parameter correctly.
