### PR TITLE
(CPR-251) Move /var/run/* to /system/volatile on solaris 11

### DIFF
--- a/templates/solaris/11/p5m.erb
+++ b/templates/solaris/11/p5m.erb
@@ -26,6 +26,13 @@ depend fmri=pkg:/<%= requirement %> type=require
 <transform dir path=usr$ -> drop>
 <transform dir path=var$ -> drop>
 
+# (CPR-251) In solaris 11, /var/run is a symlink to /system/volatile, which
+# causes conflicts during package installation. To avoid this, we transform any
+# directory under /var/run to repoint under /system/volatile and drop
+# /system/volatile itself to avoid conflicts.
+<transform dir -> edit path var/run system/volatile>
+<transform dir path=system/volatile$ -> drop>
+
 <%- get_root_directories.each do |dir| -%>
 <transform dir path=<%= strip_and_escape(dir.split('/')[0..-2].join('/')) %>$ -> drop>
 <%- end -%>

--- a/templates/solaris/11/p5m.erb
+++ b/templates/solaris/11/p5m.erb
@@ -21,6 +21,11 @@ set name=variant.opensolaris.zone value=global value=nonglobal
 depend fmri=pkg:/<%= requirement %> type=require
 <%- end -%>
 
+# Always drop /etc, /usr, and /var, it will cause conflicts with other system packages
+<transform dir path=etc$ -> drop>
+<transform dir path=usr$ -> drop>
+<transform dir path=var$ -> drop>
+
 <%- get_root_directories.each do |dir| -%>
 <transform dir path=<%= strip_and_escape(dir.split('/')[0..-2].join('/')) %>$ -> drop>
 <%- end -%>


### PR DESCRIPTION
On solaris 11, /var/run is a symlink to /system/volatile, which results
in file conflicts when attempting to install a package which declares a
directory under /var/run. This commit addresses that by rewriting the
directory entries under /var/run to move them under /system/volatile
instead. /system/volatile must then be itself dropped to avoid conflicts
on package install.