### PR TITLE
(maint) Allow the rpm spec scriptlets to be run with bash, not sh

### DIFF
--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -5,7 +5,7 @@ class Vanagon
     attr_accessor :make, :servicedir, :defaultdir, :provisioning, :num_cores, :tar
     attr_accessor :build_dependencies, :name, :vmpooler_template, :cflags, :ldflags, :settings
     attr_accessor :servicetype, :patch, :architecture, :codename, :os_name, :os_version
-    attr_accessor :docker_image, :ssh_port, :rpmbuild, :install, :platform_triple
+    attr_accessor :docker_image, :ssh_port, :rpmbuild, :install, :platform_triple, :bash
 
     # Platform names currently contain some information about the platform. Fields
     # within the name are delimited by the '-' character, and this regex can be used to

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -85,6 +85,13 @@ class Vanagon
         @platform.make = make_cmd
       end
 
+      # Set the path to make for the platform
+      #
+      # @param make_cmd [String] Full path to the make command for the platform
+      def bash(bash_cmd)
+        @platform.bash = bash_cmd
+      end
+
       # Set the path to tar for the platform
       #
       # @param tar [String] Full path to the tar command for the platform

--- a/lib/vanagon/platform/rpm.rb
+++ b/lib/vanagon/platform/rpm.rb
@@ -84,6 +84,7 @@ class Vanagon
         @patch ||= "/usr/bin/patch"
         @num_cores ||= "/bin/grep -c 'processor' /proc/cpuinfo"
         @rpmbuild ||= "/usr/bin/rpmbuild"
+        @bash = "/bin/bash"
         super(name)
       end
     end

--- a/lib/vanagon/platform/rpm/aix.rb
+++ b/lib/vanagon/platform/rpm/aix.rb
@@ -20,6 +20,7 @@ class Vanagon
           @num_cores = "lsdev -Cc processor |wc -l"
           @install = "/opt/freeware/bin/install"
           @rpmbuild = "/usr/bin/rpm"
+          @bash = "/usr/bin/bash"
           super(name)
         end
       end

--- a/templates/rpm/project.spec.erb
+++ b/templates/rpm/project.spec.erb
@@ -114,7 +114,7 @@ for entry in `cat %{SOURCE1}`; do
   fi
 done
 
-%pre
+%pre -p <%= @platform.bash %>
 <%- get_preinstall_actions.each do |task| -%>
 <%= task %>
 <%- end -%>
@@ -125,7 +125,7 @@ done
 <%= @platform.add_user(@user) %>
 <%- end -%>
 
-%post
+%post -p <%= @platform.bash %>
 <%- if @platform.is_aix? || (@platform.is_el? && @platform.os_version.to_i == 4) -%>
   ## EL-4 and AIX RPM don't have %posttrans, so we'll put them here
   <%- get_postinstall_actions.each do |task| -%>
@@ -152,7 +152,7 @@ done
   <%- end -%>
 <%- end -%>
 
-%postun
+%postun -p <%= @platform.bash %>
 <%- get_services.each do |service| -%>
   # switch based on systemd vs systemv vs smf vs aix
   #
@@ -174,7 +174,7 @@ done
   <%- end -%>
 <%- end -%>
 
-%preun
+%preun -p <%= @platform.bash %>
 <%- get_services.each do |service| -%>
   <%- if @platform.servicetype == "systemd" -%>
     <%- if @platform.is_sles? -%>
@@ -193,7 +193,7 @@ done
 <%- end -%>
 
 <%- unless @platform.is_aix? || (@platform.is_el? && @platform.os_version.to_i == 4) -%>
-%posttrans
+%posttrans -p <%= @platform.bash %>
   <%- get_postinstall_actions.each do |task| -%>
     <%= task %>
   <%- end -%>


### PR DESCRIPTION
There are some issues, like creating the homedir for a new user, that sh
fails out when trying to do. Bash is a more stable way to run these
scriptles.