### PR TITLE
(CPR-240) Ensure AIX doesn't include newlines when creating puppet subsystem

### DIFF
--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -170,7 +170,7 @@ class Vanagon
           target_mode = '0644'
           default_mode = '0755'
         when "aix"
-          @component.service = OpenStruct.new(:name => service_name, :service_command => File.read(service_file))
+          @component.service = OpenStruct.new(:name => service_name, :service_command => File.read(service_file).chomp)
           # Return here because there is no file to install, just a string read in
           return
         else

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -229,11 +229,12 @@ end" }
       expect(comp._component.service.name).to eq('service-test')
     end
 
-    it 'reads from a file when the OS AIX for services' do
+    it 'reads from a file when the OS is AIX for services' do
       comp = Vanagon::Component::DSL.new('service-test', {}, dummy_platform_aix)
       comp.install_service('spec/fixures/component/mcollective.service', nil, 'mcollective')
       expect(comp._component.service.name).to eq('mcollective')
       expect(comp._component.service.service_command).to include('/opt/puppetlabs/puppet/bin/ruby')
+      expect(comp._component.service.service_command).not_to include("\n")
     end
 
     it 'adds the correct command to the install for the component for systemd platforms' do


### PR DESCRIPTION
Previously, when reading in the puppet and mcollective service
scripts to create their subsystems on AIX, a newline in the string
was causing the command and its arguments to appear on separate lines.
This caused `mksys` to not set signorm and sigforce, rendering
the service unstoppable.

We now chomp the newline to ensure the arguments are included with
the service command.