### PR TITLE
(PA-121) adding support for .vim syntax files

### DIFF
--- a/lib/vanagon/component/source/http.rb
+++ b/lib/vanagon/component/source/http.rb
@@ -13,7 +13,7 @@ class Vanagon
         ARCHIVE_EXTENSIONS = '.tar.gz', '.tgz', '.zip'
 
         # Extensions for files we aren't going to unpack during the build
-        NON_ARCHIVE_EXTENSIONS = '.gem', '.ru', '.txt', '.conf', '.ini', '.gpg', '.rb', '.sh', '.csh', '.xml'
+        NON_ARCHIVE_EXTENSIONS = '.gem', '.ru', '.txt', '.conf', '.ini', '.gpg', '.rb', '.sh', '.csh', '.xml', '.vim'
 
         # Constructor for the Http source type
         #


### PR DESCRIPTION
In order to facilitate config files for vim, this commit
adds the .vim extension to the list of NON_ARCHIVE_EXTENSIONS
in the component/source/http.rb file