### PR TITLE
(maint) Fix user management arguments

### DIFF
--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -80,9 +80,9 @@ class Vanagon
 
       return <<-HERE.undent
         if getent passwd '#{user.name}' > /dev/null 2>&1; then
-          /usr/sbin/usermod #{useradd_args}
+          /usr/sbin/usermod #{usermod_args}
         else
-          /usr/sbin/useradd #{usermod_args}
+          /usr/sbin/useradd #{useradd_args}
         fi
       HERE
     end


### PR DESCRIPTION
Currently the arguments passed to useradd vs usermod are
backwards. This swaps the arguments so the correct set
is passed to the usermod/useradd commands.