### PR TITLE
(maint) RPM only set file-list-for-rpm path if project has directories

### DIFF
--- a/templates/rpm/project.spec.erb
+++ b/templates/rpm/project.spec.erb
@@ -253,7 +253,8 @@ if [ -e %{_localstatedir}/lib/rpm-state/%{name}/upgrade ] ; then
 fi
 <%- end -%>
 
-%files -f %{SOURCE1}
+%files <%- unless get_directories.empty? -%>-f %{SOURCE1}<%- end -%>
+
 <%- unless @bill_of_materials -%>
 %doc bill-of-materials
 <%- end -%>


### PR DESCRIPTION
Some projects do not have directories for us to package, ie pl-build-tools.  This update excludes the file list in this case preventing errors and failure in RPM 4.13

Test against pl-build-tools (without dirs) and pl-build-tools-vanagon (with dirs)

Before
```
++ cat /var/tmp/tmp.13oP32Bje8/rpmbuild/SOURCES/file-list-for-rpm
+ /usr/lib/rpm/check-buildroot
+ /usr/lib/rpm/brp-compress
+ /usr/lib/rpm/brp-strip /usr/bin/strip
+ /usr/lib/rpm/brp-strip-comment-note /usr/bin/strip /usr/bin/objdump
+ /usr/lib/rpm/brp-strip-static-archive /usr/bin/strip
+ /usr/lib/rpm/brp-python-hardlink
+ /usr/lib/rpm/redhat/brp-java-repack-jars
Processing files: pl-build-tools-release-22.0.0-4.fedoraf23.noarch

RPM build errors:
error: Empty %files file /var/tmp/tmp.13oP32Bje8/rpmbuild/SOURCES/file-list-for-rpm
    Empty %files file /var/tmp/tmp.13oP32Bje8/rpmbuild/SOURCES/file-list-for-rpm
Makefile:10: recipe for target 'pl-build-tools-release-22.0.0-4.noarch.rpm' failed
make: *** [pl-build-tools-release-22.0.0-4.noarch.rpm] Error 1
```

After
```
+ sed -i 's|^/etc/yum.repos.d/pl-build-tools.repo$||g' /var/tmp/tmp.MUacwDpBeb/rpmbuild/SOURCES/file-list-for-rpm
++ cat /var/tmp/tmp.MUacwDpBeb/rpmbuild/SOURCES/file-list-for-rpm
+ /usr/lib/rpm/check-buildroot
Processing files: pl-build-tools-release-22.0.0-4.fedoraf23.noarch
Executing(%doc): /bin/sh -e /var/tmp/rpm-tmp.HxNxVq
```