### PR TITLE
(RE-5680) Teach vanagon how to build nuget archives on windows

### DIFF
--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -6,7 +6,7 @@ class Vanagon
     attr_accessor :build_dependencies, :name, :vmpooler_template, :cflags, :ldflags, :settings
     attr_accessor :servicetype, :patch, :architecture, :codename, :os_name, :os_version
     attr_accessor :docker_image, :ssh_port, :rpmbuild, :install, :platform_triple
-    attr_accessor :target_user, :package_type
+    attr_accessor :target_user, :package_type, :find, :sort
 
     # Platform names currently contain some information about the platform. Fields
     # within the name are delimited by the '-' character, and this regex can be used to
@@ -102,6 +102,8 @@ class Vanagon
       @provisioning = []
       @install ||= "install"
       @target_user ||= "root"
+      @find ||= "find"
+      @sort ||= "sort"
     end
 
     # This allows instance variables to be accessed using the hash lookup syntax

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -102,6 +102,20 @@ class Vanagon
         @platform.package_type = pkg_type
       end
 
+      # Set the path to find for the platform
+      #
+      # @param find_cmd [String] Full path to the find command for the platform
+      def find(find_cmd)
+        @platform.find = find_cmd
+      end
+
+      # Set the path to sort for the platform
+      #
+      # @param sort_cmd [String] Full path to the find command for the platform
+      def sort(sort_cmd)
+        @platform.sort = sort_cmd
+      end
+
       # Set the path to rpmbuild for the platform
       #
       # @param rpmbuild_cmd [String] Full path to rpmbuild with arguments to be used by default

