### PR TITLE
(MAINT) Tests shouldn't emit output...

### DIFF
--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -231,7 +231,7 @@ class Vanagon
       def yum_repo(definition)
         definition = URI.parse definition
 
-        self.provision_with "rpm -q curl || yum -y install curl"
+        self.provision_with "rpm -q curl > /dev/null || yum -y install curl"
         if definition.scheme =~ /^(http|ftp)/
           if File.extname(definition.path) == '.rpm'
             # repo definition is an rpm (like puppetlabs-release)


### PR DESCRIPTION
Except maybe in debugging? We don't actually care about the output
of `rpm -q`, so testing for the presence of a `curl` package shouldn't
squawk about passing or failing.