### PR TITLE
(maint) Hardware engine should release lock upon failure

### DIFF
--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -92,7 +92,7 @@ class Vanagon
       puts e.backtrace.join("\n")
       raise e
     ensure
-      if @engine == "hardware"
+      if @engine.name == "hardware"
         @engine.teardown
       end
   end

--- a/lib/vanagon/engine/base.rb
+++ b/lib/vanagon/engine/base.rb
@@ -4,13 +4,14 @@ require 'vanagon/errors'
 class Vanagon
   class Engine
     class Base
-      attr_accessor :target, :remote_workdir
+      attr_accessor :target, :remote_workdir, :name
 
       def initialize(platform, target = nil)
         @platform = platform
         @required_attributes = ["ssh_port"]
         @target = target if target
         @target_user = @platform.target_user
+        @name = 'base'
       end
 
       # This method is used to obtain a vm to build upon

--- a/lib/vanagon/engine/docker.rb
+++ b/lib/vanagon/engine/docker.rb
@@ -7,6 +7,7 @@ class Vanagon
       # the docker engine to work
       def initialize(platform, target = nil)
         @docker_cmd = Vanagon::Utilities.find_program_on_path('docker')
+        @name = 'docker'
         super
         @required_attributes << "docker_image"
       end

--- a/lib/vanagon/engine/hardware.rb
+++ b/lib/vanagon/engine/hardware.rb
@@ -52,6 +52,7 @@ class Vanagon
 
       def initialize(platform, target)
         Vanagon::Driver.logger.debug "Hardware engine invoked."
+        @name = 'hardware'
         @platform = platform
         @build_hosts = platform.build_hosts
         # Redis is the only backend supported in lock_manager currently

--- a/lib/vanagon/engine/local.rb
+++ b/lib/vanagon/engine/local.rb
@@ -10,6 +10,7 @@ class Vanagon
       def initialize(platform, target = nil)
         @platform = platform
         @target = "local machine"
+        @name = 'local'
       end
 
       # Dispatches the command for execution

--- a/lib/vanagon/engine/pooler.rb
+++ b/lib/vanagon/engine/pooler.rb
@@ -11,6 +11,7 @@ class Vanagon
         @token = load_token
         super
         @required_attributes << "vmpooler_template"
+        @name = 'pooler'
       end
 
       # This method loads the pooler token from one of two locations


### PR DESCRIPTION
Prior to this, the hardware engine attempted to release the lock it had
on a system when regardless of the outcome of the vanagon build.
However, due to an if statement that could never evaluate to true, that
wasn't happening.

In debugging the problem, there was no way to figure out which engine
was being invoked. This commit adds a @name attribute to all engines so
other parts of the codebase can know what engine is being invoked.

This now means that if the hardware engine is being used, the ensure
block in driver.rb will release the lock regardless of pass/fail on the
build.