### PR TITLE
(maint) yum_repo - only install curl if missing

### DIFF
--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -231,7 +231,7 @@ class Vanagon
       def yum_repo(definition)
         definition = URI.parse definition
 
-        self.provision_with "yum -y install curl"
+        self.provision_with "rpm -q curl || yum -y install curl"
         if definition.scheme =~ /^(http|ftp)/
           if File.extname(definition.path) == '.rpm'
             # repo definition is an rpm (like puppetlabs-release)


### PR DESCRIPTION
When using `yum_repo` only attempt to install curl if the package is not already present.  The following failure was seen on platforms that do not have any yum repos configured by default.

```
There are no enabled repos.
 Run "yum repolist all" to see the repos you have.
 You can enable repos with yum-config-manager --enable <repo>
```