### PR TITLE
(maint) Fix case typo

### DIFF
--- a/lib/vanagon/component/source/http.rb
+++ b/lib/vanagon/component/source/http.rb
@@ -101,7 +101,7 @@ class Vanagon
         def extract(tar)
           if ARCHIVE_EXTENSIONS.include?(@extension)
             case @extension
-            when ".tar.gz" || ".tgz"
+            when ".tar.gz", ".tgz"
               return "gunzip -c '#{@file}' | '#{tar}' xf -"
             when ".zip"
               return "unzip '#{@file}'"


### PR DESCRIPTION
This PR updates a typo made when defining what extension we are dealing
with. Rather then `||`, ruby case requires `,` to define multiple
possibilities for satisfying when we enter this block.