### PR TITLE
(RE-5314) Set -T instead of -t for remote_ssh_command

### DIFF
--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -243,16 +243,11 @@ class Vanagon
     def remote_ssh_command(target, command, port = 22, return_command_output: false)
       if target
         puts "Executing '#{command}' on #{target}"
-        if return_command_output
-          ret = %x(#{ssh_command(port)} -T #{target} '#{command.gsub("'", "'\\\\''")}').chomp
-          if $?.success?
-            return ret
-          else
-            raise "Remote ssh command (#{command}) failed on '#{target}'."
-          end
+        ret = %x(#{ssh_command(port)} -T #{target} '#{command.gsub("'", "'\\\\''")}').chomp
+        if $?.success?
+          return return_command_output ? ret : true
         else
-          Kernel.system("#{ssh_command(port)} -T #{target} '#{command.gsub("'", "'\\\\''")}'")
-          $?.success? or raise "Remote ssh command (#{command}) failed on '#{target}'."
+          raise "Remote ssh command (#{command}) failed on '#{target}'."
         end
       else
         fail "Need a target to ssh to. Received none."


### PR DESCRIPTION
remote_ssh_command was largely copied from the packaging repo, which
needs to force a tty because jenkins jobs often ssh out to other
systems, which can in turn ssh out to other systems. If a tty is not
present, some commands will fail. Vanagon doesn't leverage any
interactive commands that would require a tty, so explicitly disallowing
ttys in its ssh calls will be safe. This has the added bonus of
unsetting TERM in the remote environment, which has caused problems on
certain platforms.
