### PR TITLE
(maint) Improve error messages

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -24,7 +24,7 @@ class Vanagon
       compfile = File.join(configdir, "#{name}.rb")
       code = File.read(compfile)
       dsl = Vanagon::Component::DSL.new(name, settings, platform)
-      dsl.instance_eval(code)
+      dsl.instance_eval(code, __FILE__, __LINE__)
       dsl._component
     rescue => e
       puts "Error loading project '#{name}' using '#{compfile}':"

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -22,7 +22,7 @@ class Vanagon
       platfile = File.join(configdir, "#{name}.rb")
       code = File.read(platfile)
       dsl = Vanagon::Platform::DSL.new(name)
-      dsl.instance_eval(code)
+      dsl.instance_eval(code, __FILE__, __LINE__)
       dsl._platform
     rescue => e
       puts "Error loading platform '#{name}' using '#{platfile}':"

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -24,7 +24,7 @@ class Vanagon
       projfile = File.join(configdir, "#{name}.rb")
       code = File.read(projfile)
       dsl = Vanagon::Project::DSL.new(name, platform, include_components)
-      dsl.instance_eval(code)
+      dsl.instance_eval(code, __FILE__, __LINE__)
       dsl._project
     rescue => e
       puts "Error loading project '#{name}' using '#{projfile}':"


### PR DESCRIPTION
One of the more frustrating error messages in vanagon is when a dsl
method is used incorrectly. The instance_eval often swallows it up. This
commit adds file and line number to the instance_eval calls to enable us
to get a more detailed failure message.
