### PR TITLE
(RE-3979) Add `check` stage to components

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -2,7 +2,7 @@
 load File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "vanagon.rb"))
 
 optparse = Vanagon::OptParse.new("#{File.basename(__FILE__)} <project-name> <platform-name> [<target>] [options]",
-                                 [:workdir, :configdir, :engine, :preserve, :verbose])
+                                 [:workdir, :configdir, :engine, :preserve, :verbose, :skipcheck])
 options = optparse.parse! ARGV
 
 project = ARGV[0]

--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -6,7 +6,7 @@ class Vanagon
     # @!attribute [r] files
     #   @return [Set] the list of files marked for installation
 
-    attr_accessor :name, :version, :source, :url, :configure, :build, :install
+    attr_accessor :name, :version, :source, :url, :configure, :build, :check, :install
     attr_accessor :environment, :extract_with, :dirname, :build_requires, :build_dir
     attr_accessor :settings, :platform, :patches, :requires, :service, :options
     attr_accessor :directories, :replaces, :provides, :cleanup_source, :environment
@@ -50,6 +50,7 @@ class Vanagon
       @configure = []
       @install = []
       @build = []
+      @check = []
       @patches = []
       @files = Set.new
       @directories = []

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -56,11 +56,18 @@ class Vanagon
         @component.configure << block.call
       end
 
-      # Set or add to the build call for the component. The commands required to build the component before installing it.
+      # Set or add to the build call for the component. The commands required to build the component before testing/installing it.
       #
       # @param block [Proc] the command(s) required to build the component
       def build(&block)
         @component.build << block.call
+      end
+
+      # Set or add to the check call for the component. The commands required to test the component before installing it.
+      #
+      # @param block [Proc] the command(s) required to test the component
+      def check(&block)
+        @component.check << block.call
       end
 
       # Set or add to the install call for the component. The commands required to install the component.

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -12,7 +12,7 @@ class Vanagon
     include Vanagon::Utilities
     attr_accessor :platform, :project, :target, :workdir, :verbose, :preserve
 
-    def initialize(platform, project, options = { :configdir => nil, :target => nil, :engine => nil, :components => nil })
+    def initialize(platform, project, options = { :configdir => nil, :target => nil, :engine => nil, :components => nil, :skipcheck => false })
       @verbose = false
       @preserve = false
 
@@ -23,6 +23,7 @@ class Vanagon
 
       @platform = Vanagon::Platform.load_platform(platform, File.join(@@configdir, "platforms"))
       @project = Vanagon::Project.load_project(project, File.join(@@configdir, "projects"), @platform, components)
+      @project.settings[:skipcheck] = options[:skipcheck]
       @@logger = Logger.new('vanagon_hosts.log')
       @@logger.progname = 'vanagon'
 

--- a/lib/vanagon/optparse.rb
+++ b/lib/vanagon/optparse.rb
@@ -43,6 +43,12 @@ class Vanagon
           end
         end
 
+        if @options.include?(:skipcheck)
+          opts.on('--skipcheck', 'Ship the `check` stage when building components') do |flag|
+            @options[:skipcheck] = flag
+          end
+        end
+
         opts.on('-h', '--help', 'Display help') do
           puts opts
           exit 1

--- a/lib/vanagon/optparse.rb
+++ b/lib/vanagon/optparse.rb
@@ -2,50 +2,27 @@ require 'optparse'
 
 class Vanagon
   class OptParse
+
+    FLAGS = {
+        :workdir => ['-w DIR', '--workdir DIR', "Working directory where build source should be put (defaults to a tmpdir)"],
+        :configdir => ['-c', '--configdir DIR', 'Configs dir (defaults to $pwd/configs)'],
+        :target => ['-t HOST', '--target HOST', 'Configure a target machine for build and packaging (defaults to grabbing one from the pooler)'],
+        :engine => ['-e ENGINE', '--engine ENGINE', "A custom engine to use (defaults to the pooler) [base, local, docker, pooler currently supported]"],
+        :skipcheck => ['--skipcheck', 'Ship the `check` stage when building components'],
+        :preserve => ['-p', '--preserve', 'Whether to tear down the VM on success or not (defaults to false)'],
+        :verbose => ['-v', '--verbose', 'Verbose output (does nothing)'],
+      }
+
     def initialize(banner, options = [])
       @options = Hash[options.map { |v| [v, nil] }]
       @optparse = OptionParser.new do |opts|
         opts.banner = banner
 
