### PR TITLE
(maint) Finish build deps before configuring dependents

### DIFF
--- a/templates/Makefile.erb
+++ b/templates/Makefile.erb
@@ -49,7 +49,7 @@ cleanup-components: <%= @components.map {|comp| "#{comp.name}-cleanup" }.join(" 
 	touch <%= @name %>-project
 
 <%- @components.each do |comp| -%>
-<%= comp.name %>: <%= list_component_dependencies(comp).join(" ") %> <%= comp.name %>-install
+<%= comp.name %>: <%= comp.name %>-install
 
 <%- if @cleanup -%>
 <%= comp.name %>-cleanup: <%= comp.name %>-install
@@ -72,7 +72,7 @@ cleanup-components: <%= @components.map {|comp| "#{comp.name}-cleanup" }.join(" 
 	
 	touch <%= comp.name %>-patch
 
-<%= comp.name %>-configure: <%= comp.name %>-patch
+<%= comp.name %>-configure: <%= comp.name %>-patch <%= list_component_dependencies(comp).join(" ") %>
 	<%- unless comp.configure.empty? -%>
 	cd <%= comp.dirname %> && \
 	<%= comp.get_environment %> && \


### PR DESCRIPTION
Previously, a build_requires step would only cause the final, top-level
target of the dependent to have a dependency. This means that it's
possible for the entire dependent to be built before the dependency,
entirely defeating the purpose of build dependencies.

Now, the dependent-configure target depends on the dependency target,
which ensures that include directories, etc will be properly found
when the dependent is configured.