### PR TITLE
(RE-5758) Move Vanagon bill-of-materials location on OSX

### DIFF
--- a/lib/vanagon/platform/osx.rb
+++ b/lib/vanagon/platform/osx.rb
@@ -18,8 +18,8 @@ class Vanagon
          "gunzip -c #{project.name}-#{project.version}.tar.gz | '#{@tar}' -C '$(tempdir)/osx/build/root/#{project.name}-#{project.version}' --strip-components 1 -xf -",
 
          # Move bill-of-materials into a docdir
-         "mkdir -p $(tempdir)/osx/build/root/#{project.name}-#{project.version}/usr/share/doc/#{project.name}",
-         "mv $(tempdir)/osx/build/root/#{project.name}-#{project.version}/bill-of-materials $(tempdir)/osx/build/root/#{project.name}-#{project.version}/usr/share/doc/#{project.name}/bill-of-materials",
+         "mkdir -p $(tempdir)/osx/build/root/#{project.name}-#{project.version}/usr/local/share/doc/#{project.name}",
+         "mv $(tempdir)/osx/build/root/#{project.name}-#{project.version}/bill-of-materials $(tempdir)/osx/build/root/#{project.name}-#{project.version}/usr/local/share/doc/#{project.name}/bill-of-materials",
 
          # Package the project
          "(cd $(tempdir)/osx/build/; #{@pkgbuild} --root root/#{project.name}-#{project.version} \

--- a/templates/osx/preinstall.erb
+++ b/templates/osx/preinstall.erb
@@ -3,11 +3,15 @@
 # If we appear to be in an upgrade unload services.
 
 foundpkg=`/usr/sbin/pkgutil --volume "$3" --pkgs=<%= @identifier-%>.<%= @name -%>`
+oldbom="/usr/share/doc/<%= @name %>/bill-of-materials"
 
 if [ -n "$foundpkg" ]; then
 <%- get_services.each do |service| -%>
   if /bin/launchctl list "<%= service.name %>" &> /dev/null; then
     /bin/launchctl unload "<%= service.service_file %>"
+  fi
+  if [ -f "$oldbom"]; then
+    /bin/rm "$oldbom"
   fi
 <%- end -%>
 fi


### PR DESCRIPTION
Starting with OSX 10.11, /usr is protected by default.  This commit
updates the location of the bill-of-materials to use the docdir in
/usr/local.

If we're in an upgrade, the preinstall script removes the old
bill-of-materials in /usr if it exists.