### PR TITLE
(maint) Update travis config to set sudo to false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 bundler_args: --without development
+sudo: false
 before_script:
   - 'git config --global user.email "you@example.com"'
   - 'git config --global user.name "Your Name"'


### PR DESCRIPTION
Setting sudo to false will allow travis to use container and ideally
produce a faster build.