### PR TITLE
(CPR-263) Teach vanagon how to add post-installation gem patches

### DIFF
--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -80,10 +80,13 @@ class Vanagon
       # Add a patch to the list of patches to apply to the component's source after unpacking
       #
       # @param patch [String] Path to the patch that should be applied
+      # @param destination [String] Path to the location where the patch should be applied
       # @param strip [String, Integer] directory levels to skip in applying patch
       # @param fuzz [String, Integer] levels of context miss to ignore in applying patch
-      def apply_patch(patch, strip: 1, fuzz: 0)
-        @component.patches << OpenStruct.new('path' => patch, 'strip' => strip.to_s, 'fuzz' => fuzz.to_s)
+      # @param after [String] the location in the makefile where the patch command should be run
+      def apply_patch(patch, destination: @component.dirname, strip: 1, fuzz: 0, after: 'unpack')
+        raise Vanagon::Error, "We can only apply patches after the source is unpacked or after installation" unless ['unpack', 'install'].include?(after)
+        @component.patches << OpenStruct.new('path' => patch, 'strip' => strip.to_s, 'fuzz' => fuzz.to_s, 'destination' => destination, 'after' => after)
       end
 
       # Loads and parses json from a file. Will treat the keys in the

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -139,6 +139,35 @@ end" }
       expect(comp._component.patches.first.fuzz).to eq '12'
       expect(comp._component.patches.first.strip).to eq '1000000'
     end
+
+    it 'can specify a directory where the patch should be applied' do
+      comp = Vanagon::Component::DSL.new('patch-test', {}, {})
+      comp.apply_patch('patch_file1', destination: 'random/install/directory')
+      expect(comp._component.patches.count).to eq 1
+      expect(comp._component.patches.first.path).to eq 'patch_file1'
+      expect(comp._component.patches.first.destination).to eq 'random/install/directory'
+    end
+
+    it 'can specify when to try to apply the patch' do
+      comp = Vanagon::Component::DSL.new('patch-test', {}, {})
+      comp.apply_patch('patch_file1', after: 'install')
+      expect(comp._component.patches.count).to eq 1
+      expect(comp._component.patches.first.path).to eq 'patch_file1'
+      expect(comp._component.patches.first.after).to eq 'install'
+    end
+
+    it 'will default the patch timing to after the source is unpacked' do
+      comp = Vanagon::Component::DSL.new('patch-test', {}, {})
+      comp.apply_patch('patch_file1')
+      expect(comp._component.patches.count).to eq 1
+      expect(comp._component.patches.first.path).to eq 'patch_file1'
+      expect(comp._component.patches.first.after).to eq 'unpack'
+    end
+
+    it 'will fail if the user wants to install the patch at an unsupported step' do
+      comp = Vanagon::Component::DSL.new('patch-test', {}, {})
+      expect { comp.apply_patch('patch_file1', after: 'delivery') }.to raise_error(Vanagon::Error)
+    end
   end
 
   describe '#build_requires' do

--- a/templates/Makefile.erb
+++ b/templates/Makefile.erb
@@ -69,14 +69,15 @@ cleanup-components: <%= @components.map {|comp| "#{comp.name}-cleanup" }.join(" 
 	touch <%= comp.name %>-unpack
 
 <%= comp.name %>-patch: <%= comp.name %>-unpack
-	<%- unless comp.patches.empty? -%>
-		cd <%= comp.dirname %> && \
-		<%- comp.patches.each do |patch| -%>
-			<%= @platform.patch %> --strip=<%= patch.strip %> --fuzz=<%= patch.fuzz %> --ignore-whitespace < ../patches/<%= File.basename(patch.path) %> && \
-		<%- end -%>
-		:
+<%- unless comp.patches.empty? -%>
+	cd <%= comp.dirname %> && \
+	<%- comp.patches.each do |patch| -%>
+	<%- if patch.after == "unpack" -%>
+		<%= @platform.patch %> --strip=<%= patch.strip %> --fuzz=<%= patch.fuzz %> --ignore-whitespace < ../patches/<%= File.basename(patch.path) %> && \
 	<%- end -%>
-	
+	<%- end -%>
+	:
+	<%- end -%>
 	touch <%= comp.name %>-patch
 
 <%= comp.name %>-configure: <%= comp.name %>-patch <%= list_component_dependencies(comp).join(" ") %>
@@ -103,6 +104,15 @@ cleanup-components: <%= @components.map {|comp| "#{comp.name}-cleanup" }.join(" 
 	cd <%= comp.get_build_dir %> && \
 	<%= comp.get_environment %> && \
 	<%= comp.install.join(" && \\\n\t") %>
+	<%- end -%>
+	:
+	<%- unless comp.patches.empty? -%>
+	<%- comp.patches.each do |patch| -%>
+	<%- if patch.after == "install" -%>
+	cd <%= patch.destination %> && \
+		<%= @platform.patch %> --strip=<%= patch.strip %> --fuzz=<%= patch.fuzz %> --ignore-whitespace < $(workdir)/patches/<%= File.basename(patch.path) %>
+	<%- end -%>
+	<%- end -%>
 	<%- end -%>
 	touch <%= comp.name %>-install
 


### PR DESCRIPTION
We need to be able to add patches to some of the gems we're providing in
our windows build. This commits adds in a new gem-patch task to the
Makefile if we have gems. It also exposes the extension type for the
source that we're currently working with. In the special case we're
dealing with no source or a git repo, we have to manually specify the
extension type. There's probably a better way to do this....