### PR TITLE
(maint) Allow Vanagon to override `cp`

### DIFF
--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -207,7 +207,7 @@ class Vanagon
       # @param group  [String] group owner of the file
       def install_file(source, target, mode: '0644', owner: nil, group:  nil)
         @component.install << "#{@component.platform.install} -d '#{File.dirname(target)}'"
-        @component.install << "cp -p '#{source}' '#{target}'"
+        @component.install << "#{@component.platform.copy} -p '#{source}' '#{target}'"
         @component.add_file Vanagon::Common::Pathname.file(target, mode: mode, owner: owner, group: group)
       end
 

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -6,7 +6,7 @@ class Vanagon
     attr_accessor :build_dependencies, :name, :vmpooler_template, :cflags, :ldflags, :settings
     attr_accessor :servicetype, :patch, :architecture, :codename, :os_name, :os_version
     attr_accessor :docker_image, :ssh_port, :rpmbuild, :install, :platform_triple
-    attr_accessor :target_user, :package_type, :find, :sort, :build_hosts
+    attr_accessor :target_user, :package_type, :find, :sort, :build_hosts, :copy
 
     # Platform names currently contain some information about the platform. Fields
     # within the name are delimited by the '-' character, and this regex can be used to
@@ -104,6 +104,7 @@ class Vanagon
       @target_user ||= "root"
       @find ||= "find"
       @sort ||= "sort"
+      @copy ||= "cp"
     end
 
     # This allows instance variables to be accessed using the hash lookup syntax

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -109,7 +109,7 @@ class Vanagon
 
       # Set the path to sort for the platform
       #
-      # @param sort_cmd [String] Full path to the find command for the platform
+      # @param sort_cmd [String] Full path to the sort command for the platform
       def sort(sort_cmd)
         @platform.sort = sort_cmd
       end

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -114,6 +114,13 @@ class Vanagon
         @platform.sort = sort_cmd
       end
 
+      # Set the path to copy for the platform
+      #
+      # @param copy_cmd [String] Full path to the copy command for the platform
+      def copy(copy_cmd)
+        @platform.copy = copy_cmd
+      end
+
       # Set the path to rpmbuild for the platform
       #
       # @param rpmbuild_cmd [String] Full path to rpmbuild with arguments to be used by default

--- a/lib/vanagon/platform/windows.rb
+++ b/lib/vanagon/platform/windows.rb
@@ -194,6 +194,7 @@ class Vanagon
         @find = "/usr/bin/find"
         @sort = "/usr/bin/sort"
         @num_cores = "/usr/bin/nproc"
+        @copy = "/usr/bin/cp"
         super(name)
       end
     end

--- a/lib/vanagon/platform/windows.rb
+++ b/lib/vanagon/platform/windows.rb
@@ -194,6 +194,7 @@ class Vanagon
         @find = "/usr/bin/find"
         @sort = "/usr/bin/sort"
         @num_cores = "/usr/bin/nproc"
+        @install = "/usr/bin/install"
         @copy = "/usr/bin/cp"
         super(name)
       end

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -59,6 +59,7 @@ end" }
 
   before do
     allow(platform).to receive(:install).and_return('install')
+    allow(platform).to receive(:copy).and_return('cp')
   end
 
   describe '#load_from_json' do


### PR DESCRIPTION
This PR also sets `@install` for windows and fixes a typo