### PR TITLE
(RE-6236) Add Service Handling Files to Vanagon

### DIFF
--- a/resources/windows/msi/main.wxs.erb
+++ b/resources/windows/msi/main.wxs.erb
@@ -1,0 +1,781 @@
+<?xml version='1.0' encoding='windows-1252'?>
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'
+  xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+  <!--
+  This is how to include wxi files.  We expect this file to define variables
+  like the version numbers and the upgrade UUID.
+  -->
+  <?include $(sys.SOURCEFILEDIR)include/puppet.wxi ?>
+
+  <!--
+  The Product Id should not be changed, the unique identifier enables
+  un-install of the MSI package easily.  More information about supporting
+  major upgrades is available at:
+  http://wix.sourceforge.net/manual-wix3/major_upgrade.htm
+  Name is made of localized product name and version number.
+  -->
+  <Product Id="$(var.ProductCode)" UpgradeCode="$(var.UpgradeCode)"
+    Name="$(var.OurProductName) Agent$(var.OurProductPlatformText)"
+    Language='1033'
+    Codepage='1252'
+    Version="$(var.ProductVersionNumber)"
+    Manufacturer="$(var.OurCompanyName)">
+
+    <Package
+      InstallerVersion='300'
+      InstallScope="perMachine"
+      Description="$(var.OurProductName)$(var.OurProductPlatformText) Installer"
+      Comments="http://www.puppetlabs.com/"
+      Compressed="yes"
+      Platform="$(var.Platform)"
+      />
+
+    <util:Group Id="AdminGroup" Name="Administrators"/>
+
+    <!-- We allow "downgrades" to support Puppet to Puppet Agent -->
+    <MajorUpgrade AllowDowngrades="yes" />
+
+    <!-- Note, this UI element must come _after_ the Package element -->
+    <UI>
+      <!-- (#12473) (#12474) Installation Directory Dialog -->
+      <UIRef Id="WixUI_PuppetInstallDir"/>
+      <!-- To use WixUI_InstallDir, you must set a property named
+         WIXUI_INSTALLDIR with a value of the ID of the directory you want the
+         user to be able to specify the location of. -->
+      <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
+      <!-- This text is placed as a literal string in the GUI -->
+      <Property Id="WIXUI_EXITDIALOGOPTIONALTEXT" Value="Manage your first resources on this node, explore the Puppet community and get support using the shortcuts in the Documentation folder of your Start Menu." />
+    </UI>
+
+    <Media Id="1"
+      Cabinet="$(var.OurProductNameWord).cab"
+      EmbedCab="yes"
+      CompressionLevel="high"
+      />
+
+    <?if $(var.Platform) = x64 ?>
+      <!-- http://wixtoolset.org/documentation/manual/v3/howtos/redistributables_and_install_checks/block_install_on_os.html
+        -->
+      <Condition Message="$(var.OurProductName) is no longer supported on Windows Server 2003.">
+        <![CDATA[Installed OR (VersionNT64 >= 600)]]>
+      </Condition>
+    <?else?>
+      <Condition Message="$(var.OurProductName) is no longer supported on Windows Server 2003.">
+        <![CDATA[Installed OR (VersionNT >= 600)]]>
+      </Condition>
+    <?endif ?>
+
+    <!--
+      TARGETDIR is Usually C:/  This will also be the location the install package will be copied to
+      For more information: http://msdn.microsoft.com/en-us/library/aa372064.aspx
+
+      INSTALLDIR is the root of our application, which is C:/Program Files/Puppet Labs for us.
+    -->
+    <Directory Id='TARGETDIR' Name='SourceDir'>
+      <!-- The start menu shortcuts -->
+      <Directory Id='ProgramMenuFolder'>
+        <Directory Id='PuppetShortcutDir' Name="$(var.OurProductName)">
+          <Component Id="PuppetShortcuts" Guid="0B69C3FF-8967-4F8A-AC71-0EAE34E91ACC" Win64="$(var.Win64)">
+            <Shortcut Id="PuppetShortcut"
+              Name="Run Puppet Agent"
+              Description="Run Puppet in an interactive command window"
+              Target="[INSTALLDIR]bin\run_puppet_interactive.bat"
+              Icon="PuppetShortcutIcon"
+              WorkingDirectory="bin">
+              <Icon Id="PuppetShortcutIcon" SourceFile="conf\windows\stage\misc\puppetlabs.ico"/>
+            </Shortcut>
+            <Shortcut Id="FacterShortcut"
+              Name="Run Facter"
+              Description="Run Facter in an interactive command window"
+              Target="[INSTALLDIR]bin\run_facter_interactive.bat"
+              Icon="FacterShortcutIcon"
+              WorkingDirectory="bin">
+              <Icon Id="FacterShortcutIcon" SourceFile="conf\windows\stage\misc\puppetlabs.ico"/>
+            </Shortcut>
+            <Shortcut Id="PuppetShellShortcut"
+              Name="Start Command Prompt with Puppet"
+              Description="Start a Command Prompt with Puppet already in the PATH and RUBYLIB load path."
+              Target="[%ComSpec]"
+              Arguments='/E:ON /K "[INSTALLDIR]bin\puppet_shell.bat"'
+              Icon="PuppetShellShortcutIcon"
+              WorkingDirectory="bin">
+              <Icon Id="PuppetShellShortcutIcon" SourceFile="conf\windows\stage\misc\puppetlabs.ico"/>
+            </Shortcut>
+            <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
+            <!-- This registry entry is required to be a keypath for this component -->
+            <RegistryValue Root="HKCU" Key="SOFTWARE\$(var.OurCompanyName)\$(var.OurProductNameWord)"
+              Name="installed" Value="1" Type="integer" KeyPath="yes" />
+          </Component>
+          <Directory Id='PuppetShortcutDocumentationDir' Name="Documentation">
+            <Component Id="PuppetDocumentationShortcuts" Guid="651178BC-76D8-4574-B97B-B132064EE2FB" Win64="$(var.Win64)">
+            <CreateFolder />
+              <IniFile Id="PuppetSupportURL" Name="Get $(var.OurProductName) Support.url"
+                Action="addLine"
+                Section="InternetShortcut"
+                Key="URL" Value="$(var.HelpLink)"
+                Directory="PuppetShortcutDocumentationDir" />
+              <IniFile Id="PuppetCommunityURL" Name="Explore the Puppet Community.url"
+                Action="addLine"
+                Section="InternetShortcut"
+                Key="URL" Value="$(var.CommunityLink)"
+                Directory="PuppetShortcutDocumentationDir" />
+              <IniFile Id="PuppetNextStepURL" Name="$(var.OurProductName) First Steps.url"
+                Action="addLine"
+                Section="InternetShortcut"
+                Key="URL" Value="$(var.NextStepLink)"
+                Directory="PuppetShortcutDocumentationDir" />
+              <IniFile Id="PuppetManualURL" Name="$(var.OurProductName) Manual.url"
+                Action="addLine"
+                Section="InternetShortcut"
+                Key="URL" Value="$(var.ManualLink)"
+                Directory="PuppetShortcutDocumentationDir" />
+              <IniFile Id="PuppetForgeURL" Name="Puppet Forge.url"
+                Action="addLine"
+                Section="InternetShortcut"
+                Key="URL" Value="$(var.ForgeLink)"
+                Directory="PuppetShortcutDocumentationDir" />
+              <RemoveFolder Id="PuppetShortcutDocumentationDir" On="uninstall"/>
+              <RegistryValue Root="HKCU" Key="SOFTWARE\$(var.OurCompanyName)\$(var.OurProductName)\Documentation"
+                Name="installed" Value="1" Type="integer" KeyPath="yes" />
+            </Component>
+          </Directory>
+        </Directory>
+      </Directory>
+      <!-- The application itself -->
+      <Directory Id="$(var.PlatformProgramFilesFolder)" >
+        <Directory Id='PuppetLabs' Name="$(var.OurCompanyName)">
+          <Directory Id='INSTALLDIR' Name="$(var.OurProductName)">
+            <Component Id='PuppetAgentVersionFile' Guid="4A51050C-D761-472E-91D8-95FD2AB34384">
+              <File Id="VERSION" Source="stagedir\VERSION" KeyPath="yes" Checksum="yes"/>
+            </Component>
+            <Directory Id='sys' Name='sys'>
+              <Directory Id='ruby' Name ='ruby'>
+                <Directory Id='ruby_bin' Name='bin'>
+                </Directory>
+              </Directory>
+            </Directory>
+            <Directory Id='bin' Name='bin'>
+              <Component Id="PuppetInstallDirBinToPath" Guid="F46FA9A8-43A2-4379-8933-EAAE2D0E5D72" Win64="$(var.Win64)">
+                <CreateFolder />
+                <Environment Id="PuppetBinPath" Name="PATH" Value="[INSTALLDIR]bin" Permanent="no" Part="last" Action="set" System="yes" />
+              </Component>
+            </Directory>
+            <Directory Id='service' Name='service'>
+              <Component Id="service" Guid="98BBD159-8217-4B62-AFB3-9CF8EE37C74E">
+                <CreateFolder />
+                <File Id="PuppetDaemon" KeyPath="yes" Source="stagedir\service\daemon.rb" />
+              </Component>
+            </Directory>
+          </Directory>
+        </Directory>
+      </Directory>
+      <!-- The CommonAppDataFolder is automatically filled in for us. -->
+      <Directory Id="CommonAppDataFolder" Name="CommonAppData">
+        <Directory Id="PuppetLabsAppData" Name="PuppetLabs">
+          <Directory Id="FacterAppData" Name="facter">
+            <Directory Id="FactsDotD" Name="facts.d">
+              <Component Id="PuppetInstallerFacts" Permanent="yes" Guid="4E7C234B-2837-4459-A20E-9503A922FCB9">
+                <CreateFolder>
+                  <Permission GenericAll="yes" User="Administrators" />
+                  <Permission GenericRead="yes" GenericExecute="yes" User="Everyone" />
+                </CreateFolder>
+              </Component>
+            </Directory>
+          </Directory>
+          <Directory Id="MCOAppData" Name="mcollective">
+            <Directory Id="MCOConfDir" Name="etc">
+              <Component Id="MCOConfDir" Permanent="yes" Guid="3E904914-17C7-138C-F5DF-280F680E067C">
+                <CreateFolder />
+              </Component>
+            </Directory>
+            <Directory Id="MCOVarDir" Name="var">
+              <Directory Id="MCOLogDir" Name="log">
+                <Component Id="MCOLogDir" Permanent="yes" Guid="F9357673-2AF2-90FA-8707-14EE37FA0657">
+                  <CreateFolder />
+                </Component>
+              </Directory>
+            </Directory>
+          </Directory>
+          <Directory Id="PuppetAppData" Name="puppet">
+            <Directory Id="PuppetConfDir" Name="etc">
+              <!-- This is a permanent directory, do not remove on uninstall -->
+              <Component Id="PuppetConfUnconditionalSettings" Permanent="yes" Guid="B9179A60-483F-4F32-8E3F-AD632B0DEBB4">
+                <CreateFolder />
+                <IniFile Id="PuppetConfServer" Name="puppet.conf"
+                  Action="addLine"
+                  Section="main"
+                  Key="server" Value="[PUPPET_MASTER_SERVER]"
+                  Directory="PuppetConfDir" />
+                <IniFile Id="PuppetConfPluginSync" Name="puppet.conf"
+                  Action="createLine"
+                  Section="main"
+                  Key="pluginsync" Value="true"
+                  Directory="PuppetConfDir" />
+                <IniFile Id="PuppetConfAutoflush" Name="puppet.conf"
+                  Action="createLine"
+                  Section="main"
+                  Key="autoflush" Value="true"
+                  Directory="PuppetConfDir" />
+              </Component>
+              <Component Id="PuppetConfWithAgentEnvironment" Permanent="yes" Guid="EC56FB39-A176-42BA-BB1C-10C8DE76AE67">
+                <Condition>PUPPET_AGENT_ENVIRONMENT</Condition>
+                <CreateFolder />
+                <!-- The agent environment setting will only be managed if the
+                     PUPPET_AGENT_ENVIRONMENT is not an empty string -->
+                <!-- Manage the entry itself -->
+                <IniFile Id="PuppetConfAgentEnvironment" Name="puppet.conf"
+                  Action="addLine"
+                  Section="main"
+                  Key="environment" Value="[PUPPET_AGENT_ENVIRONMENT]"
+                  Directory="PuppetConfDir" />
+              </Component>
+              <Component Id="PuppetConfWithCertname" Permanent="yes" Guid="5D1813E1-0AEB-4965-B504-354D7F10DCEA">
+                <Condition>PUPPET_AGENT_CERTNAME</Condition>
+                <CreateFolder />
+                <!-- The certname setting will only be managed if the
+                     PUPPET_AGENT_CERTNAME is not an empty string -->
+                <!-- Manage the entry itself -->
+                <IniFile Id="PuppetConfCertname" Name="puppet.conf"
+                  Action="addLine"
+                  Section="main"
+                  Key="certname" Value="[PUPPET_AGENT_CERTNAME]"
+                  Directory="PuppetConfDir" />
+              </Component>
+              <Component Id="PuppetConfWithCaServer" Permanent="yes" Guid="CE676CF1-2E12-4CDC-B87F-D4BC4E71FF85">
+                <Condition>PUPPET_CA_SERVER</Condition>
+                <CreateFolder />
+                <!-- The certname setting will only be managed if the
+                     PUPPET_CA_SERVER is not an empty string -->
+                <IniFile Id="PuppetConfCaServer" Name="puppet.conf"
+                  Action="addLine"
+                  Section="main"
+                  Key="ca_server" Value="[PUPPET_CA_SERVER]"
+                  Directory="PuppetConfDir" />
+              </Component>
+            </Directory>
+            <Directory Id="PuppetVarDir" Name="var">
+              <Component Id="PuppetVarDir" Permanent="yes" Guid="B95A17F3-CF5E-4EC7-859E-F10C0965645F">
+                <CreateFolder />
+              </Component>
+            </Directory>
+          </Directory>
+          <Directory Id="CodeDir" Name="code">
+            <Component Id="CodeDir" Permanent="yes" Guid="0D29EB1B-604D-4FE1-A75C-F18CC230BEED">
+              <CreateFolder />
+              <File Id="HieraConf" KeyPath="yes" Source="stagedir\hiera\ext\hiera.yaml" />
+            </Component>
+            <Directory Id="HieraDataDir" Name="hieradata">
+              <Component Id="HieraDataDir" Permanent="yes" Guid="2438387C-BEA5-47C1-8B43-46FE30E14BEA">
+                <CreateFolder />
+              </Component>
+            </Directory>
+            <Directory Id="CodeModulesDir" Name="modules">
+              <Component Id="CodeModulesDir" Permanent="yes" Guid="ae4a85a4-a305-4c95-b254-c2f06c586482">
+                <CreateFolder />
+              </Component>
+            </Directory>
+            <Directory Id="EnvironmentsDir" Name="environments">
+              <Component Id="EnvironmentsDir" Permanent="yes" Guid="6a6a390a-8783-40b6-b49d-9e2b368e069d">
+                <CreateFolder />
+              </Component>
+              <Directory Id="ProductionDir" Name="production">
+                <Component Id="ProductionDir" Permanent="yes" Guid="b902efcd-756e-4340-8f13-5a79d46b93c7">
+                  <CreateFolder />
+                  <File Id="EnvironmentConf" KeyPath="yes" Source="stagedir\puppet\conf\environment.conf" />
+                </Component>
+                <Directory Id="ManifestsDir" Name="manifests">
+                  <Component Id="ManifestsDir" Permanent="yes" Guid="5484fadf-6d5e-4053-83fc-ea68918d6f2e">
+                    <CreateFolder />
+                  </Component>
+                </Directory>
+                <Directory Id="ModulesDir" Name="modules">
+                  <Component Id="ModulesDir" Permanent="yes" Guid="cbe9cc8d-3a38-4c4c-9f16-39e42093481a">
+                    <CreateFolder />
+                  </Component>
+                </Directory>
+              </Directory>
+            </Directory>
+          </Directory>
+          <Directory Id="pxpAgentDataFolder" Name="pxp-agent">
+            <Directory Id="pxpAgentDataFolderVar" Name="var">
+              <Directory Id="pxpAgentDataFolderLog" Name="log">
+                <Component Id="PXPAgentLogDir" Guid="DF0D0E2A-F069-4933-8AE9-5E779C8E93B9" Permanent="yes" >
+                  <CreateFolder/>
+                </Component>
+              </Directory>
+              <Directory Id="pxpAgentDataFolderRun" Name="run" >
+                <Component Id="PXPAgentRunDir" Guid="4AD77345-D8AE-40E4-B41C-706EC51FE63F" Permanent="yes" >
+                  <CreateFolder/>
+                </Component>
+              </Directory>
+              <Directory Id="pxpAgentDataFolderSpool" Name="spool" >
+                <Component Id="PXPAgentSpoolDir" Guid="F265A518-A7B7-4FA8-85D8-7306A10E1659" Permanent="yes" >
+                  <CreateFolder/>
+                </Component>
+              </Directory>
+            </Directory>
+            <Directory Id="pxpAgentDataFolderEtc" Name="etc">
+              <Directory Id="pxpAgentDataFolderModules" Name="modules" >
+                <Component Id="PXPAgentModulesDir" Guid="EC0FC78E-CCC5-42EB-AF09-378274AC7530" Permanent="yes" >
+                  <CreateFolder/>
+                </Component>
+              </Directory>
+            </Directory>
+          </Directory>
+        </Directory>
+      </Directory>
+
+      <!--
+        If puppet is configured to run as someone other than LocalSystem
+        and we are installing or upgrading, then allow the account to
+        logon as a service and add the account to the local Administrators
+        account. If the account doesn't exist, the install will fail.
+      -->
+      <Component Id="PuppetServiceUser" Guid="0CCA1CDC-CD25-43A5-BE8A-0D455C63D1BE" Win64="$(var.Win64)">
+        <Condition><![CDATA[NOT Installed AND PUPPET_AGENT_ACCOUNT_USER <> "LocalSystem"]]></Condition>
+        <util:User Id="puppetServiceUser"
+                   Domain="[PUPPET_AGENT_ACCOUNT_DOMAIN]"
+                   Name="[PUPPET_AGENT_ACCOUNT_USER]"
+                   Password="[PUPPET_AGENT_ACCOUNT_PASSWORD]"
+                   LogonAsService="yes"
+                   CreateUser="no"
+                   UpdateIfExists="yes"
+                   RemoveOnUninstall="no">
+          <util:GroupRef Id="AdminGroup"/>
+        </util:User>
+      </Component>
+
+      <!-- This section inspired by: http://wix.sourceforge.net/manual-wix3/write_a_registry_entry.htm -->
+      <!-- We write to $(var.OurCompanyName)\$(var.OurCommonProductNameWord)
+           (Puppet Labs\CommonProduct)
+           in order to restore the PUPPET_MASTER_SERVER property -->
+      <Component Id="RegistryEntries" Guid="68F5D91C-49C8-43F7-940A-481007689E79" Win64="no">
+        <RegistryKey
+          Root="HKLM"
+          Key="SOFTWARE\$(var.OurCompanyName)\$(var.OurCommonProductNameWord)"
+          Action="create" >
+          <!-- This is the default (aka 'unnamed') key value of this path -->
+          <RegistryValue Type="integer" Value="0"/>
+          <!-- This is the specified value of a key at this path -->
+          <RegistryValue Name="InstalledFlag" Value="1" Type="integer" KeyPath="yes"/>
+          <!-- Store properties for later recall during uninstall, upgrade, repair -->
+          <RegistryValue Name="RememberedPuppetMasterServer" Type="string" Value="[PUPPET_MASTER_SERVER]" />
+          <RegistryValue Name="RememberedPuppetAgentEnvironment" Type="string" Value="[PUPPET_AGENT_ENVIRONMENT]" />
+          <RegistryValue Name="RememberedPuppetCaServer" Type="string" Value="[PUPPET_CA_SERVER]" />
+          <RegistryValue Name="RememberedPuppetAgentCertname" Type="string" Value="[PUPPET_AGENT_CERTNAME]" />
+          <RegistryValue Name="RememberedPuppetAgentStartupMode" Type="string" Value="[PUPPET_AGENT_STARTUP_MODE]" />
+        </RegistryKey>
+        <RegistryKey
+            Root="HKLM"
+            Key="SYSTEM\CurrentControlSet\services\eventlog\Application\Puppet"
+            Action="createAndRemoveOnUninstall">
+          <RegistryValue Type="string" Name="EventMessageFile" Value="[INSTALLDIR]misc\puppetres.dll"/>
+          <RegistryValue Type="integer" Name="TypesSupported" Value="7"/>
+        </RegistryKey>
+      </Component>
+      <?if $(var.Platform) = x86 ?>
+        <Component Id="RegistryEntriesArchitectureDependent" Guid="E6D5AF4F-ACC4-4D11-AFCE-299A9ED2152C" Win64="no" Permanent="yes">
+          <!-- Product Specific Properties.  We keep INSTALLDIR here. -->
+          <RegistryKey
+            Root="HKLM"
+            Key="SOFTWARE\$(var.OurCompanyName)\$(var.OurProductNameWord)"
+            Action="create" >
+            <!-- This is the default (aka 'unnamed') key value of this path -->
+            <RegistryValue Type="integer" Value="0"/>
+            <!-- RememberedInstallDir -->
+            <RegistryValue Name="RememberedInstallDir" Type="string" Value="[INSTALLDIR]"  KeyPath="yes" />
+            <!--
+              x86 install on top of x64 cannot capture the custom install path, because WIN64DUALFOLDERS will
+              string substitute, and replace 'Program Files' with 'Program Files (x86)'
+
+              Fortunately, x64 installers have always had Permanent set for the x64 custom install path
+              so it will never be removed during uninstall.
+            -->
+          </RegistryKey>
+        </Component>
+      <?else?>
+        <Component Id="RegistryEntriesArchitectureDependent" Guid="E6D5AF4F-ACC4-4D11-AFCE-299A9ED2152C" Win64="no" Permanent="yes">
+        <RegistryKey
+          Root="HKLM"
+          Key="SOFTWARE\$(var.OurCompanyName)\$(var.OurProductNameWord)"
+          Action="create" >
+          <RegistryValue Type="integer" Value="0"/>
+          <!--
+            When upgrading from Puppet 3.6.x to Puppet 3.7 x64, the 3.6 x86 uninstall will remove the remembered x86
+            install location, which is problematic if a user chooses to switch back to 3.7 x86.  Going forward this
+            wouldn't be an issue since Permanent is set, but our hands are tied given prior art.
+
+            Fortunately, when Wix recalls the old property value with 'Program Files (x86)', it will not be automatically
+            string substituted to 'Program Files', which is a problem when going from x64 -> x86.
+          -->
+          <RegistryValue Name="RememberedInstallDir" Type="string" Value="[INSTALLDIR_X86]" />
+          <RegistryValue Name="RememberedInstallDir64" Type="string" Value="[INSTALLDIR]" KeyPath="yes" />
+        </RegistryKey>
+      </Component>
+    <?endif?>
+    </Directory>
+
+    <!-- It is possible to override WixVariable's on the command line using the
+         -d flag to light when Overridable="yes". -->
+    <!-- #12475 - Specify the license. -->
+    <WixVariable Id="WixUILicenseRtf" Value="conf\windows\stage\misc\LICENSE.rtf" Overridable="yes" />
+    <!-- (#12521) Use local Bitmaps -->
+    <WixVariable Id="WixUIBannerBmp" Value="$(var.BitmapFolder)\bannrbmp.bmp" />
+    <WixVariable Id="WixUIDialogBmp" Value="$(var.BitmapFolder)\$(var.DialogBitmap)" />
+    <WixVariable Id="WixUIExclamationIco" Value="$(var.BitmapFolder)\exclamic.ico" />
+    <WixVariable Id="WixUIInfoIco" Value="$(var.BitmapFolder)\info.ico" />
+    <WixVariable Id="WixUINewIco" Value="$(var.BitmapFolder)\new.ico" />
+    <WixVariable Id="WixUIUpIco" Value="$(var.BitmapFolder)\up.ico" />
+
+    <!-- Add/Remove Programs icon and help link -->
+    <Icon Id="$(var.OurCompanyNameWord).ico" SourceFile="conf\windows\stage\misc\puppetlabs.ico"/>
+    <Property Id="ARPPRODUCTICON" Value="$(var.OurCompanyNameWord).ico" />
+    <Property Id="ARPHELPLINK" Value="$(var.HelpLink)" />
+    <!-- Save destination folder in Add/Remove programs (ARP) registry key -->
+    <SetProperty Id="ARPINSTALLLOCATION" Value="[INSTALLDIR]" After="CostFinalize" />
+
+    <!-- This property is used in the localization strings for the GUI -->
+    <Property Id="VersionUIString" Value="$(var.VersionUIString)" />
+
+    <!--
+      By default, install puppet agent to run as LocalSystem. Password
+      is hidden to prevent it from appearing in msiexec log files
+    -->
+    <Property Id="PUPPET_AGENT_ACCOUNT_DOMAIN" Value="."/>
+    <Property Id="PUPPET_AGENT_ACCOUNT_USER" Value="LocalSystem"/>
+    <Property Id="PUPPET_AGENT_ACCOUNT_PASSWORD" Hidden="yes"/>
+
+    <!--
+      Remembered Property Pattern
+      http://robmensching.com/blog/posts/2010/5/2/The-WiX-toolsets-Remember-Property-pattern
+      -->
+    <!-- Registry settings, remembered install dir is dependent on x86/64.
+         Everything else stays with x86 so both installer types can see it
+      -->
+    <Property Id="INSTALLDIR">
+      <!-- Recall the property in repair, upgrade, and uninstall scenarios -->
+      <RegistrySearch Id="RecallInstallDir" Root="HKLM"
+        Key="SOFTWARE\$(var.OurCompanyName)\$(var.OurProductNameWord)"
+        Name="$(var.RememberedInstallDirRegKey)" Type="raw" Win64="no" />
+    </Property>
+    <Property Id="INSTALLDIR_X86" >
+      <!-- Recall the property in repair, upgrade, and uninstall scenarios -->
+      <RegistrySearch Id="RecallInstallDirx86" Root="HKLM"
+        Key="SOFTWARE\$(var.OurCompanyName)\$(var.OurProductNameWord)"
+        Name="RememberedInstallDir" Type="raw" Win64="no" />
+    </Property>
+    <!-- Note the static default value of "puppet".  This will be overriden by
+         the command line. -->
+    <Property Id="PUPPET_MASTER_SERVER">
+      <!-- Recall the property in repair, upgrade, and uninstall scenarios -->
+      <RegistrySearch Id="RecallPuppetMasterServer" Root="HKLM"
+        Key="SOFTWARE\$(var.OurCompanyName)\$(var.OurCommonProductNameWord)"
+        Name="RememberedPuppetMasterServer" Type="raw" Win64="no" />
+    </Property>
+    <Property Id="PUPPET_AGENT_ENVIRONMENT">
+      <!-- Recall the property in repair, upgrade, and uninstall scenarios -->
+      <RegistrySearch Id="RecallPuppetAgentEnvironment" Root="HKLM"
+        Key="SOFTWARE\$(var.OurCompanyName)\$(var.OurCommonProductNameWord)"
+        Name="RememberedPuppetAgentEnvironment" Type="raw" Win64="no" />
+    </Property>
+    <Property Id="PUPPET_AGENT_CERTNAME">
+      <!-- Recall the property in repair, upgrade, and uninstall scenarios -->
+      <RegistrySearch Id="RecallPuppetAgentCertname" Root="HKLM"
+        Key="SOFTWARE\$(var.OurCompanyName)\$(var.OurCommonProductNameWord)"
+        Name="RememberedPuppetAgentCertname" Type="raw" Win64="no" />
+    </Property>
+    <Property Id="PUPPET_CA_SERVER">
+      <RegistrySearch Id="RecallPuppetCAServer" Root="HKLM"
+        Key="SOFTWARE\$(var.OurCompanyName)\$(var.OurCommonProductNameWord)"
+        Name="RememberedPuppetCaServer" Type="raw" Win64="no" />
+    </Property>
+    <Property Id="PUPPET_AGENT_STARTUP_MODE">
+      <RegistrySearch Id="RecallPuppetAgentStartupMode" Root="HKLM"
+        Key="SOFTWARE\$(var.OurCompanyName)\$(var.OurCommonProductNameWord)"
+        Name="RememberedPuppetAgentStartupMode" Type="raw" Win64="no" />
+    </Property>
+
+    <!-- Custom Actions to handle command line property values that override
+         remembered property values -->
+    <!-- INSTALLDIR -->
+    <CustomAction Id="SaveCmdLineInstallDir"
+      Property="CMDLINE_INSTALLDIR"
+      Value="[INSTALLDIR]"
+      Execute="firstSequence" />
+    <CustomAction Id="SetFromCmdLineInstallDir"
+      Property="INSTALLDIR"
+      Value="[CMDLINE_INSTALLDIR]"
+      Execute="firstSequence" />
+    <!-- PUPPET_MASTER_SERVER -->
+    <CustomAction Id="SaveCmdLinePuppetMasterServer"
+      Property="CMDLINE_PUPPET_MASTER_SERVER"
+      Value="[PUPPET_MASTER_SERVER]"
+      Execute="firstSequence" />
+    <CustomAction Id="SetFromCmdLinePuppetMasterServer"
+      Property="PUPPET_MASTER_SERVER"
+      Value="[CMDLINE_PUPPET_MASTER_SERVER]"
+      Execute="firstSequence" />
+    <CustomAction Id="SetDefaultPuppetMasterServer"
+      Property="PUPPET_MASTER_SERVER"
+      Value="puppet"
+      Execute="firstSequence" />
+    <!-- PUPPET_AGENT_ENVIRONMENT -->
+    <CustomAction Id="SaveCmdLinePuppetAgentEnvironment"
+      Property="CMDLINE_PUPPET_AGENT_ENVIRONMENT"
+      Value="[PUPPET_AGENT_ENVIRONMENT]"
+      Execute="firstSequence" />
+    <CustomAction Id="SetFromCmdLinePuppetAgentEnvironment"
+      Property="PUPPET_AGENT_ENVIRONMENT"
+      Value="[CMDLINE_PUPPET_AGENT_ENVIRONMENT]"
+      Execute="firstSequence" />
+    <CustomAction Id="SetDefaultPuppetAgentEnvironment"
+      Property="PUPPET_AGENT_ENVIRONMENT"
+      Value="production"
+      Execute="firstSequence" />
+    <!-- PUPPET_AGENT_CERTNAME -->
+    <CustomAction Id="SaveCmdLinePuppetAgentCertname"
+      Property="CMDLINE_PUPPET_AGENT_CERTNAME"
+      Value="[PUPPET_AGENT_CERTNAME]"
+      Execute="firstSequence" />
+    <CustomAction Id="SetFromCmdLinePuppetAgentCertname"
+      Property="PUPPET_AGENT_CERTNAME"
+      Value="[CMDLINE_PUPPET_AGENT_CERTNAME]"
+      Execute="firstSequence" />
+    <!-- PUPPET_CA_SERVER -->
+    <CustomAction Id="SaveCmdLinePuppetCaServer"
+      Property="CMDLINE_PUPPET_CA_SERVER"
+      Value="[PUPPET_CA_SERVER]"
+      Execute="firstSequence" />
+    <CustomAction Id="SetFromCmdLinePuppetCaServer"
+      Property="PUPPET_CA_SERVER"
+      Value="[CMDLINE_PUPPET_CA_SERVER]"
+      Execute="firstSequence" />
+    <!-- PUPPET_AGENT_STARTUP_MODE -->
+    <CustomAction Id="SaveCmdLinePuppetAgentStartupMode"
+      Property="CMDLINE_PUPPET_AGENT_STARTUP_MODE"
+      Value="[PUPPET_AGENT_STARTUP_MODE]"
+      Execute="firstSequence" />
+    <CustomAction Id="SetFromCmdLinePuppetAgentStartupMode"
+      Property="PUPPET_AGENT_STARTUP_MODE"
+      Value="[CMDLINE_PUPPET_AGENT_STARTUP_MODE]"
+      Execute="firstSequence" />
+    <CustomAction Id="SetDomainToLocalComputer"
+       Property="PUPPET_AGENT_ACCOUNT_DOMAIN"
+       Value="[ComputerName]"
+       Execute="firstSequence"/>
+    <CustomAction Id="SetDomainToNtAuthority"
+       Property="PUPPET_AGENT_ACCOUNT_DOMAIN"
+       Value="NT AUTHORITY"
+       Execute="firstSequence"/>
+
+    <?if $(var.Platform) = x86 ?>
+    <!-- If these fail, we don't want to fail the installer -->
+    <!-- We can't do a registry search for powershell's installed location because it will turn up the WOW64Node version due to not being able to bypass redirection in RegistrySearch
+         So we will assume the default install location and if it fails, we will ignore the error.
+         this is the only way to grab path without expanding variables
+         [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey("SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment\\").GetValue("PATH", "", [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames).ToString();
+         [System.Text.RegularExpressions.Regex]::Replace([Microsoft.Win32.Registry]::LocalMachine.OpenSubKey("SYSTEM\CurrentControlSet\Control\Session Manager\Environment\").GetValue("PATH", "", [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames).ToString(), "c:\\Program files\\Puppet Labs\\Puppet\\bin(?>;)?", "", [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+
+         "c:\windows\System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NonInteractive -InputFormat None -NoProfile -ExecutionPolicy Bypass -Command "[System.Text.RegularExpressions.Regex]::Replace([Microsoft.Win32.Registry]::LocalMachine.OpenSubKey('SYSTEM\CurrentControlSet\Control\Session Manager\Environment\').GetValue('PATH', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames).ToString(),  [System.Text.RegularExpressions.Regex]::Escape('c:\Program Files\Puppet Labs\Puppet\bin') + '(?>;)?', '', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) | %{[System.Environment]::SetEnvironmentVariable('PATH',$_,'Machine')}"
+         &quot;[%WINDIR]\System32\WindowsPowerShell\v1.0\powershell.exe&quot; -NoLogo -NonInteractive -InputFormat None -NoProfile -ExecutionPolicy Bypass -Command &quot;[\[]System.Text.RegularExpressions.Regex[\]]::Replace([\[]Microsoft.Win32.Registry[\]]::LocalMachine.OpenSubKey(&apos;SYSTEM\CurrentControlSet\Control\Session Manager\Environment\&apos;).GetValue(&apos;PATH&apos;, &apos;&apos;, [\[]Microsoft.Win32.RegistryValueOptions[\]]::DoNotExpandEnvironmentNames).ToString(),  [\[]System.Text.RegularExpressions.Regex[\]]::Escape(&apos;[ProgramFiles64Folder]$(var.OurCompanyName)\Puppet\bin&apos;) + &apos;([\?]&gt;;)[\?]&apos;, &apos;&apos;, [\[]System.Text.RegularExpressions.RegexOptions[\]]::IgnoreCase) | %[\{][\[]System.Environment[\]]::SetEnvironmentVariable(&apos;PATH&apos;,$_, &apos;Machine&apos;)[\}]&quot;
+    -->
+    <CustomAction Id="Remove64BitPath_SetProp"
+                  Property="Remove64BitPath"
+                  Value="&quot;[%WINDIR]\System32\WindowsPowerShell\v1.0\powershell.exe&quot; -NoLogo -NonInteractive -InputFormat None -NoProfile -ExecutionPolicy Bypass -Command &quot;[\[]System.Text.RegularExpressions.Regex[\]]::Replace([\[]Microsoft.Win32.Registry[\]]::LocalMachine.OpenSubKey(&apos;SYSTEM\CurrentControlSet\Control\Session Manager\Environment\&apos;).GetValue(&apos;PATH&apos;, &apos;&apos;, [\[]Microsoft.Win32.RegistryValueOptions[\]]::DoNotExpandEnvironmentNames).ToString(),  [\[]System.Text.RegularExpressions.Regex[\]]::Escape(&apos;[ProgramFiles64Folder]$(var.OurCompanyName)\Puppet\bin&apos;) + &apos;([\?]&gt;;)[\?]&apos;, &apos;&apos;, [\[]System.Text.RegularExpressions.RegexOptions[\]]::IgnoreCase) | %[\{][\[]System.Environment[\]]::SetEnvironmentVariable(&apos;PATH&apos;,$_, &apos;Machine&apos;)[\}]&quot;"
+                  Execute="immediate" />
+    <CustomAction Id="Remove64BitPath"
+                  BinaryKey="WixCA"
+                  DllEntry="CAQuietExec64"
+                  Execute="deferred"
+                  Return="ignore" />
+    <CustomAction Id="Remove64BitProgramFiles_SetProp"
+                  Property="Remove64BitProgramFiles"
+                  Value="&quot;[%WINDIR]\System32\cmd.exe&quot; /c IF EXIST &quot;[ProgramFiles64Folder]$(var.OurCompanyName)\&quot; rmdir /s /q &quot;[ProgramFiles64Folder]$(var.OurCompanyName)&quot;"
+                  Execute="immediate" />
+    <CustomAction Id="Remove64BitProgramFiles"
+                  BinaryKey="WixCA"
+                  DllEntry="CAQuietExec64"
+                  Execute="deferred"
+                  Return="ignore" />
+    <?endif?>
+
+    <!--<Property Id="WixQuietExecCmdLine" Value="&quot;[INSTALLDIR]service\nssm.exe&quot; stop pxp-agent"/> -->
+    <CustomAction Id="ShutdownPxpAgentService_SetProp"
+                  Property="QtExecCmdLine"
+                  Value="&quot;[INSTALLDIR]service\nssm.exe&quot; stop pxp-agent"
+                  Execute="immediate" />
+    <CustomAction Id="ShutdownPxpAgentService"
+                  BinaryKey="WixCA"
+                  DllEntry="CAQuietExec"
+                  Execute="immediate"
+                  Return="ignore" />
+
+    <!-- First, save off properties specified on the command line Second,
+         restore the properties set by the command line overriding the recalled
+         value from the registry -->
+    <InstallUISequence>
+      <!-- INSTALLDIR -->
+      <Custom Action='SaveCmdLineInstallDir' Before='AppSearch' />
+      <Custom Action='SetFromCmdLineInstallDir' After='AppSearch'>
+        CMDLINE_INSTALLDIR
+      </Custom>
+      <!-- PUPPET_MASTER_SERVER -->
+      <Custom Action='SaveCmdLinePuppetMasterServer' Before='AppSearch' />
+      <Custom Action='SetFromCmdLinePuppetMasterServer' After='AppSearch'>
+        CMDLINE_PUPPET_MASTER_SERVER
+      </Custom>
+      <Custom Action='SetDefaultPuppetMasterServer' After='AppSearch'>
+        PUPPET_MASTER_SERVER=""
+      </Custom>
+      <!-- PUPPET_AGENT_ENVIRONMENT -->
+      <Custom Action='SaveCmdLinePuppetAgentEnvironment' Before='AppSearch' />
+      <Custom Action='SetFromCmdLinePuppetAgentEnvironment' After='AppSearch'>
+        CMDLINE_PUPPET_AGENT_ENVIRONMENT
+      </Custom>
+      <Custom Action='SetDefaultPuppetAgentEnvironment' After='AppSearch'>
+        PUPPET_AGENT_ENVIRONMENT=""
+      </Custom>
+      <!-- PUPPET_AGENT_CERTNAME -->
+      <Custom Action='SaveCmdLinePuppetAgentCertname' Before='AppSearch' />
+      <Custom Action='SetFromCmdLinePuppetAgentCertname' After='AppSearch'>
+        CMDLINE_PUPPET_AGENT_CERTNAME
+      </Custom>
+      <!-- PUPPET_CA_SERVER -->
+      <Custom Action='SaveCmdLinePuppetCaServer' Before='AppSearch' />
+      <Custom Action='SetFromCmdLinePuppetCaServer' After='AppSearch'>
+        CMDLINE_PUPPET_CA_SERVER
+      </Custom>
+      <!-- PUPPET_AGENT_STARTUP_MODE -->
+      <Custom Action='SaveCmdLinePuppetAgentStartupMode' Before='AppSearch' />
+      <Custom Action='SetFromCmdLinePuppetAgentStartupMode' After='AppSearch'>
+        CMDLINE_PUPPET_AGENT_STARTUP_MODE
+      </Custom>
+      <!-- PUPPET_AGENT_ACCOUNT_DOMAIN -->
+      <Custom Action='SetDomainToLocalComputer' After='AppSearch'>
+        PUPPET_AGENT_ACCOUNT_DOMAIN = "."
+      </Custom>
+      <Custom Action='SetDomainToNtAuthority' After='SetDomainToLocalComputer'>
+        (PUPPET_AGENT_ACCOUNT_USER ~= "LocalService") OR (PUPPET_AGENT_ACCOUNT_USER ~= "NetworkService")
+      </Custom>
+    </InstallUISequence>
+    <InstallExecuteSequence>
+      <!-- INSTALLDIR -->
+      <Custom Action='SaveCmdLineInstallDir' Before='AppSearch' />
+      <Custom Action='SetFromCmdLineInstallDir' After='AppSearch'>
+        CMDLINE_INSTALLDIR
+      </Custom>
+      <!-- PUPPET_MASTER_SERVER -->
+      <Custom Action='SaveCmdLinePuppetMasterServer' Before='AppSearch' />
+      <Custom Action='SetFromCmdLinePuppetMasterServer' After='AppSearch'>
+        CMDLINE_PUPPET_MASTER_SERVER
+      </Custom>
+      <Custom Action='SetDefaultPuppetMasterServer' After='AppSearch'>
+        PUPPET_MASTER_SERVER=""
+      </Custom>
+      <!-- PUPPET_AGENT_ENVIRONMENT -->
+      <Custom Action='SaveCmdLinePuppetAgentEnvironment' Before='AppSearch' />
+      <Custom Action='SetFromCmdLinePuppetAgentEnvironment' After='AppSearch'>
+        CMDLINE_PUPPET_AGENT_ENVIRONMENT
+      </Custom>
+      <Custom Action='SetDefaultPuppetAgentEnvironment' After='AppSearch'>
+        PUPPET_AGENT_ENVIRONMENT=""
+      </Custom>
+       <!-- PUPPET_AGENT_CERTNAME -->
+      <Custom Action='SaveCmdLinePuppetAgentCertname' Before='AppSearch' />
+      <Custom Action='SetFromCmdLinePuppetAgentCertname' After='AppSearch'>
+        CMDLINE_PUPPET_AGENT_CERTNAME
+      </Custom>
+      <!-- PUPPET_CA_SERVER -->
+      <Custom Action='SaveCmdLinePuppetCaServer' Before='AppSearch' />
+      <Custom Action='SetFromCmdLinePuppetCaServer' After='AppSearch'>
+        CMDLINE_PUPPET_CA_SERVER
+      </Custom>
+      <!-- PUPPET_AGENT_START_MODE -->
+      <Custom Action='SaveCmdLinePuppetAgentStartupMode' Before='AppSearch' />
+      <Custom Action='SetFromCmdLinePuppetAgentStartupMode' After='AppSearch'>
+        CMDLINE_PUPPET_AGENT_STARTUP_MODE
+      </Custom>
+      <!-- PUPPET_AGENT_ACCOUNT_DOMAIN -->
+      <Custom Action='SetDomainToLocalComputer' After='AppSearch'>
+        PUPPET_AGENT_ACCOUNT_DOMAIN = "."
+      </Custom>
+      <Custom Action='SetDomainToNtAuthority' After='SetDomainToLocalComputer'>
+        (PUPPET_AGENT_ACCOUNT_USER ~= "LocalService") OR (PUPPET_AGENT_ACCOUNT_USER ~= "NetworkService")
+      </Custom>
+      <?if $(var.Platform) = x86 ?>
+      <Custom Action='Remove64BitPath_SetProp' After='CostFinalize' />
+      <Custom Action='Remove64BitProgramFiles_SetProp' After='CostFinalize' />
+      <Custom Action='Remove64BitProgramFiles' After='InstallFiles'>
+        <![CDATA[VersionNT64 >= 100 AND $(var.Win64) = no AND NOT (&$(var.OurProductNameWord)Runtime = 2)]]>
+      </Custom>
+      <Custom Action='Remove64BitPath' After='InstallFiles'>
+        <![CDATA[VersionNT64 >= 100 AND $(var.Win64) = no AND NOT (&$(var.OurProductNameWord)Runtime = 2)]]>
+      </Custom>
+      <?endif?>
+      <!-- Make sure pxp-agent service is shutdown before we validate the install -->
+      <!-- Only executed if pxp-agent is already installed (i.e. an Uninstall or upgrade - check for repair also) -->
+      <Custom Action='ShutdownPxpAgentService_SetProp' Before='ShutdownPxpAgentService'>
+        REMOVE="ALL" OR WIX_UPGRADE_DETECTED or REINSTALL
+      </Custom>
+      <Custom Action='ShutdownPxpAgentService' Before='InstallValidate'>
+        REMOVE="ALL" OR WIX_UPGRADE_DETECTED or REINSTALL
+      </Custom>
+      <!--
+      WIX_UPGRADE_DETECTED
+      -->
+    </InstallExecuteSequence>
+
+    <!--
+      The Features to install.  We're using ComponentGroupRef instead of ComponentRef since we're
+      generating the ruby wxs file using heat
+    -->
+    <Feature Id="$(var.OurProductNameWord)Runtime" Title="$(var.OurProductName) Runtime" Level="1">
+      <ComponentRef Id="RegistryEntries" />
+      <ComponentRef Id="RegistryEntriesArchitectureDependent" />
+      <ComponentRef Id="PuppetVarDir" />
+      <ComponentRef Id="CodeDir" />
+      <ComponentRef Id="HieraDataDir" />
+      <ComponentRef Id="CodeModulesDir" />
+      <ComponentRef Id="EnvironmentsDir" />
+      <ComponentRef Id="ProductionDir" />
+      <ComponentRef Id="ManifestsDir" />
+      <ComponentRef Id="ModulesDir" />
+      <ComponentRef Id="PXPAgentModulesDir" />
+      <ComponentRef Id="PXPAgentSpoolDir" />
+      <ComponentRef Id="PXPAgentRunDir" />
+      <ComponentRef Id="PXPAgentLogDir" />
+      <ComponentRef Id="PuppetShortcuts" />
+      <ComponentRef Id="PuppetDocumentationShortcuts" />
+
+      <ComponentRef Id="PuppetInstallDirBinToPath" />
+
+      <ComponentGroupRef Id="sys" />
+      <ComponentGroupRef Id="puppet" />
+      <ComponentGroupRef Id="facter" />
+      <ComponentGroupRef Id="pxp-agent" />
+      <ComponentGroupRef Id="hiera" />
+      <ComponentGroupRef Id="bin" />
+      <ComponentGroupRef Id="misc" />
+      <ComponentRef Id="service" />
+      <ComponentRef Id="service_nssm" />
+
+      <!-- The PuppetConf components are conditional on PUPPET_AGENT_CERTNAME -->
+      <ComponentRef Id="PuppetConfWithCertname" />
+      <!-- The PuppetConf components are conditional on PUPPET_CA_SERVER -->
+      <ComponentRef Id="PuppetConfWithCaServer" />
+      <!-- The PuppetConf components are conditional on PUPPET_AGENT_ENVIRONMENT -->
+      <ComponentRef Id="PuppetConfWithAgentEnvironment" />
+      <ComponentRef Id="PuppetConfUnconditionalSettings" />
+      <ComponentRef Id="PuppetInstallerFacts" />
+      <ComponentRef Id="PuppetServiceUser" />
+      <ComponentRef Id="PuppetServiceAutomatic" />
+      <ComponentRef Id="PuppetServiceManual" />
+      <ComponentRef Id="PuppetServiceDisabled" />
+      <ComponentGroupRef Id="mcollective" />
+      <ComponentRef Id="MCOConfDir" />
+      <ComponentRef Id="MCOLogDir" />
+      <ComponentRef Id="MCOService" />
+      <ComponentRef Id="PuppetAgentVersionFile" />
+    </Feature>
+  </Product>
+</Wix>

--- a/resources/windows/msi/service-filter.xslt.erb
+++ b/resources/windows/msi/service-filter.xslt.erb
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+ xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+ xmlns:wix="http://schemas.microsoft.com/wix/2006/wi">
+  <!-- https://ahordijk.wordpress.com/2013/03/26/automatically-add-references-and-content-to-the-wix-installer/ -->
+  <!-- http://www.chriskonces.com/using-xslt-with-heat-exe-wix-to-create-windows-service-installs/ -->
+  <xsl:output method="xml" indent="yes" />
+  <!--<xsl:strip-space elements="*"/>-->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- ERB STUFF -->
+  <!-- Loop through the list of services and add filters for each component requiring Service type special treatment -->
+  <xsl:template match="wix:Component[wix:File[@Source='$(var.StageDir)\ruby\bin\ruby.exe']]" />
+  <xsl:template match="wix:Component[wix:File[@Source='$(var.StageDir)\ruby\bin\rubyw.exe']]" />
+</xsl:stylesheet>

--- a/resources/windows/msi/service.wxs.erb
+++ b/resources/windows/msi/service.wxs.erb
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='windows-1252'?>
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi' xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+
+<!-- Some ERB Here to include the set of service files -->
+
+  <?include $(sys.SOURCEFILEDIR)include/puppet.wxi ?>
+
+</Wix>


### PR DESCRIPTION
Add in configurable filter (XSLT) file to filter out service components
from the main heat run in the build.
Remove Service entries from main.wxs (top level Wix File) to move them
to project specific service files.
The service.wxs.erb file will list and include these specific service
files.