### PR TITLE
(maint) Fix minimum Ruby version to allow Ruby 2.x

### DIFF
--- a/vanagon.gemspec
+++ b/vanagon.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.email    = 'info@puppetlabs.com'
   gem.homepage = 'http://github.com/puppetlabs/vanagon'
   gem.specification_version = 3
-  gem.required_ruby_version = '~> 2.1.0'
+  gem.required_ruby_version = '~> 2.1'
 
   gem.add_development_dependency('rspec', ["~> 3.0"])
   gem.add_development_dependency('yard', '~> 0.8')


### PR DESCRIPTION
Previously, Vanagon's minimum Ruby version was set to '~> 2.1.0',
which meant that versions equal or greater than 2.1.0 but less than
2.2.0 were allowed. Any version of Ruby above 2.1.0 in the 2.x series
should be valid.