### PR TITLE
(maint) Remove nxos platform from vanagon

### DIFF
--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -146,7 +146,7 @@ class Vanagon
     # @return [true, false] true if it is a redhat variety or uses rpm
     # under the hood, false otherwise
     def is_rpm?
-      return !!@name.match(/^(aix|cisco-wrlinux|el|eos|fedora|huaweios|nxos|sles)-.*$/)
+      return !!@name.match(/^(aix|cisco-wrlinux|el|eos|fedora|huaweios|sles)-.*$/)
     end
 
     # Utility matcher to determine is the platform is an enterprise linux variety
@@ -189,13 +189,6 @@ class Vanagon
     # @return [true, false] true if it is a HuaweiOS variety, false otherwise
     def is_huaweios?
       return !!@name.match(/^huaweios-.*$/)
-    end
-
-    # Utility matcher to determine is the platform is an nxos variety
-    #
-    # @return [true, false] true if it is an nxos variety, false otherwise
-    def is_nxos?
-      return !!@name.match(/^nxos-.*$/)
     end
 
     # Utility matcher to determine is the platform is a cisco-wrlinux

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -25,7 +25,7 @@ class Vanagon
       # @param block [Proc] DSL definition of the platform to call
       def platform(name, &block)
         @platform = case name
-                    when /^(aix|cisco-wrlinux|el|fedora|nxos|sles)-/
+                    when /^(aix|cisco-wrlinux|el|fedora|sles)-/
                       Vanagon::Platform::RPM.new(@name)
                     when /^huaweios-/
                       Vanagon::Platform::RPM::WRL.new(@name)
@@ -247,7 +247,7 @@ class Vanagon
           else
             reponame = "#{SecureRandom.hex}-#{File.basename(definition.path)}"
             reponame = "#{reponame}.repo"  if File.extname(reponame) != '.repo'
-            if @platform.is_nxos? or @platform.is_cisco_wrlinux?
+            if @platform.is_cisco_wrlinux?
               self.provision_with "curl -o '/etc/yum/repos.d/#{reponame}' '#{definition}'"
             else
               self.provision_with "curl -o '/etc/yum.repos.d/#{reponame}' '#{definition}'"

--- a/spec/lib/vanagon/platform/dsl_spec.rb
+++ b/spec/lib/vanagon/platform/dsl_spec.rb
@@ -5,7 +5,7 @@ describe 'Vanagon::Platform::DSL' do
   let (:el_5_platform_block)   { "platform 'el-5-fixture'        do |plat| end" }
   let (:el_6_platform_block)   { "platform 'el-6-fixture'        do |plat| end" }
   let (:sles_platform_block)   { "platform 'sles-test-fixture'   do |plat| end" }
-  let (:nxos_5_platform_block) { "platform 'nxos-5-fixture'      do |plat| end" }
+  let (:cicso_wrlinux_platform_block) { "platform 'cisco-wrlinux-fixture'      do |plat| end" }
   let (:solaris_10_platform_block) { "platform 'solaris-10-fixture'      do |plat| end" }
   let (:solaris_11_platform_block) { "platform 'solaris-11-fixture'      do |plat| end" }
 
@@ -16,7 +16,7 @@ describe 'Vanagon::Platform::DSL' do
   let(:el_definition_rpm) { "http://builds.delivery.puppetlabs.net/puppet-agent/0.2.1/repo_configs/rpm/pl-puppet-agent-0.2.1-release.rpm" }
   let(:sles_definition) { "http://builds.delivery.puppetlabs.net/puppet-agent/0.2.2/repo_configs/rpm/pl-puppet-agent-0.2.2-sles-12-x86_64" }
   let(:sles_definition_rpm) { "http://builds.delivery.puppetlabs.net/puppet-agent/0.2.1/repo_configs/rpm/pl-puppet-agent-0.2.1-release.rpm" }
-  let(:nxos_definition) { "http://builds.delivery.puppetlabs.net/puppet-agent/0.2.1/repo_configs/rpm/pl-puppet-agent-0.2.1-nxos-5-x86_64.repo" }
+  let(:cisco_wrlinux_definition) { "http://builds.delivery.puppetlabs.net/puppet-agent/0.2.1/repo_configs/rpm/pl-puppet-agent-0.2.1-cisco-wrlinux-5-x86_64.repo" }
 
   let(:hex_value) { "906264d248061b0edb1a576cc9c8f6c7" }
 
@@ -54,12 +54,13 @@ describe 'Vanagon::Platform::DSL' do
       expect(plat._platform.provisioning).to include("curl -o '/etc/yum.repos.d/#{hex_value}-pl-puppet-agent-0.2.1-el-7-x86_64.repo' '#{el_definition}'")
     end
 
-    it "downloads the repo file to the correct yum location for nxos" do
-      plat = Vanagon::Platform::DSL.new('nxos-5-fixture')
+    # This test currently covers wrlinux 5 and 7
+    it "downloads the repo file to the correct yum location for wrlinux" do
+      plat = Vanagon::Platform::DSL.new('cisco-wrlinux-fixture')
       expect(SecureRandom).to receive(:hex).and_return(hex_value)
-      plat.instance_eval(nxos_5_platform_block)
-      plat.yum_repo(nxos_definition)
-      expect(plat._platform.provisioning).to include("curl -o '/etc/yum/repos.d/#{hex_value}-pl-puppet-agent-0.2.1-nxos-5-x86_64.repo' '#{nxos_definition}'")
+      plat.instance_eval(cicso_wrlinux_platform_block)
+      plat.yum_repo(cisco_wrlinux_definition)
+      expect(plat._platform.provisioning).to include("curl -o '/etc/yum/repos.d/#{hex_value}-pl-puppet-agent-0.2.1-cisco-wrlinux-5-x86_64.repo' '#{cisco_wrlinux_definition}'")
     end
 
     describe "installs a rpm when given a rpm" do


### PR DESCRIPTION
NXOS was long ago renamed to cisco-wrlinux, so this commit goes through
and removes the nxos specific methods, tests and logic. All repos that
were exercising nxos platforms have been updated to remove that usage.