### PR TITLE
(maint) Pass ':' if there is nothing to extract

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -118,6 +118,9 @@ class Vanagon
 
         # If there is no source, we don't want to try to change directories, so we just change to the current directory.
         @dirname = './'
+
+        # If there is no source, there is nothing to do to extract
+        @extract_with = ':'
       end
     end
 

--- a/lib/vanagon/component/source/http.rb
+++ b/lib/vanagon/component/source/http.rb
@@ -103,7 +103,7 @@ class Vanagon
             return "gunzip -c '#{@file}' | '#{tar}' xf -"
           elsif NON_ARCHIVE_EXTENSIONS.include?(@extension)
             # Don't need to unpack gems, ru, txt, conf, ini, gpg
-            return nil
+            return ':'
           else
             fail "Extraction unimplemented for '#{@extension}' in source '#{@file}'. Please teach me."
           end


### PR DESCRIPTION
Because of excitement on windows, we need to set certain environment
variables when we unpack tarballs that contain symlinks. That means
we've modified the Makefile to include the environment settings as well
as '&& \'. When this is followed by an empty line, make fails. So, in
order to prevent this failure, we need to pass in ':' so that nothing
happens when there is no extract command to pass in.