### PR TITLE
(CPR-264) Rewrite chocolatey packaging scripts

### DIFF
--- a/templates/windows/chocolateyInstall.ps1.erb
+++ b/templates/windows/chocolateyInstall.ps1.erb
@@ -1,26 +1,28 @@
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$fileList = Join-Path -path $toolsDir -childpath "file-list.txt"
 
-<%- dirnames = get_directories.map {|d| d.path } -%>
-<%- dirnames.each do |dir| -%>
-  <%- windows_path = platform.convert_to_windows_path(dir) -%>
-if (Test-Path -path "<%= windows_path %>") {
-  Write-Debug "Warning: copying over '<%= windows_path %>'"
-} else {
-  New-Item -ItemType directory -Path "<%= windows_path %>"
+if (!(Test-Path -path "$fileList")) {
+  Throw "Unable to find file '$fileList', cannot proceed with install"
 }
-$origin = Join-Path -path "$toolsDir" -childpath "<%= dir.gsub('/', '\\') %>"
-Copy-Item -path "$origin\*" -destination "<%= windows_path.gsub('/', '\\') %>\" -Recurse -Force
-<%- end -%>
 
-<%- filenames = get_files.map {|f| f.path} -%>
-<%- configfilenames = get_configfiles.map {|cf| cf.path} -%>
-<%- (filenames + configfilenames).each do |file| -%>
-  <%- windows_path = platform.convert_to_windows_path(file) -%>
-if (Test-Path -path "<%= windows_path %>") {
-  Write-Debug "Warning: copying over '<%= windows_path %>'"
-} elseif (!(Test-Path -path "<%= File.dirname windows_path %>")) {
-  New-Item -ItemType directory -Path "<%= File.dirname windows_path %>"
+$lines = Get-Content "$fileList"
+foreach ($destination in $lines) {
+  $originFile = "$destination" -replace '^[a-zA-Z]:/',''
+  $origin = Join-Path -path "$toolsDir" -childpath "$originFile"
+  if (Test-Path -path "$origin") {
+    $parent = Split-Path -path "$destination" -parent
+    if (!(Test-Path -path "$parent")) {
+      New-Item -ItemType directory -Path "$parent"
+    }
+    if (Test-Path -path "$destination") {
+      Write-Debug "Overwriting '$destination'"
+    }
+    Copy-Item -path "$origin" -destination "$destination" -Force
+  } else {
+    # If the item we are trying to copy over does not exist in our source directory,
+    # we assume it is an empty directory and simply create one in its place. There is
+    # a possibility that this will hide an error where there is actually a missing
+    # file. However, this is such a slim possibity, this action was deemed safe.
+    New-Item -ItemType directory -Path "$destination"
+  }
 }
-$origin = Join-Path -path "$toolsDir" -childpath "<%= file.gsub('/', '\\') %>"
-Copy-Item -path "$origin" -destination "<%= windows_path.gsub('/', '\\') %>" -Force
-<%- end -%>

--- a/templates/windows/chocolateyUninstall.ps1.erb
+++ b/templates/windows/chocolateyUninstall.ps1.erb
@@ -1,54 +1,24 @@
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$fileList = Join-Path -path $toolsDir -childpath "file-list.txt"
 
-$contentFile=(join-path -path "$toolsDir" -childpath "file-list") + ".txt"
-if (Test-Path -path "$contentFile") {
-  Write-Debug "Removing files defiend in `'$contentFile`'"
-  $contents=get-content "$contentFile"
-  foreach ($fileInstalled in $contents) {
-    $fileInstalled=$fileInstalled.Replace("/cygdrive/c", "C:")
-    $fileInstalled=$fileInstalled.Replace("/", "\")
-    if (Test-Path -path "$fileInstalled" -PathType Container) {
-      Write-Debug "Not removing directory $fileInstalled"
-    } elseif (Test-Path -path "$fileInstalled") {
-      remove-item -Path "$fileInstalled" -Force
-    } else {
-      Write-Debug "Skipping missing file $fileInstalled"
+if (!(Test-Path -path "$fileList")) {
+  Throw "Unable to find file '$fileList', cannot proceed with uninstall"
+}
+
+$lines = Get-Content "$fileList"
+foreach ($file in $lines) {
+  if (Test-Path -path "$file") {
+    # We cannot guarentee a directory is only populated with files from
+    # this package, so we cannot whole-sale remove directories. We could
+    # check to see if a directory is empty after we remove all the files,
+    # but that would still end up with some reminantes of our skeletal
+    # directory structure. It doesn't seem worth it ATM. As is, only remove
+    # things that are files, and do not remove any directories.
+    if (!((Get-Item "$file") -is [System.IO.DirectoryInfo])) {
+      Write-Debug "Removing '$file'"
+      remove-item -Path "$file" -Force
     }
-  }
-} else {
-  Write-Debug "'$contentFile' not found, not removing any files in non-standard chocolatey location"
-}
-
-<%- dirnames = get_directories.map {|d| d.path } -%>
-<%- dirnames.each do |dir| -%>
-  <%- windows_path = platform.convert_to_windows_path(dir) -%>
-if (Test-Path -path "<%= windows_path %>") {
-  # If this directory is empty, let's just delete it
-  if (!(Test-Path -Path "<%= windows_path %>\*")) {
-    Remove-Item -Path "<%= windows_path %>" -Force
   } else {
-    # We need to try to remove all directories added in this package. We don't
-    # want to force remove a directory in case a different package has also
-    # installed files into that directory. We've already removed all the files
-    # for this package we are trying to remove. This half-way works, in that
-    # order matters, but is not well defined here.
-    Write-Debug "Removing any empty directories in '<%= windows_path %>'"
-    # Remove any empty subdirectories
-    $SearchRoot = "<%= windows_path %>"
-    Get-ChildItem -Path $SearchRoot -Recurse |
-      Where-Object {$_.PSIsContainer -eq $true -and (Get-ChildItem -Path $_.FullName) -eq $null} |
-        Remove-Item
-    # Remove the main directory if it's now empty after removing all empty subdirectories
-    Where-Object {(Get-ChildItem -Path "<%= windows_path %>" -Recurse) -eq $null} | Remove-Item
+    Write-Debug "Skipping missing file '$file'"
   }
 }
-<%- end -%>
-
-<%- filenames = get_files.map {|f| f.path} -%>
-<%- configfilenames = get_configfiles.map {|cf| cf.path} -%>
-<%- (filenames + configfilenames).each do |file| -%>
-  <%- windows_path = platform.convert_to_windows_path(file) -%>
-if (Test-Path -path "<%= windows_path %>") {
-  Remove-Item -Path "<%= windows_path %>" -Force
-}
-<%- end -%>


### PR DESCRIPTION
Our current nuget packaging scripts make a few assumptions that have
turned out to be false. Namely, these assumptions surround the path
specifications for where we are installing. Previously, we were using a
list of files and directories picked up from the project and component
configs. This was fine, but we have a better source for this
information. We have a file-list.txt file that details all of the files
and directories (even if they are empty) that are to be included in the
package. These paths have already been normalized to deal with spaces
and shortcuts (if any are used). So any use of `Progra~1` will already
have been expanded to `Program Files`. This is especially important
because we cannot guarentee that `Progra~1` will expand to what we want
it to be on the system the package is installed on. We have to expand
all of these shortcuts prior to packaging anything up. We use these
powershell scripts to then copy over files and directories from the
chocolatey install location to the final install location on the system.

The uninstall script only cleans up files. It does leave an empty
directory system in place.