### PR TITLE
(maint) Fix type in extract

### DIFF
--- a/lib/vanagon/component/source/http.rb
+++ b/lib/vanagon/component/source/http.rb
@@ -101,7 +101,7 @@ class Vanagon
         def extract(tar)
           if ARCHIVE_EXTENSIONS.include?(@extension)
             case @extension
-            when "tar.gz" || ".tgz"
+            when ".tar.gz" || ".tgz"
               return "gunzip -c '#{@file}' | '#{tar}' xf -"
             when ".zip"
               return "unzip '#{@file}'"


### PR DESCRIPTION
Prior to this PR, if we had a package that ended with `.tar.gz`, we
would be unable to unpack it. This method would return the wrong thing.
We need the leading `.` in this string in order to correctly match this
ending.