### PR TITLE
(RE-5979) Solaris-11 VERSION file should match other platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.4.1] - 2015-11-12
+### Changed
+- Fixed an issue where, with test builds when the version string contains
+  a git sha alphanumeric component, the Solaris 11 VERSION file contains 
+  the transformed IPS-compatible version string (with the alpha characters
+  stripped). Now the VERSION file will be consistent across all of the
+  platforms.
+
 ## [0.4.0] - 2015-11-03
 ### Added
 - xml files are now valid http component sources

--- a/lib/vanagon/platform/solaris_11.rb
+++ b/lib/vanagon/platform/solaris_11.rb
@@ -98,8 +98,8 @@ class Vanagon
       # @param release [String] Standard package release
       # @return [String] version in IPS format
       def ips_version(version, release)
-        version.gsub!(/[a-zA-Z]/, '')
-        version.gsub!(/(^-)|(-$)/, '')
+        version = version.gsub(/[a-zA-Z]/, '')
+        version = version.gsub(/(^-)|(-$)/, '')
 
         # Here we strip leading 0 from version components but leave singular 0 on their own.
         version = version.split('.').map(&:to_i).join('.')
@@ -134,5 +134,3 @@ class Vanagon
     end
   end
 end
-
-


### PR DESCRIPTION
On Solaris 11, the version transformation to an IPS-compatible
format (minus alpha characters) also makes it into the VERSION
file.

This updates the logic to operate on a duplicate object instead
of the actual version variable when making the transformation,
so that the transformed value only winds up where we explicitly
ask for it.