### PR TITLE
(maint) Use @noarch for solaris packages

### DIFF
--- a/templates/solaris/10/pkginfo.erb
+++ b/templates/solaris/10/pkginfo.erb
@@ -1,7 +1,7 @@
 PKG="<%= @name %>"
 NAME="<%= @name %> - <%= @homepage %>"
 VERSION=<%= @version %>-<%= @release %>
-ARCH=<%= @platform.architecture %>
+ARCH=<%= @noarch ? 'all' : @platform.architecture %>
 CLASSES=none
 CATEGORY=application
 VENDOR=<%= @vendor %>

--- a/templates/solaris/11/p5m.erb
+++ b/templates/solaris/11/p5m.erb
@@ -6,7 +6,9 @@ set name=info.classification value="org.opensolaris.category.2008:System/Adminis
 set name=org.opensolaris.consolidation value="<%= @name %>"
 set name=description value="<%= @description %>"
 set name=variant.opensolaris.zone value=global value=nonglobal
-set name=variant.arch value="<%= @platform.architecture %>"
+<%- unless @noarch -%>
+  set name=variant.arch value="<%= @platform.architecture %>"
+<%- end -%>
 
 <%
   def strip_and_escape(str)


### PR DESCRIPTION
Solaris support neglected to use the @noarch variable to indicate when
packages are non-architecture specific. This commit addresses that by
omitting the architecture declaration on solaris 11 and by using all for
the arch in solaris 10.
