### PR TITLE
(CPR-269) Assume unknown extension types are just files

### DIFF
--- a/lib/vanagon/component/source/http.rb
+++ b/lib/vanagon/component/source/http.rb
@@ -12,9 +12,6 @@ class Vanagon
         # Extensions for files we intend to unpack during the build
         ARCHIVE_EXTENSIONS = '.tar.gz', '.tgz', '.zip'
 
-        # Extensions for files we aren't going to unpack during the build
-        NON_ARCHIVE_EXTENSIONS = '.gem', '.ru', '.txt', '.conf', '.ini', '.gpg', '.rb', '.sh', '.csh', '.xml', '.vim', '.json', '.service'
-
         # Constructor for the Http source type
         #
         # @param url [String] url of the http source to fetch
@@ -106,11 +103,9 @@ class Vanagon
             when ".zip"
               return "unzip '#{@file}'"
             end
-          elsif NON_ARCHIVE_EXTENSIONS.include?(@extension)
-            # Don't need to unpack gems, ru, txt, conf, ini, gpg
-            return nil
           else
-            fail "Extraction unimplemented for '#{@extension}' in source '#{@file}'. Please teach me."
+            # Extension does not appear to be an archive
+            return nil
           end
         end
 
@@ -121,24 +116,25 @@ class Vanagon
         def cleanup
           if ARCHIVE_EXTENSIONS.include?(@extension)
             return "rm #{@file}; rm -r #{dirname}"
-          elsif NON_ARCHIVE_EXTENSIONS.include?(@extension)
+          else
             # Because dirname will be ./ here, we don't want to try to nuke it
             return "rm #{@file}"
-          else
-            fail "Don't know how to cleanup for '#{@file}' with extension: '#{@extension}'. Please teach me."
           end
         end
 
         # Returns the extension for @file
         #
         # @return [String] the extension of @file
-        # @raise [RuntimeError] an exception is raised if the extension isn't in the current list
         def get_extension
-          extension_match = @file.match(/.*(#{Regexp.union(ARCHIVE_EXTENSIONS + NON_ARCHIVE_EXTENSIONS)})/)
+          extension_match = @file.match(/.*(#{Regexp.union(ARCHIVE_EXTENSIONS)})/)
           unless extension_match
-            fail "Unrecognized extension for '#{@file}'. Don't know how to extract this format. Please teach me."
+            if @file.split('.').last.include?('.')
+              return '.' +  @file.split('.').last
+            else
+              # This is the case where the file has no extension
+              return @file
+            end
           end
-
           extension_match[1]
         end
 
@@ -149,12 +145,8 @@ class Vanagon
         def dirname
           if ARCHIVE_EXTENSIONS.include?(@extension)
             return @file.chomp(@extension)
-          elsif NON_ARCHIVE_EXTENSIONS.include?(@extension)
-            # Because we cd into the source dir, using ./ here avoids special casing single file
-            # sources in the Makefile
-            return './'
           else
-            fail "Don't know how to guess dirname for '#{@file}' with extension: '#{@extension}'. Please teach me."
+            return './'
           end
         end
       end

--- a/spec/lib/vanagon/component/source/http_spec.rb
+++ b/spec/lib/vanagon/component/source/http_spec.rb
@@ -30,13 +30,22 @@ describe "Vanagon::Component::Source::Http" do
 
   describe "#get_extension" do
     it "returns the extension for valid extensions" do
-      (Vanagon::Component::Source::Http::ARCHIVE_EXTENSIONS + Vanagon::Component::Source::Http::NON_ARCHIVE_EXTENSIONS).each do |ext|
+      Vanagon::Component::Source::Http::ARCHIVE_EXTENSIONS.each do |ext|
         filename = "#{file_base}#{ext}"
         url = File.join(base_url, filename)
         http_source = Vanagon::Component::Source::Http.new(url, md5sum, workdir)
         expect(http_source).to receive(:download).and_return(filename)
         http_source.fetch
         expect(http_source.get_extension).to eq(ext)
+      end
+    end
+
+    it "is able to download non archive extensions" do
+      ["gpg.txt", "foo.service", "configi.json", "config.repo.txt", "noextensionfile"].each do |filename|
+        url = File.join(base_url, filename)
+        http_source = Vanagon::Component::Source::Http.new(url, md5sum, workdir)
+        expect(http_source).to receive(:download).and_return(filename)
+        http_source.fetch
       end
     end
   end


### PR DESCRIPTION
Prior to this patch, we had to explicitly add every extension we wanted
to use a source with vanagon. This resulted in lots of small patches
with a simple addition of .json or .txt or something. It also meant
that to use those extensions, a release of vanagon was needed. This
slows down work.

Instead, we'll default to any extension that is not explicitly called
out as an archive, is simply a flat file and able to be used that way.
The net result here is that only new archive extensions will require
patches.



![](http://i.imgur.com/EE6lGNP.jpg)