-        if @options.include?(:workdir)
-          opts.on('-w DIR', '--workdir DIR', "Working directory where build source should be put (defaults to a tmpdir)") do |dir|
-            @options[:workdir] = dir
-          end
-        end
-
-        if @options.include?(:configdir)
-          opts.on('-c', '--configdir DIR', 'Configs dir (defaults to $pwd/configs)') do |dir|
-            @options[:configdir] = dir
-          end
-        end
-
-        if @options.include?(:target)
-          opts.on('-t HOST', '--target HOST', 'Configure a target machine for build and packaging (defaults to grabbing one from the pooler)') do |name|
-            @options[:target] = name
-          end
-        end
-
-        if @options.include?(:engine)
-          opts.on('-e ENGINE', '--engine ENGINE', "A custom engine to use (defaults to the pooler) [base, local, docker, pooler currently supported]") do |engine|
-            @options[:engine] = engine
-          end
-        end
-
-        if @options.include?(:preserve)
-          opts.on('-p', '--preserve', 'Whether to tear down the VM on success or not (defaults to false)') do |flag|
-            @options[:preserve] = flag
-          end
-        end
-
-        if @options.include?(:verbose)
-          opts.on('-v', '--verbose', 'Verbose output (does nothing)') do |flag|
-            @options[:verbose] = flag
-          end
-        end
-
-        if @options.include?(:skipcheck)
-          opts.on('--skipcheck', 'Ship the `check` stage when building components') do |flag|
-            @options[:skipcheck] = flag
+        FLAGS.each_pair do |name, args|
+          if @options.include?(name)
+            opts.on(*args) do |value|
+              @options[name] = value
+            end
           end
         end
 

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -105,6 +105,21 @@ end" }
     end
   end
 
+  describe '#check' do
+    it 'sets check to the value if check is empty' do
+      comp = Vanagon::Component::DSL.new('check-test', {}, {})
+      comp.check { './check' }
+      expect(comp._component.check).to eq(['./check'])
+    end
+
+    it 'appends to the existing check if not empty' do
+      comp = Vanagon::Component::DSL.new('check-test', {}, {})
+      comp.check { 'make test' }
+      comp.check { 'make cpplint' }
+      expect(comp._component.check).to eq(['make test', 'make cpplint'])
+    end
+  end
+
   describe '#install' do
     it 'sets install to the value if install is empty' do
       comp = Vanagon::Component::DSL.new('install-test', {}, {})

--- a/spec/lib/vanagon/optparse_spec.rb
+++ b/spec/lib/vanagon/optparse_spec.rb
@@ -1,0 +1,40 @@
+require 'vanagon/optparse'
+
+describe Vanagon::OptParse do
+
+  describe "options that don't take a value" do
+    [:skipcheck, :preserve, :verbose].each do |flag|
+      it "can create an option parser that accepts the #{flag} flag" do
+        subject = described_class.new("test", [flag])
+        expect(subject.parse!(["--#{flag}"])).to eq(flag => true)
+      end
+    end
+
+    describe "short options" do
+      [["p", :preserve], ["v", :verbose]].each do |short, long|
+        it "maps the short option #{short} to #{long}" do
+          subject = described_class.new("test", [long])
+          expect(subject.parse!(["-#{short}"])).to eq(long => true)
+        end
+      end
+    end
+  end
+
+  describe "options that take a value" do
+    [:workdir, :configdir, :target, :engine].each do |option|
+      it "can create an option parser that accepts the #{option} option" do
+        subject = described_class.new("test", [option])
+        expect(subject.parse!(["--#{option}", "hello"])).to eq(option => "hello")
+      end
+    end
+
+    describe "short options" do
+      [["w", :workdir], ["c", :configdir], ["t", :target], ["e", :engine]].each do |short, long|
+        it "maps the short option #{short} to #{long}" do
+          subject = described_class.new("test", [long])
+          expect(subject.parse!(["-#{short}", "hello"])).to eq(long => "hello")
+        end
+      end
+    end
+  end
+end

--- a/templates/Makefile.erb
+++ b/templates/Makefile.erb
@@ -98,7 +98,7 @@ cleanup-components: <%= @components.map {|comp| "#{comp.name}-cleanup" }.join(" 
 	touch <%= comp.name %>-build
 
 <%= comp.name %>-check: <%= comp.name %>-build
-	<%- unless comp.check.empty? -%>
+	<%- unless comp.check.empty? || settings[:skipcheck] -%>
 	cd <%= comp.get_build_dir %> && \
 	<%= comp.get_environment %> && \
 	<%= comp.check.join(" && \\\n\t") %>

--- a/templates/Makefile.erb
+++ b/templates/Makefile.erb
@@ -97,7 +97,15 @@ cleanup-components: <%= @components.map {|comp| "#{comp.name}-cleanup" }.join(" 
 	<%- end -%>
 	touch <%= comp.name %>-build
 
-<%= comp.name %>-install: <%= comp.name %>-build
+<%= comp.name %>-check: <%= comp.name %>-build
+	<%- unless comp.check.empty? -%>
+	cd <%= comp.get_build_dir %> && \
+	<%= comp.get_environment %> && \
+	<%= comp.check.join(" && \\\n\t") %>
+	<%- end -%>
+	touch <%= comp.name %>-check
+
+<%= comp.name %>-install: <%= comp.name %>-check
 	<%- unless comp.install.empty? -%>
 	cd <%= comp.get_build_dir %> && \
 	<%= comp.get_environment %> && \


### PR DESCRIPTION
This pull request adds a `check` stage to components for running component unit tests/code linting/static analysis after compilation and before installation/packaging. It also adds a `--skipcheck` flag to the `build` executable to disable the `check` stage on all components when build speed is more important than code verification.