### PR TITLE
(maint) Allow json files to be used as sources

### DIFF
--- a/lib/vanagon/component/source/http.rb
+++ b/lib/vanagon/component/source/http.rb
@@ -13,7 +13,7 @@ class Vanagon
         ARCHIVE_EXTENSIONS = '.tar.gz', '.tgz', '.zip'
 
         # Extensions for files we aren't going to unpack during the build
-        NON_ARCHIVE_EXTENSIONS = '.gem', '.ru', '.txt', '.conf', '.ini', '.gpg', '.rb', '.sh', '.csh', '.xml', '.vim'
+        NON_ARCHIVE_EXTENSIONS = '.gem', '.ru', '.txt', '.conf', '.ini', '.gpg', '.rb', '.sh', '.csh', '.xml', '.vim', '.json', '.service'
 
         # Constructor for the Http source type
         #


### PR DESCRIPTION
JSON files should be able to be used as non archive sources, since it's
fairly common to have them as configuration.