### PR TITLE
(RE-4894) Augment apply_patch DSL method

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -135,7 +135,7 @@ class Vanagon
       unless @patches.empty?
         patchdir = File.join(workdir, "patches")
         FileUtils.mkdir_p(patchdir)
-        FileUtils.cp(@patches, patchdir)
+        FileUtils.cp(@patches.map(&:path), patchdir)
       end
     end
 

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -80,9 +80,10 @@ class Vanagon
       # Add a patch to the list of patches to apply to the component's source after unpacking
       #
       # @param patch [String] Path to the patch that should be applied
-      # @param flag [String] Any extra flags to add to the patch call (not yet implemented)
-      def apply_patch(patch, flag = nil)
-        @component.patches << patch
+      # @param strip [String, Integer] directory levels to skip in applying patch
+      # @param fuzz [String, Integer] levels of context miss to ignore in applying patch
+      def apply_patch(patch, strip: 1, fuzz: 0)
+        @component.patches << OpenStruct.new('path' => patch, 'strip' => strip.to_s, 'fuzz' => fuzz.to_s)
       end
 
       # Loads and parses json from a file. Will treat the keys in the

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -125,8 +125,19 @@ end" }
       comp = Vanagon::Component::DSL.new('patch-test', {}, {})
       comp.apply_patch('patch_file1')
       comp.apply_patch('patch_file2')
-      expect(comp._component.patches).to include('patch_file1')
-      expect(comp._component.patches).to include('patch_file2')
+      expect(comp._component.patches.count).to eq 2
+      expect(comp._component.patches.first.path).to eq 'patch_file1'
+      expect(comp._component.patches.last.path).to eq 'patch_file2'
+    end
+
+    it 'can specify strip and fuzz' do
+      comp = Vanagon::Component::DSL.new('patch-test', {}, {})
+      # This patch must be amazing
+      comp.apply_patch('patch_file1', fuzz: 12, strip: 1000000)
+      expect(comp._component.patches.count).to eq 1
+      expect(comp._component.patches.first.path).to eq 'patch_file1'
+      expect(comp._component.patches.first.fuzz).to eq '12'
+      expect(comp._component.patches.first.strip).to eq '1000000'
     end
   end
 

--- a/templates/Makefile.erb
+++ b/templates/Makefile.erb
@@ -65,7 +65,7 @@ cleanup-components: <%= @components.map {|comp| "#{comp.name}-cleanup" }.join(" 
 	<%- unless comp.patches.empty? -%>
 		cd <%= comp.dirname %> && \
 		<%- comp.patches.each do |patch| -%>
-			<%= @platform.patch %> -p1 < ../patches/<%= File.basename(patch) %> && \
+			<%= @platform.patch %> --strip=<%= patch.strip %> --fuzz=<%= patch.fuzz %> --ignore-whitespace < ../patches/<%= File.basename(patch.path) %> && \
 		<%- end -%>
 		:
 	<%- end -%>


### PR DESCRIPTION
Previously the apply_patch method assumed you had a well formed patch
that would apply cleanly with strip set to 1. This isn't always true,
and patches aren't always under our control. This commit allows users to
overcome deficiencies in patches by allowing them to override strip and
fuzz. It also updates the patch calls to ignore whitespace. The
apply_patch method now takes two new keyword arguments, fuzz and strip,
to specify these flags.
