### PR TITLE
(CPR-272) git submodule failure does not stop vanagon

### DIFF
--- a/lib/vanagon/component/source/git.rb
+++ b/lib/vanagon/component/source/git.rb
@@ -27,10 +27,10 @@ class Vanagon
         def fetch
           puts "Cloning ref '#{@ref}' from url '#{@url}'"
           Dir.chdir(@workdir) do
-            git('clone', @url)
+            git("clone #{@url}", true)
             Dir.chdir(dirname) do
-              git('checkout', @ref)
-              git('submodule', 'update', '--init', '--recursive')
+              git("checkout #{@ref}", true)
+              git("submodule update --init --recursive", true)
               @version = git_version
             end
           end

--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -146,16 +146,19 @@ class Vanagon
     # Simple wrapper around git command line executes the given commands and
     # returns the results.
     #
-    # @param commands [String] The commands to be run
+    # @param command_string [String] The commands to be run
+    # @param raise_error [boolean] if this function should raise an error
+    #                              on a git failure
     # @return [String] The output of the command
-    def git(*commands)
+    def git(command_string, raise_error = false)
       git_bin = find_program_on_path('git')
-      output = %x(#{git_bin} #{commands.join(' ')})
-      if !$?.success?
-        raise %(git #{commands.join(' ')} failed)
-      else
-        return output
+      output = %x(#{git_bin} #{command_string})
+      if raise_error
+        unless $?.success?
+          raise %(git #{command_string} failed)
+        end
       end
+      return output
     end
 
     # Determines if the given directory is a git repo or not
@@ -164,7 +167,7 @@ class Vanagon
     # @return [true, false] True if the directory is a git repo, false otherwise
     def is_git_repo?(directory = Dir.pwd)
       Dir.chdir(directory) do
-        git('rev-parse', '--git-dir', '> /dev/null 2>&1')
+        git('rev-parse --git-dir > /dev/null 2>&1')
         $?.success?
       end
     end
@@ -178,7 +181,7 @@ class Vanagon
     def git_version(directory = Dir.pwd)
       if is_git_repo?(directory)
         Dir.chdir(directory) do
-          version = git('describe', '--tags', '2> /dev/null').chomp
+          version = git('describe --tags 2> /dev/null').chomp
           if version.empty?
             warn "Directory '#{directory}' cannot be versioned by git. Maybe it hasn't been tagged yet?"
           end

--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -150,7 +150,12 @@ class Vanagon
     # @return [String] The output of the command
     def git(*commands)
       git_bin = find_program_on_path('git')
-      %x(#{git_bin} #{commands.join(' ')})
+      output = %x(#{git_bin} #{commands.join(' ')})
+      if !$?.success?
+        raise %(git #{commands.join(' ')} failed)
+      else
+        return output
+      end
     end
 
     # Determines if the given directory is a git repo or not

--- a/spec/lib/vanagon/component/source/git_spec.rb
+++ b/spec/lib/vanagon/component/source/git_spec.rb
@@ -6,6 +6,7 @@ describe "Vanagon::Component::Source::Git" do
   let (:workdir) { "/tmp" }
 
   describe "#dirname" do
+    after(:each) { %x(rm -rf #{workdir}/facter) }
     it "returns the name of the repo" do
       git_source = Vanagon::Component::Source::Git.new(url, ref, workdir)
       expect(git_source.dirname).to eq('facter')
@@ -14,6 +15,19 @@ describe "Vanagon::Component::Source::Git" do
     it "returns the name of the repo and strips .git" do
       git_source = Vanagon::Component::Source::Git.new("#{url}.git", ref, workdir)
       expect(git_source.dirname).to eq('facter')
+    end
+  end
+
+  describe "#fetch" do
+    after(:each) { %x(rm -rf #{workdir}/facter) }
+    it "raises error on clone failure" do
+      #this test has a spelling error for the git repo        V      this is on purpose
+      git_source = Vanagon::Component::Source::Git.new("#{url}l.git", ref, workdir)
+      expect { git_source.fetch }.to raise_error(RuntimeError, "git clone #{url}l.git failed")
+    end
+    it "raises error on checkout failure" do
+      git_source = Vanagon::Component::Source::Git.new("#{url}", "999.9.9", workdir)
+      expect { git_source.fetch }.to raise_error(RuntimeError, "git checkout 999.9.9 failed")
     end
   end
 end


### PR DESCRIPTION
Vanagon should halt and raise an error if any of the
git commands fail. It does not currently, this will
add the functionality to fail and raise an error
if any of the git commands fail