### PR TITLE
(CPR-273) Allow repeatable builds

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -10,7 +10,7 @@ class Vanagon
     attr_accessor :name, :version, :source, :url, :configure, :build, :check, :install
     attr_accessor :environment, :extract_with, :dirname, :build_requires, :build_dir
     attr_accessor :settings, :platform, :patches, :requires, :service, :options
-    attr_accessor :directories, :replaces, :provides, :cleanup_source, :environment
+    attr_accessor :directories, :replaces, :provides, :cleanup_source
     attr_accessor :sources, :preinstall_actions, :postinstall_actions
     attr_accessor :preremove_actions, :postremove_actions
 

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -244,7 +244,10 @@ class Vanagon
       # @param target [String] path to the desired symlink
       def link(source, target)
         @component.install << "#{@component.platform.install} -d '#{File.dirname(target)}'"
-        @component.install << "ln -s '#{source}' '#{target}'"
+        # Use a bash conditional to only create the link if it doesn't already point to the correct source.
+        # This allows rerunning the install step to be idempotent, rather than failing because the link
+        # already exists.
+        @component.install << "([[ '#{target}' -ef '#{source}' ]] || ln -s '#{source}' '#{target}')"
         @component.add_file Vanagon::Common::Pathname.file(target)
       end
 

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -578,7 +578,7 @@ end" }
       comp = Vanagon::Component::DSL.new('link-test', {}, platform)
       comp.link('link-source', '/place/to/put/things')
       expect(comp._component.install).to include("install -d '/place/to/put'")
-      expect(comp._component.install).to include("ln -s 'link-source' '/place/to/put/things'")
+      expect(comp._component.install).to include("([[ '/place/to/put/things' -ef 'link-source' ]] || ln -s 'link-source' '/place/to/put/things')")
     end
   end
 


### PR DESCRIPTION
Vanagon builds should be repeatable over the same temporary directory
(via make). Currently attempting to repeat a link fails the build
because the symlink already exists. Only attempt to create the symlink
if it doesn't already point to the correct file.