### PR TITLE
(maint) Only test install on correct architecture

### DIFF
--- a/lib/vanagon/platform/solaris_11.rb
+++ b/lib/vanagon/platform/solaris_11.rb
@@ -31,7 +31,7 @@ class Vanagon
           "pkgrecv -s 'file://$(tempdir)/repo' -a -d 'output/#{target_dir}/#{pkg_name}' '#{project.name}@#{ips_version(project.version, project.release)}'",
 
           # Now make sure the package we built isn't totally broken (but not when cross-compiling)
-          %(if [ "#{@architecture}" = `uname -p` ]; then pkg install -g 'output/#{target_dir}/#{pkg_name}' '#{project.name}@#{ips_version(project.version, project.release)}'; fi),
+          %(if [ "#{@architecture}" = `uname -p` ]; then pkg install -nv -g 'output/#{target_dir}/#{pkg_name}' '#{project.name}@#{ips_version(project.version, project.release)}'; fi),
         ]
       end
 


### PR DESCRIPTION
Package builds that are the result of a cross compile should not be test
installed. To achieve this, the build command now checks to see if the
target architecture matches the system architecture and only installs
the package if it does.
