### PR TITLE
Add upstream URL to component sources

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -12,7 +12,7 @@ class Vanagon
     attr_accessor :settings, :platform, :patches, :requires, :service, :options
     attr_accessor :directories, :replaces, :provides, :cleanup_source
     attr_accessor :sources, :preinstall_actions, :postinstall_actions
-    attr_accessor :preremove_actions, :postremove_actions, :license
+    attr_accessor :preremove_actions, :postremove_actions, :license, :upstream_url
 
     # Loads a given component from the configdir
     #
@@ -105,7 +105,7 @@ class Vanagon
     #
     # @param workdir [String] working directory to put the source into
     def get_source(workdir)
-      if @url
+      if @url || @options[:upstream_url]
         @source = Vanagon::Component::Source.source(@url, @options, workdir)
         @source.fetch
         @source.verify

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -270,6 +270,10 @@ class Vanagon
         @component.url = the_url
       end
 
+      def upstream_url(the_url)
+        @component.options[:upstream_url] = the_url
+      end
+
       # Sets the md5 sum to verify the sum of the source
       #
       # @param md5 [String] md5 sum of the source for verification
@@ -310,8 +314,8 @@ class Vanagon
       # @param url [String] url of the source
       # @param ref [String] Used for git sources, must be a git ref of some sort
       # @param sum [String] sum used to validate http and file sources
-      def add_source(url, ref: nil, sum: nil)
-        @component.sources << OpenStruct.new(:url => url, :ref => ref, :sum => sum)
+      def add_source(url, ref: nil, sum: nil, upstream_url: nil)
+        @component.sources << OpenStruct.new(:url => url, :ref => ref, :sum => sum, :upsteam_url => upstream_url)
       end
 
       # Adds a directory to the list of directories provided by the project, to be included in any packages of the project

--- a/lib/vanagon/component/source.rb
+++ b/lib/vanagon/component/source.rb
@@ -62,9 +62,9 @@ class Vanagon
         uri_scheme = url_match[1] if url_match
         local_source =  case uri_scheme
                         when /^http/
-                          Vanagon::Component::Source::Http.new(self.rewrite(url, 'http'), options[:sum], workdir)
+                          Vanagon::Component::Source::Http.new(self.rewrite(url, 'http'), options[:sum], workdir, options[:upstream_url])
                         when /^file/
-                          Vanagon::Component::Source::Http.new(self.rewrite(url, 'file'), options[:sum], workdir)
+                          Vanagon::Component::Source::Http.new(self.rewrite(url, 'file'), options[:sum], workdir, options[:upstream_url])
                         when /^git/
                           Vanagon::Component::Source::Git.new(self.rewrite(url, 'git'), options[:ref], workdir)
                         else

--- a/spec/lib/vanagon/component/source/http_spec.rb
+++ b/spec/lib/vanagon/component/source/http_spec.rb
@@ -11,17 +11,18 @@ describe "Vanagon::Component::Source::Http" do
   let (:plaintext_dirname) { './' }
   let (:md5sum) { 'abcdssasasa' }
   let (:workdir) { "/tmp" }
+  let (:upstream_url) { "http://ftp.gnu.org/#{tar_dirname}/#{tar_filename}" }
 
   describe "#dirname" do
     it "returns the name of the tarball, minus extension for archives" do
-      http_source = Vanagon::Component::Source::Http.new(tar_url, md5sum, workdir)
+      http_source = Vanagon::Component::Source::Http.new(tar_url, md5sum, workdir, upstream_url)
       expect(http_source).to receive(:download).and_return(tar_filename)
       http_source.fetch
       expect(http_source.dirname).to eq(tar_dirname)
     end
 
     it "returns the current directory for non-archive files" do
-      http_source = Vanagon::Component::Source::Http.new(plaintext_url, md5sum, workdir)
+      http_source = Vanagon::Component::Source::Http.new(plaintext_url, md5sum, workdir, upstream_url)
       expect(http_source).to receive(:download).and_return(plaintext_filename)
       http_source.fetch
       expect(http_source.dirname).to eq(plaintext_dirname)
@@ -33,7 +34,7 @@ describe "Vanagon::Component::Source::Http" do
       Vanagon::Component::Source::Http::ARCHIVE_EXTENSIONS.each do |ext|
         filename = "#{file_base}#{ext}"
         url = File.join(base_url, filename)
-        http_source = Vanagon::Component::Source::Http.new(url, md5sum, workdir)
+        http_source = Vanagon::Component::Source::Http.new(url, md5sum, workdir, upstream_url)
         expect(http_source).to receive(:download).and_return(filename)
         http_source.fetch
         expect(http_source.get_extension).to eq(ext)
@@ -43,7 +44,7 @@ describe "Vanagon::Component::Source::Http" do
     it "is able to download non archive extensions" do
       ["gpg.txt", "foo.service", "configi.json", "config.repo.txt", "noextensionfile"].each do |filename|
         url = File.join(base_url, filename)
-        http_source = Vanagon::Component::Source::Http.new(url, md5sum, workdir)
+        http_source = Vanagon::Component::Source::Http.new(url, md5sum, workdir, upstream_url)
         expect(http_source).to receive(:download).and_return(filename)
         http_source.fetch
       end


### PR DESCRIPTION
When trying to work with puppet-agent and other PL software outside of
Puppet Labs, things are difficult. This is an attempt to make it
slightly easier. This commit adds a new DSL method called 'upstream_url'
to a component source. This URL is used for fetching content if the
'url' specified fails.

The advantage of this is that we'll now have the upstream URL in the
component, and you won't have to spend your first 25 minutes download
sources and making a mirror on a webserver to use vanagon's url rewrite
engine.

Basically, this just means you need something like:

    pkg.upstream_url "http://ftp.gnu.org/gnu/#{pkg.get_name}/#{pkg.get_name}-#{pkg.get_version}.tar.gz"

Upstream URL is always the second choice behind pkg.url.

This patch has no affect on git urls. 