### PR TITLE
(maint) Add name to the project DSL

### DIFF
--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -71,6 +71,13 @@ class Vanagon
         @project.description = descr
       end
 
+      # Resets the name of the project. Is useful for dynamically changing the project name.
+      #
+      # @param the_name [String] name of the project
+      def name(the_name)
+        @project.name = the_name
+      end
+
       # Sets the homepage for the project. Mainly for use in packaging.
       #
       # @param page [String] url of homepage of the project


### PR DESCRIPTION
With solaris 11 support, it will be necessary to modify the project's
name from within the project block. This commit adds a name method
to the project dsl to reset the project's name, for which there is
already an accessor.
