### PR TITLE
(maint) Handle git versioning scheme in nuspec template

### DIFF
--- a/templates/windows/project.nuspec.erb
+++ b/templates/windows/project.nuspec.erb
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id><%= "#{@name}-#{@platform.architecture}" %></id>
-    <version><%= "#{@version}.#{@release}" %></version>
+    <version><%= @platform.nuget_package_version(@version, @release) %></version>
     <title><%= @name %></title>
     <authors><%= @vendor.match(/^(.*) <.*>$/)[1] %></authors>
     <owners><%= @vendor.match(/^(.*) <.*>$/)[1] %></owners>


### PR DESCRIPTION
Nuget is challenging when it comes to versions. We can only have four
numeric elements seperated by periods. We have the option of specifying
a build version, but this must be the last element in the version tag
and must be a dash followed immediately by a letter and then either
numbers or letters but no punctuation. Since we cannot guarentee a git
short sha will begin with a letter, this isn't an options.

As a result, we must have a version of at most four elements containing
only numbers. If we only have three elements in the version string, then
we get to use the release variable. Otherwise, we just just the first
four elements from the version.

Gross.