### PR TITLE
Add helper for out of tree builds

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -7,7 +7,7 @@ class Vanagon
     #   @return [Set] the list of files marked for installation
 
     attr_accessor :name, :version, :source, :url, :configure, :build, :install
-    attr_accessor :environment, :extract_with, :dirname, :build_requires
+    attr_accessor :environment, :extract_with, :dirname, :build_requires, :build_dir
     attr_accessor :settings, :platform, :patches, :requires, :service, :options
     attr_accessor :directories, :replaces, :provides, :cleanup_source, :environment
     attr_accessor :sources, :preinstall_actions, :postinstall_actions
@@ -121,6 +121,14 @@ class Vanagon
       end
     end
 
+    # Expands the build directory
+    def get_build_dir
+      if @build_dir
+        File.join(@dirname, @build_dir)
+      else
+        @dirname
+      end
+    end
 
     # Fetches secondary sources for the component. These are just dumped into the workdir currently.
     #

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -263,6 +263,27 @@ class Vanagon
         @component.options[:ref] = the_ref
       end
 
+      # Set a build dir relative to the source directory.
+      #
+      # The build dir will be created before the configure block runs and configure/build/install commands will be run
+      # in the build dir.
+      #
+      # @example
+      #   pkg.build_dir "build"
+      #   pkg.source "my-cmake-project" # Will create the path "my-cmake-project/build"
+      #   pkg.configure { ["cmake .."] }
+      #   pkg.build { ["make -j 3"] }
+      #   pkg.install { ["make install"] }
+      #
+      # @param path [String] The build directory to use for building the project
+      def build_dir(path)
+        if Pathname.new(path).relative?
+          @component.build_dir = path
+        else
+          raise Vanagon::Error, "build_dir should be a relative path, but '#{path}' looks to be absolute."
+        end
+      end
+
       # This will add a source to the project and put it in the workdir alongside the other sources
       #
       # @param url [String] url of the source

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -484,6 +484,21 @@ end" }
     end
   end
 
+  describe "#build_dir" do
+    it "sets the build_dir when given a relative path" do
+      comp = Vanagon::Component::DSL.new('build-dir-test', {}, platform)
+      comp.build_dir("build")
+      expect(comp._component.build_dir).to eq("build")
+    end
+
+    it "raises an error when given an absolute path" do
+      comp = Vanagon::Component::DSL.new('build-dir-test', {}, platform)
+      expect {
+        comp.build_dir("/build")
+      }.to raise_error(Vanagon::Error, %r[build_dir should be a relative path, but '/build' looks to be absolute\.])
+    end
+  end
+
   describe '#link' do
     it 'adds the correct command to the install for the component' do
       comp = Vanagon::Component::DSL.new('link-test', {}, platform)

--- a/spec/lib/vanagon/component_spec.rb
+++ b/spec/lib/vanagon/component_spec.rb
@@ -19,4 +19,21 @@ describe "Vanagon::Component" do
       expect(comp.get_environment).to eq(':')
     end
   end
+
+  describe "#get_build_dir" do
+    subject(:comp) do
+      Vanagon::Component.new('build-dir-test', {}, {}).tap do |comp|
+        comp.dirname = "build-dir-test"
+      end
+    end
+
+    it "uses the dirname when no build_dir was set" do
+      expect(comp.get_build_dir).to eq "build-dir-test"
+    end
+
+    it "joins the dirname and the build dir when a build_dir was set" do
+      comp.build_dir = "cmake-build"
+      expect(comp.get_build_dir).to eq File.join("build-dir-test", "cmake-build")
+    end
+  end
 end

--- a/templates/Makefile.erb
+++ b/templates/Makefile.erb
@@ -79,8 +79,11 @@ cleanup-components: <%= @components.map {|comp| "#{comp.name}-cleanup" }.join(" 
 	touch <%= comp.name %>-patch
 
 <%= comp.name %>-configure: <%= comp.name %>-patch <%= list_component_dependencies(comp).join(" ") %>
+	<%- if comp.get_build_dir -%>
+	[ -d <%= comp.get_build_dir %> ] || mkdir -p <%= comp.get_build_dir %>
+	<%- end -%>
 	<%- unless comp.configure.empty? -%>
-	cd <%= comp.dirname %> && \
+	cd <%= comp.get_build_dir %> && \
 	<%= comp.get_environment %> && \
 	<%= comp.configure.join(" && \\\n\t") %>
 	<%- end -%>
@@ -88,7 +91,7 @@ cleanup-components: <%= @components.map {|comp| "#{comp.name}-cleanup" }.join(" 
 
 <%= comp.name %>-build: <%= comp.name %>-configure
 	<%- unless comp.build.empty? -%>
-	cd <%= comp.dirname %> && \
+	cd <%= comp.get_build_dir %> && \
 	<%= comp.get_environment %> && \
 	<%= comp.build.join(" && \\\n\t") %>
 	<%- end -%>
@@ -96,14 +99,14 @@ cleanup-components: <%= @components.map {|comp| "#{comp.name}-cleanup" }.join(" 
 
 <%= comp.name %>-install: <%= comp.name %>-build
 	<%- unless comp.install.empty? -%>
-	cd <%= comp.dirname %> && \
+	cd <%= comp.get_build_dir %> && \
 	<%= comp.get_environment %> && \
 	<%= comp.install.join(" && \\\n\t") %>
 	<%- end -%>
 	touch <%= comp.name %>-install
 
 <%= comp.name %>-clean:
-	[ -d <%= comp.dirname %> ] && cd <%= comp.dirname %> && \
+	[ -d <%= comp.get_build_dir %> ] && cd <%= comp.get_build_dir %> && \
 	<%= @platform[:make] %> clean
 	<%- ["configure", "build", "install"].each do |type| -%>
 	[ -e <%= comp.name %>-<%= type %> ] && rm <%= comp.name %>-<%= type %>


### PR DESCRIPTION
Tools like cmake use out of tree builds to prevent source files and
build files from intermingling; when they're used all commands are run
from a separate build directory. This commit adds a #build_dir method to
the component (and DSL) that when set will create the build dir relative
to the source directory for each component, and when running any build
command will cd into the build directory before running the command.