### PR TITLE
(CPR-145) Add .sh and .csh as valid source types

### DIFF
--- a/lib/vanagon/component/source/http.rb
+++ b/lib/vanagon/component/source/http.rb
@@ -13,7 +13,7 @@ class Vanagon
         ARCHIVE_EXTENSIONS = '.tar.gz', '.tgz'
 
         # Extensions for files we aren't going to unpack during the build
-        NON_ARCHIVE_EXTENSIONS = '.gem', '.ru', '.txt', '.conf', '.ini', '.gpg', '.rb'
+        NON_ARCHIVE_EXTENSIONS = '.gem', '.ru', '.txt', '.conf', '.ini', '.gpg', '.rb', '.sh', '.csh'
 
         # Constructor for the Http source type
         #


### PR DESCRIPTION
Prior to this, vanagon blew up if a source was a .sh or .csh file. This
commit allows those explicitly in the http.rb file. We use .sh or .csh files to
set PATH for things like puppet-agent.
