### PR TITLE
(maint) Add minimum ruby version and specification to gemspec

### DIFF
--- a/vanagon.gemspec
+++ b/vanagon.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |gem|
   gem.authors  = ['Puppet Labs']
   gem.email    = 'info@puppetlabs.com'
   gem.homepage = 'http://github.com/puppetlabs/vanagon'
+  gem.specification_version = 3
+  gem.required_ruby_version = '~> 2.1.0'
 
   gem.add_development_dependency('rspec', ["~> 3.0"])
   gem.add_development_dependency('yard', '~> 0.8')


### PR DESCRIPTION
Because of the use of keyword arguments with defaults, vanagon won't
work on anything less than ruby 2.1.0, so this commit updates the
gemspec to reflect that. We also add the specification version to
enforce a relatively modern version of rubygems.