### PR TITLE
(RE-5583) Update osx package name

### DIFF
--- a/lib/vanagon/platform/osx.rb
+++ b/lib/vanagon/platform/osx.rb
@@ -69,7 +69,7 @@ class Vanagon
       # @param project [Vanagon::Project] project to name
       # @return [String] name of the osx package for this project
       def package_name(project)
-        "#{project.name}-#{project.version}-#{project.release}.#{@codename}.dmg"
+        "#{project.name}-#{project.version}-#{project.release}.#{@os_name}#{@os_version}.dmg"
       end
 
       # Get the expected output dir for the osx packages. This allows us to


### PR DESCRIPTION
Previously, we changed the puppet-agent package name on osx to include
the codename rather than the version number. The hope was to increate
clarity for users. However, this thought completely backfired. Given
that osx tooling doesn't report the codename, programatically figuring
out the package would be entirely too difficult. To prevent any manual
intervention, we are removing the codename reference from the package
name.

Now it will be shipped as:
`downloads.puppetlabs.com/mac/10.10/PC1/x86_64/puppet-agent-1.2.3.322.g249c98b-1.osx1010.dmg`