--- a/lib/vanagon/platform/windows.rb
+++ b/lib/vanagon/platform/windows.rb
@@ -52,7 +52,7 @@ class Vanagon
             commands << %(C:/ProgramData/chocolatey/bin/choco.exe source add -n #{definition.host}-#{definition.path.gsub('/', '-')} -s "#{definition}" --debug || echo "Oops, it seems that you don't have chocolatey installed on this system. Please ensure it's there by adding something like 'plat.add_repository 'https://chocolatey.org/install.ps1'' to your platform definition.")
           end
         else
-          fail "Invalid repo specification #{definition}"
+          raise Vanagon::Error "Invalid repo specification #{definition}"
         end
 
         commands

--- a/lib/vanagon/platform/windows.rb
+++ b/lib/vanagon/platform/windows.rb
@@ -74,6 +74,8 @@ class Vanagon
       # @return [Vanagon::Platform::DEB] the win derived platform with the given name
       def initialize(name)
         @target_user = "Administrator"
+        @find = "/usr/bin/find"
+        @sort = "/usr/bin/sort"
         super(name)
       end
     end

--- a/lib/vanagon/platform/windows.rb
+++ b/lib/vanagon/platform/windows.rb
@@ -6,23 +6,17 @@ class Vanagon
       # @param project [Vanagon::Project] project to build a windows package of
       # @return [Array] list of commands required to build a windows package for the given project from a tarball
       def generate_package(project)
-        target_dir = project.repo ? output_dir(project.repo) : output_dir
-        ["mkdir -p output/#{target_dir}",
-        "touch output/#{target_dir}/#{project.name}-#{project.version}-#{project.release}-#{@architecture}.msi"]
-      end
-
-      # Method to generate the files required to build a windows package for the project
-      #
-      # @param workdir [String] working directory to stage the evaluated templates in
-      # @param name [String] name of the project
-      # @param binding [Binding] binding to use in evaluating the packaging templates
-      def generate_packaging_artifacts(workdir, name, binding)
-        win_dir = File.join(workdir, "windows")
-        FileUtils.mkdir_p(win_dir)
-
-        # We'll uncomment this once we have templates to parse here
-        [""].each do |win_file|
-          #erb_file(File.join(VANAGON_ROOT, "templates/win/#{win_file}.erb"), File.join(win_dir, win_file), false, { :binding => binding })
+        # If nothing is passed in as platform type, default to building a nuget package
+        # We should default to building an MSI once that code has been implimented
+        if project.platform.package_type.nil? || project.platform.package_type.empty?
+          return generate_nuget_package(project)
+        else
+          case project.platform.package_type
+          when "nuget", "nupkg"
+            return generate_nuget_package(project)
+          else
+            raise Vanagon::Error "I don't know how to build package type '#{project.platform.package_type}' for Windows. Teach me?"
+          end
         end
       end
 
@@ -31,7 +25,67 @@ class Vanagon
       # @param project [Vanagon::Project] project to name
       # @return [String] name of the windows package for this project
       def package_name(project)
-        "#{project.name}-#{project.version}-#{project.release}-#{@architecture}.msi"
+        # If nothing is passed in as platform type, default to a nuget package
+        # We should default to an MSI once that code has been implimented
+        if project.platform.package_type.nil? || project.platform.package_type.empty?
+          return nuget_package_name(project)
+        else
+          case project.platform.package_type
+          when "nuget", "nupkg"
+            return nuget_package_name(project)
+          else
+            raise Vanagon::Error "I don't know how to name package type '#{project.platform.package_type}' for Windows. Teach me?"
+          end
+        end
+      end
+
+      # Method to generate the files required to build a windows package for the project
+      #
+      # @param workdir [String] working directory to stage the evaluated templates in
+      # @param name [String] name of the project
+      # @param binding [Binding] binding to use in evaluating the packaging templates
+      def generate_packaging_artifacts(workdir, name, binding)
+        # templates that do require a name change
+        erb_file(File.join(VANAGON_ROOT, "templates/windows/project.nuspec.erb"), File.join(workdir, "#{name}.nuspec"), false, { :binding => binding })
+
+        # templates that don't require a name change
+        ["chocolateyInstall.ps1", "chocolateyUninstall.ps1"].each do |win_file|
+          erb_file(File.join(VANAGON_ROOT, "templates/windows/#{win_file}.erb"), File.join(workdir, win_file), false, { :binding => binding })
+        end
+      end
+
+      # The specific bits used to generate a windows nuget package for a given project
+      # Nexus expects packages to be named #{name}-#{version}.nupkg. However, chocolatey
+      # will generate them to be #{name}.#{version}.nupkg. So, we have to rename the
+      # package after we build it. We also take advantage of the rename to sneak the
+      # architecture in the package name. Neither chocolatey nor nexus know how to deal
+      # with architecture, so we are just pretending it's part of the package name.
+      #
+      # @param project [Vanagon::Project] project to build a nuget package of
+      # @return [Array] list of commands required to build a nuget package for the given project from a tarball
+      def generate_nuget_package(project)
+        target_dir = project.repo ? output_dir(project.repo) : output_dir
+        ["mkdir -p output/#{target_dir}",
+        "mkdir -p $(tempdir)/#{project.name}/tools",
+        "cp #{project.name}.nuspec $(tempdir)/#{project.name}/",
+        "cp chocolateyInstall.ps1 chocolateyUninstall.ps1 $(tempdir)/#{project.name}/tools/",
+        "cp file-list $(tempdir)/#{project.name}/tools/file-list.txt",
+        "gunzip -c #{project.name}-#{project.version}.tar.gz | '#{@tar}' -C '$(tempdir)/#{project.name}/tools' --strip-components 1 -xf -",
+        "(cd $(tempdir)/#{project.name} ; #{self.drive_root}/ProgramData/chocolatey/bin/choco.exe pack #{project.name}.nuspec)",
+        "cp $(tempdir)/#{project.name}/#{project.name}-#{@architecture}.#{project.version}.#{project.release}.nupkg ./output/#{target_dir}/#{nuget_package_name(project)}"]
+      end
+
+      # Method to derive the package name for the project.
+      # Nexus expects packages to be named #{name}-#{version}.nupkg. However, chocolatey
+      # will generate them to be #{name}.#{version}.nupkg. So, we have to rename the
+      # package after we build it. We also take advantage of the rename to sneak the
+      # architecture in the package name. Neither chocolatey nor nexus know how to deal
+      # with architecture, so we are just pretending it's part of the package name.
+      #
+      # @param project [Vanagon::Project] project to name
+      # @return [String] name of the windows package for this project
+      def nuget_package_name(project)
+        "#{project.name}-#{@architecture}-#{project.version}.#{project.release}.nupkg"
       end
 
       # Add a repository (or install Chocolatey)
@@ -68,12 +122,32 @@ class Vanagon
         File.join("windows", target_repo, @architecture)
       end
 
+      # Return the drive root currently used on windows. At the moment, this is cygwin, but
+      # may at some unknown date change to bitvise.
+      #
+      # @return [String] the cygwin drive root
+      def drive_root
+        "/cygdrive/c"
+      end
+
+      # Get the windows path equivelant using cygpath
+      #
+      # @param path [String] the path to convert to windows style pathing
+      # @return [String] the windows style path for the given path
+      def convert_to_windows_path(path)
+        path.sub("/cygdrive/c", "C:")
+      end
+
       # Constructor. Sets up some defaults for the windows platform and calls the parent constructor
+      #
+      # Mingw varies on where it is installed based on architecure. We want to use which ever is on the system.
       #
       # @param name [String] name of the platform
       # @return [Vanagon::Platform::DEB] the win derived platform with the given name
       def initialize(name)
         @target_user = "Administrator"
+        @make = "(#{self.drive_root}/tools/mingw64/bin/mingw32-make || #{self.drive_root}/tools/mingw32/bin/mingw32-make)"
+        @tar = "/usr/bin/tar"
         @find = "/usr/bin/find"
         @sort = "/usr/bin/sort"
         super(name)

--- a/templates/Makefile.erb
+++ b/templates/Makefile.erb
@@ -13,14 +13,14 @@ file-list-before-build:
 <%- if dirnames.empty? -%>
 	touch file-list-before-build
 <%- else -%>
-	(find -L <%= dirnames.join(' ') %> 2>/dev/null || find <%= dirnames.join(' ') %> -follow 2>/dev/null) | sort | uniq > file-list-before-build
+	(<%= @platform.find %> -L <%= dirnames.join(' ') %> 2>/dev/null || <%= @platform.find %> <%= dirnames.join(' ') %> -follow 2>/dev/null) | <%= @platform.sort %> | uniq > file-list-before-build
 <%- end -%>
 
 file-list-after-build: <%= @components.map {|comp| comp.name }.join(" ") %>
 <%- if dirnames.empty? -%>
 	touch file-list-after-build
 <%- else -%>
-	(find -L <%= dirnames.join(' ') %>  2>/dev/null || find <%= dirnames.join(' ') %> -follow 2>/dev/null) | sort | uniq > file-list-after-build
+	(<%= @platform.find %> -L <%= dirnames.join(' ') %> 2>/dev/null || <%= @platform.find %> <%= dirnames.join(' ') %> -follow 2>/dev/null) | <%= @platform.sort %> | uniq > file-list-after-build
 <%- end -%>
 
 <%= @name %>-<%= @version %>.tar.gz: file-list <%= @cleanup ? 'cleanup-components' : '' %>

--- a/templates/windows/chocolateyInstall.ps1.erb
+++ b/templates/windows/chocolateyInstall.ps1.erb
@@ -1,0 +1,26 @@
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+<%- dirnames = get_directories.map {|d| d.path } -%>
+<%- dirnames.each do |dir| -%>
+  <%- windows_path = platform.convert_to_windows_path(dir) -%>
+if (Test-Path -path "<%= windows_path %>") {
+  Write-Debug "Warning: copying over '<%= windows_path %>'"
+} else {
+  New-Item -ItemType directory -Path "<%= windows_path %>"
+}
+$origin = Join-Path -path "$toolsDir" -childpath "<%= dir.gsub('/', '\\') %>"
+Copy-Item -path "$origin\*" -destination "<%= windows_path.gsub('/', '\\') %>\" -Recurse -Force
+<%- end -%>
+
+<%- filenames = get_files.map {|f| f.path} -%>
+<%- configfilenames = get_configfiles.map {|cf| cf.path} -%>
+<%- (filenames + configfilenames).each do |file| -%>
+  <%- windows_path = platform.convert_to_windows_path(file) -%>
+if (Test-Path -path "<%= windows_path %>") {
+  Write-Debug "Warning: copying over '<%= windows_path %>'"
+} elseif (!(Test-Path -path "<%= File.dirname windows_path %>")) {
+  New-Item -ItemType directory -Path "<%= File.dirname windows_path %>"
+}
+$origin = Join-Path -path "$toolsDir" -childpath "<%= file.gsub('/', '\\') %>"
+Copy-Item -path "$origin" -destination "<%= windows_path.gsub('/', '\\') %>" -Force
+<%- end -%>

--- a/templates/windows/chocolateyUninstall.ps1.erb
+++ b/templates/windows/chocolateyUninstall.ps1.erb
@@ -1,0 +1,52 @@
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+$contentFile=(join-path -path "$toolsDir" -childpath "file-list") + ".txt"
+if (Test-Path -path "$contentFile") {
+  Write-Debug "Removing files defiend in `'$contentFile`'"
+  $contents=get-content "$contentFile"
+  foreach ($fileInstalled in $contents) {
+    $fileInstalled=$fileInstalled.Replace("/cygdrive/c", "C:")
+    $fileInstalled=$fileInstalled.Replace("/", "\")
+    if (Test-Path -path "$fileInstalled" -PathType Container) {
+      Write-Debug "Not removing directory $fileInstalled"
+    } else {
+      remove-item -Path "$fileInstalled" -Force
+    }
+  }
+} else {
+  Write-Debug "'$contentFile' not found, not removing any files in non-standard chocolatey location"
+}
+
+<%- dirnames = get_directories.map {|d| d.path } -%>
+<%- dirnames.each do |dir| -%>
+  <%- windows_path = platform.convert_to_windows_path(dir) -%>
+if (Test-Path -path "<%= windows_path %>") {
+  # If this directory is empty, let's just delete it
+  if (!(Test-Path -Path "<%= windows_path %>\*")) {
+    Remove-Item -Path "<%= windows_path %>" -Force
+  } else {
+    # We need to try to remove all directories added in this package. We don't
+    # want to force remove a directory in case a different package has also
+    # installed files into that directory. We've already removed all the files
+    # for this package we are trying to remove. This half-way works, in that
+    # order matters, but is not well defined here.
+    Write-Debug "Removing any empty directories in '<%= windows_path %>'"
+    # Remove any empty subdirectories
+    $SearchRoot = "<%= windows_path %>"
+    Get-ChildItem -Path $SearchRoot -Recurse |
+      Where-Object {$_.PSIsContainer -eq $true -and (Get-ChildItem -Path $_.FullName) -eq $null} |
+        Remove-Item
+    # Remove the main directory if it's now empty after removing all empty subdirectories
+    Where-Object {(Get-ChildItem -Path "<%= windows_path %>" -Recurse) -eq $null} | Remove-Item
+  }
+}
+<%- end -%>
+
+<%- filenames = get_files.map {|f| f.path} -%>
+<%- configfilenames = get_configfiles.map {|cf| cf.path} -%>
+<%- (filenames + configfilenames).each do |file| -%>
+  <%- windows_path = platform.convert_to_windows_path(file) -%>
+if (Test-Path -path "<%= windows_path %>") {
+  Remove-Item -Path "<%= windows_path %>" -Force
+}
+<%- end -%>

--- a/templates/windows/project.nuspec.erb
+++ b/templates/windows/project.nuspec.erb
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id><%= "#{@name}-#{@platform.architecture}" %></id>
+    <version><%= "#{@version}.#{@release}" %></version>
+    <title><%= @name %></title>
+    <authors><%= @vendor.match(/^(.*) <.*>$/)[1] %></authors>
+    <owners><%= @vendor.match(/^(.*) <.*>$/)[1] %></owners>
+    <projectUrl><%= @homepage %></projectUrl>
+    <packageSourceUrl><%= "https://github.com/puppetlabs/#{project}-vanagon" %></packageSourceUrl>
+    <projectSourceUrl><%= "https://github.com/puppetlabs/#{project}" %></projectSourceUrl>
+    <docsUrl><%= @homepage %></docsUrl>
+    <mailingListUrl><%= @homepage %></mailingListUrl>
+    <bugTrackerUrl><%= @homepage %></bugTrackerUrl>
+    <licenseUrl><%= @homepage %></licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>
+<%= @description %>
+    </description>
+    <summary><%= @description.lines.first.chomp %></summary>
+    <releaseNotes><%= @homepage %></releaseNotes>
+    <copyright><%= @vendor.match(/^(.*) <.*>$/)[1] %></copyright>
+    <tags>puppet configuration management infrastructure automation facter hiera mco mcollective marionette collective</tags>
+    <provides><%= get_replaces.map { |replace| "#{replace.replacement}" }.join(" ") %></provides>
+    <replaces><%= get_replaces.map { |replace| "#{replace.replacement}" }.join(" ") %></replaces>
+  </metadata>
+  <files>
+  <file src="tools\**" target="tools" />
+  </files>
+</package>
+<!-- character encoding: “UTF-8” -->


### PR DESCRIPTION
These are changes needed to build nuget packages. Once https://github.com/puppetlabs/vanagon/pull/217 is sorted out, we can use the procedure established there to build either msi or nuget packages. That will likely require that the methods added here to windows.rb will have to be moved.