### PR TITLE
(maint) Normalize path shortcuts

### DIFF
--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -232,6 +232,11 @@ class Vanagon
       files = ['file-list', 'bill-of-materials']
       files.push get_files.map(&:path)
       files.push get_configfiles.map(&:path)
+      if @platform.is_windows?
+        files.flatten.map { |f| "$$(cygpath --mixed --long-name '#{f}')" }
+      else
+        files.flatten
+      end
     end
 
     # Generate a bill-of-materials: a listing of the components and their

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -248,7 +248,7 @@ class Vanagon
     def pack_tarball_command
       tar_root = "#{@name}-#{@version}"
       ["mkdir -p '#{tar_root}'",
-       %('#{@platform.tar}' -cf - -T #{get_tarball_files.join(" ")} | ( cd '#{tar_root}/'; '#{@platform.tar}' xfp -)),
+       %('#{@platform.tar}' -cf - -T "#{get_tarball_files.join('" "')}" | ( cd '#{tar_root}/'; '#{@platform.tar}' xfp -)),
        %('#{@platform.tar}' -cf - #{tar_root}/ | gzip -9c > #{tar_root}.tar.gz)].join("\n\t")
     end
 

--- a/templates/Makefile.erb
+++ b/templates/Makefile.erb
@@ -13,14 +13,14 @@ file-list-before-build:
 <%- if dirnames.empty? -%>
 	touch file-list-before-build
 <%- else -%>
-	(<%= @platform.find %> -L "<%= dirnames.join('" "') %>" 2>/dev/null || <%= @platform.find %> "<%= dirnames.join('" "') %>" -follow 2>/dev/null) | <%= @platform.sort %> | uniq > file-list-before-build
+	(<%= @platform.find %> -L "<%= dirnames.join('" "') %>" 2>/dev/null || <%= @platform.find %> "<%= dirnames.join('" "') %>" -follow 2>/dev/null) | <%= "xargs -I[] cygpath --mixed --long-name --absolute [] |" if @platform.is_windows? %> <%= @platform.sort %> | uniq > file-list-before-build
 <%- end -%>
 
 file-list-after-build: <%= @components.map {|comp| comp.name }.join(" ") %>
 <%- if dirnames.empty? -%>
 	touch file-list-after-build
 <%- else -%>
-	(<%= @platform.find %> -L "<%= dirnames.join('" "') %>" 2>/dev/null || <%= @platform.find %> "<%= dirnames.join('" "') %>" -follow 2>/dev/null) | <%= @platform.sort %> | uniq > file-list-after-build
+	(<%= @platform.find %> -L "<%= dirnames.join('" "') %>" 2>/dev/null || <%= @platform.find %> "<%= dirnames.join('" "') %>" -follow 2>/dev/null) | <%= "xargs -I[] cygpath --mixed --long-name --absolute [] |" if @platform.is_windows? %> <%= @platform.sort %> | uniq > file-list-after-build
 <%- end -%>
 
 <%= @name %>-<%= @version %>.tar.gz: file-list <%= @cleanup ? 'cleanup-components' : '' %>

--- a/templates/Makefile.erb
+++ b/templates/Makefile.erb
@@ -13,14 +13,14 @@ file-list-before-build:
 <%- if dirnames.empty? -%>
 	touch file-list-before-build
 <%- else -%>
-	(<%= @platform.find %> -L <%= dirnames.join(' ') %> 2>/dev/null || <%= @platform.find %> <%= dirnames.join(' ') %> -follow 2>/dev/null) | <%= @platform.sort %> | uniq > file-list-before-build
+	(<%= @platform.find %> -L "<%= dirnames.join('" "') %>" 2>/dev/null || <%= @platform.find %> "<%= dirnames.join('" "') %>" -follow 2>/dev/null) | <%= @platform.sort %> | uniq > file-list-before-build
 <%- end -%>
 
 file-list-after-build: <%= @components.map {|comp| comp.name }.join(" ") %>
 <%- if dirnames.empty? -%>
 	touch file-list-after-build
 <%- else -%>
-	(<%= @platform.find %> -L <%= dirnames.join(' ') %> 2>/dev/null || <%= @platform.find %> <%= dirnames.join(' ') %> -follow 2>/dev/null) | <%= @platform.sort %> | uniq > file-list-after-build
+	(<%= @platform.find %> -L "<%= dirnames.join('" "') %>" 2>/dev/null || <%= @platform.find %> "<%= dirnames.join('" "') %>" -follow 2>/dev/null) | <%= @platform.sort %> | uniq > file-list-after-build
 <%- end -%>
 
 <%= @name %>-<%= @version %>.tar.gz: file-list <%= @cleanup ? 'cleanup-components' : '' %>


### PR DESCRIPTION
On windows, we need the ability to deal with spaces in path names. This
commit does two things to handle that. First, it adds double quotes
around all the path names when we query the filesystem. Then, it adds
cygpath to normalize the path. This lets us change Progra~1 to Program
Files. Super gross, I know. I didn't know what else to do. There are
enough assumptions on cygwin currently, I figured it was safe to add one
more.