### PR TITLE
(maint) Allow environment to be specified when unpacking tarballs

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -107,7 +107,7 @@ class Vanagon
         @source = Vanagon::Component::Source.source(@url, @options, workdir)
         @source.fetch
         @source.verify
-        @extract_with = @source.extract(@platform.tar) if @source.respond_to?(:extract)
+        @extract_with = @source.respond_to?(:extract) ? @source.extract(@platform.tar) : ':'
         @cleanup_source = @source.cleanup if @source.respond_to?(:cleanup)
         @dirname = @source.dirname
 

--- a/templates/Makefile.erb
+++ b/templates/Makefile.erb
@@ -64,6 +64,7 @@ cleanup-components: <%= @components.map {|comp| "#{comp.name}-cleanup" }.join(" 
 <%- end -%>
 
 <%= comp.name %>-unpack: file-list-before-build
+	<%= comp.get_environment %> && \
 	<%= comp.extract_with %>
 	touch <%= comp.name %>-unpack
 


### PR DESCRIPTION
On windows, we need to be able to set certain environment variables
prior to unpacking our source. The is mainly for dealing with sticky
things like symlinks in cygwin versus windows environments. However,
this only works when we actually have something to unpack. Otherwise,
our extract command returns an empty string. In order for the makefile
not to fail, we return a simple ':' when there is nothing to extract.