### PR TITLE
(CPR-247) Add BOM method to project DSL

### DIFF
--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -11,6 +11,7 @@ class Vanagon
     attr_accessor :version, :directories, :license, :description, :vendor
     attr_accessor :homepage, :requires, :user, :repo, :noarch, :identifier
     attr_accessor :cleanup, :version_file, :release, :replaces, :provides
+    attr_accessor :bill_of_materials
 
     # Loads a given project from the configdir
     #

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -208,10 +208,16 @@ class Vanagon
         @project.cleanup = true
       end
 
-      # This method will write the projects version to a designated file during package creation
+      # This method will write the project's version to a designated file during package creation
       # @param target [String] a full path to the version file for the project
       def write_version_file(target)
         @project.version_file = Vanagon::Common::Pathname.file(target)
+      end
+
+      # This method will write the project's bill-of-materials to a designated directory during package creation.
+      # @param target [String] a full path to the directory for the bill-of-materials for the project
+      def bill_of_materials(target)
+        @project.bill_of_materials = Vanagon::Common::Pathname.new(target)
       end
     end
   end

--- a/templates/Makefile.erb
+++ b/templates/Makefile.erb
@@ -26,13 +26,19 @@ file-list-after-build: <%= @components.map {|comp| comp.name }.join(" ") %>
 <%= @name %>-<%= @version %>.tar.gz: file-list <%= @cleanup ? 'cleanup-components' : '' %>
 	<%= pack_tarball_command %>
 
-file-list: file-list-before-build <%= @name %>-project <%= @version_file ? @version_file.path : '' %>
+file-list: file-list-before-build <%= @name %>-project
 	comm -23 file-list-after-build file-list-before-build > file-list
 	comm -23 file-list-after-build file-list-before-build | sed -e 's/\(^.*[[:space:]].*$$\)/"\1"/g' > file-list-for-rpm
 
 <%- if @version_file -%>
 <%= @version_file.path %>:
 	echo <%= @version %> > '<%= @version_file.path %>'
+<%- end -%>
+
+<%- if @bill_of_materials -%>
+<%= @bill_of_materials %>:
+	mkdir -p '<%= @bill_of_materials.path %>'
+	mv bill-of-materials '<%= @bill_of_materials.path %>'
 <%- end -%>
 
 <%- dirnames.each do |dir| -%>
@@ -45,7 +51,7 @@ cleanup-components: <%= @components.map {|comp| "#{comp.name}-cleanup" }.join(" 
 	touch cleanup-components
 <%- end -%>
 
-<%= @name %>-project: <%= dirnames.join(' ') %> file-list-after-build
+<%= @name %>-project: <%= dirnames.join(' ') %> <%= @version_file ? @version_file.path : '' %> <%= @bill_of_materials ? @bill_of_materials.path : '' %> file-list-after-build
 	touch <%= @name %>-project
 
 <%- @components.each do |comp| -%>

--- a/templates/deb/docs.erb
+++ b/templates/deb/docs.erb
@@ -1,1 +1,3 @@
+<%- unless @bill_of_materials -%>
 bill-of-materials
+<%- end -%>

--- a/templates/rpm/project.spec.erb
+++ b/templates/rpm/project.spec.erb
@@ -254,7 +254,9 @@ fi
 <%- end -%>
 
 %files -f %{SOURCE1}
+<%- unless @bill_of_materials -%>
 %doc bill-of-materials
+<%- end -%>
 %defattr(-, root, root, 0755)
 <%- get_directories.each do |dir| -%>
 %dir %attr(<%= dir.mode || "-" %>, <%= dir.owner || "-" %>, <%= dir.group || "-" %>) <%= dir.path %>

--- a/templates/solaris/11/p5m.erb
+++ b/templates/solaris/11/p5m.erb
@@ -47,8 +47,10 @@ depend fmri=pkg:/<%= requirement %> type=require
 set name=org.opensolaris.smf.fmri <%= get_services.map {|service| "value=svc:/#{service.name}"}.join(" ") %>
 <%- end -%>
 
+<%- unless @bill_of_materials -%>
 # Move the bill-of-materials into a docdir for the package to avoid conflicts
 <transform file path=bill-of-materials$ -> set path usr/share/doc/<%= @name %>/bill-of-materials>
+<%- end -%>
 
 <%- get_configfiles.each do |config| -%>
 # Preserve the old conf file on upgrade


### PR DESCRIPTION
Previously, the bill-of-materials was laid down by default in the docdir
on various platforms. This causes problems on platforms like newer osx,
and isn't very configurable, so this commit adds a method to the project
DSL which allows the location to be overridden. This is a backward
compatible addition, and contains some shims that can be removed when
bill-of-materials is no longer desired to be on by default.