### PR TITLE
(RE-6106) Allow for putting items in /usr/local on debian

### DIFF
--- a/templates/deb/rules.erb
+++ b/templates/deb/rules.erb
@@ -21,5 +21,7 @@ override_dh_auto_install:
 
 override_dh_shlibdeps:
 
+override_dh_usrlocal:
+
 %:
 	dh $@


### PR DESCRIPTION
Prior to this, dh_usrlocal ran and would cause package builds to fail if
things were placed in /usr/local. This patch simply declares an override
of the dh_userlocal target that is a noop.