### PR TITLE
Revert "(RE-5314) Refactor remote_ssh_command method"

### DIFF
--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -243,11 +243,16 @@ class Vanagon
     def remote_ssh_command(target, command, port = 22, return_command_output: false)
       if target
         puts "Executing '#{command}' on #{target}"
-        ret = %x(#{ssh_command(port)} -T #{target} '#{command.gsub("'", "'\\\\''")}').chomp
-        if $?.success?
-          return return_command_output ? ret : true
+        if return_command_output
+          ret = %x(#{ssh_command(port)} -T #{target} '#{command.gsub("'", "'\\\\''")}').chomp
+          if $?.success?
+            return ret
+          else
+            raise "Remote ssh command (#{command}) failed on '#{target}'."
+          end
         else
-          raise "Remote ssh command (#{command}) failed on '#{target}'."
+          Kernel.system("#{ssh_command(port)} -T #{target} '#{command.gsub("'", "'\\\\''")}'")
+          $?.success? or raise "Remote ssh command (#{command}) failed on '#{target}'."
         end
       else
         fail "Need a target to ssh to. Received none."


### PR DESCRIPTION
This reverts commit f60cbf1a9d3eed0d595233f532c99040ca515067.
This commit unintentionally reduced the output of vanagon builds, which
will make failures harder to debug. Because all ssh calls captured the
stdout into a variable, none of stdout ever makes it to the console
(don't worry stderr still does). So let's pretend this change never
happened, okay?
