### PR TITLE
(RE-5285) Add support for custom pre/post install scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.3.17] - 2015-10-02
+### Added
+- Initial support for custom pre- and post-install actions from the component
+  level. Currently implemented for RPM, we will expand that as needed.
+
 ## [0.3.16] - 2015-09-24
 ### Fixed
 - Configfiles installed explicitly on debian

--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -10,7 +10,7 @@ class Vanagon
     attr_accessor :environment, :extract_with, :dirname, :build_requires
     attr_accessor :settings, :platform, :patches, :requires, :service, :options
     attr_accessor :directories, :replaces, :provides, :cleanup_source, :environment
-    attr_accessor :sources
+    attr_accessor :sources, :preinstall_actions, :postinstall_actions
 
     # Loads a given component from the configdir
     #
@@ -56,6 +56,8 @@ class Vanagon
       @provides = []
       @environment = {}
       @sources = []
+      @preinstall_actions = []
+      @postinstall_actions = []
     end
 
     # Adds the given file to the list of files and returns @files.

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -288,6 +288,20 @@ class Vanagon
       def environment(env)
         @component.environment.merge!(env)
       end
+
+      # Adds actions to run at the beginning of a package install
+      #
+      # @param action [String] Bourne shell compatible scriptlets to execute
+      def add_preinstall_action(action)
+        @component.preinstall_actions << action
+      end
+
+      # Adds actions to run at the end of a package install
+      #
+      # @param action [String] Bourne shell compatible scriptlets to execute
+      def add_postinstall_action(action)
+        @component.postinstall_actions << action
+      end
     end
   end
 end

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -110,6 +110,20 @@ class Vanagon
       provides.flatten.uniq
     end
 
+    # Collects the pre-install actions for the project and it's components
+    #
+    # @return [Array] array of Bourne shell compatible scriptlets to execute
+    def get_preinstall_actions
+      @components.map(&:preinstall_actions).flatten
+    end
+
+    # Collects the post-install actions for the project and it's components
+    #
+    # @return [Array] array of Bourne shell compatible scriptlets to execute
+    def get_postinstall_actions
+      @components.map(&:postinstall_actions).flatten
+    end
+
     # Collects any configfiles supplied by components
     #
     # @return [Array] array of configfiles installed by components of the project

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -195,6 +195,20 @@ end" }
     end
   end
 
+  describe '#add_actions' do
+    it 'adds the corect preinstall action to the component for rpm platforms' do
+      comp = Vanagon::Component::DSL.new('action-test', {}, dummy_platform_sysv)
+      comp.add_preinstall_action('chkconfig --list')
+      expect(comp._component.preinstall_actions).to include("chkconfig --list")
+    end
+
+    it 'adds the corect postinstall action to the component for rpm platforms' do
+      comp = Vanagon::Component::DSL.new('action-test', {}, dummy_platform_sysv)
+      comp.add_postinstall_action('chkconfig --list')
+      expect(comp._component.postinstall_actions).to include("chkconfig --list")
+    end
+  end
+
   describe '#install_service' do
     it 'adds the correct command to the install for the component for sysv platforms' do
       comp = Vanagon::Component::DSL.new('service-test', {}, dummy_platform_sysv)

--- a/templates/rpm/project.spec.erb
+++ b/templates/rpm/project.spec.erb
@@ -115,6 +115,10 @@ for entry in `cat %{SOURCE1}`; do
 done
 
 %pre
+<%- get_preinstall_actions.each do |task| -%>
+<%= task %>
+<%- end -%>
+
 <%- if @user -%>
 # Add our user and group
 <%= @platform.add_group(@user) %>
@@ -122,6 +126,12 @@ done
 <%- end -%>
 
 %post
+<%- if @platform.is_aix? || (@platform.is_el? && @platform.os_version.to_i == 4) -%>
+  ## EL-4 and AIX RPM don't have %posttrans, so we'll put them here
+  <%- get_postinstall_actions.each do |task| -%>
+    <%= task %>
+  <%- end -%>
+<%- end -%>
 <%- get_services.each do |service| -%>
   # switch based on systemd vs systemv vs smf vs aix
   #
@@ -182,6 +192,12 @@ done
   <%- end -%>
 <%- end -%>
 
+<%- unless @platform.is_aix? || (@platform.is_el? && @platform.os_version.to_i == 4) -%>
+%posttrans
+  <%- get_postinstall_actions.each do |task| -%>
+    <%= task %>
+  <%- end -%>
+<%- end -%>
 
 %files -f %{SOURCE1}
 %doc bill-of-materials


### PR DESCRIPTION
This adds the ability to create custom pre- and post- install
scripts at the component level for RPMs.

Currently this is implemented as %pre and %posttrans scriptlets
in the RPM world.
