### PR TITLE
DO NOT MERGE - RFC (maint) add support for platforms that cannot remotely install build …

### DIFF
--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -133,6 +133,12 @@ class Vanagon
       @architecture ||= @name.match(PLATFORM_REGEX)[3]
     end
 
+    # Utility matcher to determine if the platform supports installing
+    # packages via remote urls
+    def supports_remote_package_installs?
+      return !@name.match(/^(huaweios)-.*?/)
+    end
+
     # Utility matcher to determine is the platform is a debian variety
     #
     # @return [true, false] true if it is a debian variety, false otherwise


### PR DESCRIPTION
…deps

For some platforms (HuaweiOS for example), the rpm command is compiled
without support for installing packages via remote uris for security
reasons. So for these platforms we create a tmpdir and download the
build dependency packages to it using curl, and then issue the package
installation command against the locally downloaded files.
