### PR TITLE
(CPR-248) Add link to files list in link DSL method

### DIFF
--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -232,6 +232,7 @@ class Vanagon
       def link(source, target)
         @component.install << "#{@component.platform.install} -d '#{File.dirname(target)}'"
         @component.install << "ln -s '#{source}' '#{target}'"
+        @component.add_file Vanagon::Common::Pathname.file(target)
       end
 
       # Sets the version for the component

--- a/templates/deb/rules.erb
+++ b/templates/deb/rules.erb
@@ -16,7 +16,7 @@ override_dh_auto_install:
 	# Copy each of the extra files into place
 <%- get_files.map {|f| f.path.sub(/^\//,'')}.each do |file| -%>
 	install -d debian/tmp/<%= File.dirname(file) %>
-	cp -p <%= file %> debian/tmp/<%= File.dirname(file) %>
+	cp -Rp <%= file %> debian/tmp/<%= File.dirname(file) %>
 <%- end -%>
 
 override_dh_shlibdeps:

--- a/templates/deb/rules.erb
+++ b/templates/deb/rules.erb
@@ -14,7 +14,7 @@ override_dh_auto_install:
 	fi
 <%- end -%>
 	# Copy each of the extra files into place
-<%- get_files.map {|f| f.path.sub(/^\//,'')}.each do |file| -%>
+<%- (get_files + get_configfiles).map {|f| f.path.sub(/^\//,'')}.each do |file| -%>
 	install -d debian/tmp/<%= File.dirname(file) %>
 	cp -Rp <%= file %> debian/tmp/<%= File.dirname(file) %>
 <%- end -%>

--- a/templates/rpm/project.spec.erb
+++ b/templates/rpm/project.spec.erb
@@ -87,7 +87,7 @@ install -d %{buildroot}
 # Copy each of the extra files into place
 <%- (get_files + get_configfiles).map {|f| f.path.sub(/^\//,'')}.each do |file| -%>
   install -d %{buildroot}/<%= File.dirname(file) %>
-  cp -p <%= file %> %{buildroot}/<%= File.dirname(file) %>
+  cp -Rp <%= file %> %{buildroot}/<%= File.dirname(file) %>
 <%- end -%>
 
 <%- if @platform.is_cisco_wrlinux? || @platform.is_huaweios? -%>


### PR DESCRIPTION
Previously links were not added to the files list which meant that they
would not be collected if they fell outside of the directories being
watched by vanagon. This commit adds them to the files list.
The cp calls in the spec and rules files need the -R flag added to
ensure that links are not dereferenced and are copied as is, which would
otherwise break packaging.