### PR TITLE
(RE-4784) Rename vcloud_name to vmpooler_template

### DIFF
--- a/lib/vanagon/engine/pooler.rb
+++ b/lib/vanagon/engine/pooler.rb
@@ -5,12 +5,12 @@ class Vanagon
     class Pooler < Base
       attr_reader :token
 
-      # The vcloud_name is required to use the pooler engine
+      # The vmpooler_template is required to use the pooler engine
       def initialize(platform, target = nil)
         @pooler = "http://vmpooler.delivery.puppetlabs.net"
         @token = load_token
         super
-        @required_attributes << "vcloud_name"
+        @required_attributes << "vmpooler_template"
       end
 
       # This method loads the pooler token from one of two locations
@@ -34,12 +34,12 @@ class Vanagon
         response = Vanagon::Utilities.http_request(
           "#{@pooler}/vm",
           'POST',
-          '{"' + @platform.vcloud_name + '":"1"}',
+          '{"' + @platform.vmpooler_template + '":"1"}',
           { 'X-AUTH-TOKEN' => @token }
         )
         if response and response["ok"]
-          @target = response[@platform.vcloud_name]['hostname'] + '.' + response['domain']
-          Vanagon::Driver.logger.info "Reserving #{@target} (#{@platform.vcloud_name}) [#{@token ? 'token used' : 'no token used'}]"
+          @target = response[@platform.vmpooler_template]['hostname'] + '.' + response['domain']
+          Vanagon::Driver.logger.info "Reserving #{@target} (#{@platform.vmpooler_template}) [#{@token ? 'token used' : 'no token used'}]"
 
           tags = {
             'tags' => {
@@ -50,13 +50,13 @@ class Vanagon
           }
 
           response_tag = Vanagon::Utilities.http_request(
-            "#{@pooler}/vm/#{response[@platform.vcloud_name]['hostname']}",
+            "#{@pooler}/vm/#{response[@platform.vmpooler_template]['hostname']}",
             'PUT',
             tags.to_json,
             { 'X-AUTH-TOKEN' => @token }
           )
         else
-          raise Vanagon::Error, "Something went wrong getting a target vm to build on, maybe the pool for #{@platform.vcloud_name} is empty?"
+          raise Vanagon::Error, "Something went wrong getting a target vm to build on, maybe the pool for #{@platform.vmpooler_template} is empty?"
         end
       end
 

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -3,7 +3,7 @@ require 'vanagon/platform/dsl'
 class Vanagon
   class Platform
     attr_accessor :make, :servicedir, :defaultdir, :provisioning, :num_cores, :tar
-    attr_accessor :build_dependencies, :name, :vcloud_name, :cflags, :ldflags, :settings
+    attr_accessor :build_dependencies, :name, :vmpooler_template, :cflags, :ldflags, :settings
     attr_accessor :servicetype, :patch, :architecture, :codename, :os_name, :os_version
     attr_accessor :docker_image, :ssh_port, :rpmbuild, :install, :platform_triple
 

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -151,9 +151,18 @@ class Vanagon
 
       # Set the name of this platform as the vm pooler expects it
       #
+      # @param name [String] name of the target template to use from the vmpooler
+      def vmpooler_template(name)
+        @platform.vmpooler_template = name
+      end
+
+      # Set the name of this platform as the vm pooler expects it
+      #
       # @param name [String] name that the pooler uses for this platform
+      # @deprecated Please use vmpooler_template instead, this will be removed in a future vanagon release.
       def vcloud_name(name)
-        @platform.vcloud_name = name
+        warn "vcloud_name is a deprecated platform DSL method, and will be removed in a future vanagon release. Please use vmpooler_template instead."
+        self.vmpooler_template(name)
       end
 
       # Set the name of the docker image to use

--- a/spec/lib/vanagon/platform/dsl_spec.rb
+++ b/spec/lib/vanagon/platform/dsl_spec.rb
@@ -109,4 +109,20 @@ describe 'Vanagon::Platform::DSL' do
       expect {plat.add_build_repository("anything")}.to raise_error(Vanagon::Error, /Adding a build repository not defined/)
     end
   end
+
+  describe '#vmpooler_template' do
+    it 'sets the instance variable on platform' do
+      plat = Vanagon::Platform::DSL.new('solaris-test-fixture')
+      plat.instance_eval(solaris_10_platform_block)
+      plat.vmpooler_template 'solaris-10-x86_64'
+      expect(plat._platform.vmpooler_template).to eq('solaris-10-x86_64')
+    end
+
+    it 'is called by vcloud_name as a deprecation' do
+      plat = Vanagon::Platform::DSL.new('solaris-test-fixture')
+      plat.instance_eval(solaris_10_platform_block)
+      plat.vcloud_name 'solaris-11-x86_64'
+      expect(plat._platform.vmpooler_template).to eq('solaris-11-x86_64')
+    end
+  end
 end


### PR DESCRIPTION
vcloud_name is the incorrect name to use for this attribute.
vmpooler_template is more accurate, so this commit deprecates the old
method while calling the new one for backward compatibility. The pooler
engine is updated to use the new attribute name.
