### PR TITLE
(maint) Use pathname to normalize paths 

### DIFF
--- a/lib/vanagon/common/pathname.rb
+++ b/lib/vanagon/common/pathname.rb
@@ -1,3 +1,5 @@
+require 'pathname'
+
 class Vanagon
   class Common
     class Pathname
@@ -28,7 +30,7 @@ class Vanagon
       #   and exposed through the {#configfile?} method.
       # @return [Vanagon::Common::Pathname] Returns a new Pathname instance.
       def initialize(path, mode: nil, owner: nil, group: nil, config: false)
-        @path = File.expand_path(path)
+        @path = ::Pathname.new(path).cleanpath.to_s
         @mode ||= mode
         @owner ||= owner
         @group ||= group


### PR DESCRIPTION
We are currently using `expand_path` to normalize any path references in
whichever vanagon project we are building. This helps us handle any
extra `/` or `..` in the path. Unfortunately, this method doesn't work
well with paths that are not in unix format and do not exist on the
current machine. Since we are moving to add support for using vangon to
build windows projects, we need to handle windows paths. If we try to
run `expand_path` on an MS-DOS style path (i.e., `C:/Program
Files/Puppet Labs/Puppet`), then `expand_path`, in it's attempt to
normalize the path, will prepend the current working directory to the
path. This is the directory where you kick off your vanagon build. For
me, this would result in paths like
`/home/melissa/puppet-agent/C:/Program Files/Puppet Labs/Puppet`. These
are referenced in the makefile we use to build, which fails hard because
it doesn't understand the path format. Quite frankly, neither do I.