### PR TITLE
(CPR-266) Allow vanagon to work with zip files

### DIFF
--- a/lib/vanagon/component/source/http.rb
+++ b/lib/vanagon/component/source/http.rb
@@ -10,7 +10,7 @@ class Vanagon
         attr_accessor :url, :sum, :file, :extension, :workdir, :cleanup
 
         # Extensions for files we intend to unpack during the build
-        ARCHIVE_EXTENSIONS = '.tar.gz', '.tgz'
+        ARCHIVE_EXTENSIONS = '.tar.gz', '.tgz', '.zip'
 
         # Extensions for files we aren't going to unpack during the build
         NON_ARCHIVE_EXTENSIONS = '.gem', '.ru', '.txt', '.conf', '.ini', '.gpg', '.rb', '.sh', '.csh', '.xml'
@@ -100,7 +100,12 @@ class Vanagon
         # @raise [RuntimeError] an exception is raised if there is no known extraction method for @extension
         def extract(tar)
           if ARCHIVE_EXTENSIONS.include?(@extension)
-            return "gunzip -c '#{@file}' | '#{tar}' xf -"
+            case @extension
+            when "tar.gz" || ".tgz"
+              return "gunzip -c '#{@file}' | '#{tar}' xf -"
+            when ".zip"
+              return "unzip '#{@file}'"
+            end
           elsif NON_ARCHIVE_EXTENSIONS.include?(@extension)
             # Don't need to unpack gems, ru, txt, conf, ini, gpg
             return nil


### PR DESCRIPTION
Prior to this patch, vanagon could not work with a zip file as a source
to fetch/extract and build a package from. This simply adds zip to the
ARCHIVE_EXTENSIONS constant and returns the correct command to use for
unpacking the archive.