### PR TITLE
(maint) Do not add additional line breaks to description 

### DIFF
--- a/templates/deb/control.erb
+++ b/templates/deb/control.erb
@@ -15,7 +15,7 @@ Conflicts: <%= get_replaces.map { |replace| "#{replace.replacement} #{replace.ve
 Depends: <%= get_requires.join(", ") %>
 Provides: <%= get_provides.map { |prov| prov.provide }.join(", ") %>
 Description: <%= @description.lines.first.chomp %>
- <%= @description.lines[1..-1].join("\n\s") -%>
+ <%= @description.lines[1..-1].join("\s") -%>
  .
  Contains the following components:
  <%= generate_bill_of_materials.join("\n\s") %>


### PR DESCRIPTION
Currently, we define the description for a project in that projects
file, then parse it out into the debian control file. This is all fine
and dandy for one-line descriptions, but when you add in multi-line
descriptions, it gets interesting. Most multi-line descriptions will
already have line breaks in them, for ease of reading and writing for
the maintainer. The way things currently are, we are adding in an
additional line break for every line we add in to the control file.
Debian doesn't know how to parse descriptions with all of these line
breaks, and fails to build the package. This commit removes the line
break addition.