### PR TITLE
(CPR-242) Don't assume all smf services are top level

### DIFF
--- a/templates/solaris/11/p5m.erb
+++ b/templates/solaris/11/p5m.erb
@@ -27,7 +27,10 @@ depend fmri=pkg:/<%= requirement %> type=require
 
 <%- if has_services? -%>
 # Make sure smf manifests cause manifest-import to happen
-<transform file path=(var|lib)/svc/manifest/.*\.xml$ -> default restart_fmri svc:/system/manifest-import:default>
+<%- get_services.each do |service| -%>
+  <transform file path=<%= strip_and_escape(service.service_file) -%>$ -> default restart_fmri svc:/system/manifest-import:default>
+  <transform dir path=<%= strip_and_escape(File.dirname(service.service_file)) -%>$ -> drop>
+<%- end -%>
 <transform dir path=(var|lib)/svc/manifest$ -> drop>
 set name=org.opensolaris.smf.fmri <%= get_services.map {|service| "value=svc:/#{service.name}"}.join(" ") %>
 <%- end -%>


### PR DESCRIPTION
Previously the ips manifest made the naive assumption that all services
could live at /var/svc/manifest or /lib/svc/manifest. Solaris 11 won't
detect services when there, and unfortunately, when moving the services
into subdirs of those directories, the manifest did not previously drop
the subdirectory from the package. This commit updates the manifest to
drop all of the directories holding smf definitions and also to restart
the manifest-import service for each service.