### PR TITLE
(maint) Add WRL platform for WindRiver Linux RPM oddities

### DIFF
--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -1,5 +1,6 @@
 require 'vanagon/platform/deb'
 require 'vanagon/platform/rpm'
+require 'vanagon/platform/rpm/wrl'
 require 'vanagon/platform/swix'
 require 'vanagon/platform/osx'
 require 'vanagon/platform/solaris_10'
@@ -24,8 +25,10 @@ class Vanagon
       # @param block [Proc] DSL definition of the platform to call
       def platform(name, &block)
         @platform = case name
-                    when /^(aix|cisco-wrlinux|el|fedora|huaweios|nxos|sles)-/
+                    when /^(aix|cisco-wrlinux|el|fedora|nxos|sles)-/
                       Vanagon::Platform::RPM.new(@name)
+                    when /^huaweios-/
+                      Vanagon::Platform::RPM::WRL.new(@name)
                     when /^(cumulus|debian|ubuntu)-/
                       Vanagon::Platform::DEB.new(@name)
                     when /^eos-/

--- a/lib/vanagon/platform/rpm/wrl.rb
+++ b/lib/vanagon/platform/rpm/wrl.rb
@@ -1,0 +1,39 @@
+# This platform definition was created to account for oddities with
+# the RPM available on WindRiver Linux based systems. WRL uses RPMv5
+# and some of the WRL-based OS platforms we support (e.g, HuaweiOS)
+# do not have package repo systems or support for installing remote
+# RPMs via urls
+class Vanagon
+  class Platform
+    class RPM
+      class WRL < Vanagon::Platform::RPM
+        # Some WRL RPM platforms (e.g, HuaweiOS) don't allow you to
+        # install remote packages via url, so we'll do a dance to
+        # download them via curl and then perform the installs locally.
+        # This method generates a shell script to be executed on the
+        # system to do this.
+        #
+        # @param build_dependencies [Array] list of all build dependencies to install
+        # @return [String] a command to install all of the build dependencies
+        def install_build_dependencies(build_dependencies)
+          commands = []
+          unless build_dependencies.empty?
+            commands << "tmpdir=$(mktemp -p /var/tmp -d)"
+            commands << "cd ${tmpdir}"
+            build_dependencies.each do |build_dependency|
+              if build_dependency.match(/^http.*\.rpm$/)
+                # We're downloading each package individually so
+                # failures are easier to troubleshoot
+                commands << %(curl --remote-name --location --fail --silent #{build_dependency} && echo "Successfully downloaded #{build_dependency}")
+              end
+            end
+            # Install the downloaded packages
+            commands << "rpm -Uvh --nodeps --replacepkgs ${tmpdir}/*.rpm"
+          end
+
+          commands.join(' && ')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Some WindRiver Linux based platforms do not offer online package repos
or even remote package installation via urls. This RPM based platform
works around these annoyances by curling down build dependency packages
and installing them locally. The abstraction into a separate platorm
also allows for a place to maintain further workarounds if needed.

Note: I haven't tested it yet, but wanted to share for initial feedback.
