### PR TITLE
(maint) Add license, update yard dependency in gemspec

### DIFF
--- a/vanagon.gemspec
+++ b/vanagon.gemspec
@@ -7,13 +7,14 @@ Gem::Specification.new do |gem|
 
   gem.summary = "Another mega-package build tool, now with more Make"
   gem.description = "Vanagon is a tool to build a single package out of a project, which can itself contain one or more components."
+  gem.license = "Apache-2.0"
 
   gem.authors  = ['Puppet Labs']
   gem.email    = 'info@puppetlabs.com'
   gem.homepage = 'http://github.com/puppetlabs/vanagon'
 
   gem.add_development_dependency('rspec', ["~> 3.0"])
-  gem.add_development_dependency('yard')
+  gem.add_development_dependency('yard', '~> 0.8')
   gem.require_path = 'lib'
   gem.bindir       = 'bin'
   gem.executables  = ['build', 'ship', 'repo', 'devkit']

--- a/vanagon.gemspec
+++ b/vanagon.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |gem|
   gem.version = %x(git describe --tags).gsub('-', '.').chomp
   gem.date    = Date.today.to_s
 
-  gem.summary = "Another mega-package build tool, now with more Make"
+  gem.summary = "All of your packages will fit into this van with this one simple trick."
   gem.description = "Vanagon is a tool to build a single package out of a project, which can itself contain one or more components."
   gem.license = "Apache-2.0"
 


### PR DESCRIPTION
Having a license in the gemspec is a good practice, and gem will warn
when building if a dependency has no version requirements, so this
commit adds the license field and adds a versioning requirement to the
yard development dependency.