### PR TITLE
(RE-6476) Add option to enable SSH agent forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ A full path on disk for a private ssh key to be used in ssh and rsync
 communications. This will be used instead of whatever defaults are configured
 in .ssh/config.
 
+##### VANAGON\_SSH\_AGENT
+When set, Vanagon will forward the ssh authentication agent connection. 
+
 ##### VMPOOLER\_TOKEN
 Used in conjunction with the pooler engine, this is a token to pass to the
 vmpooler to access the API. Without this token, the default lifetime of vms

--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -219,6 +219,7 @@ class Vanagon
       args << " -p #{port} "
       args << " -o UserKnownHostsFile=/dev/null"
       args << " -o StrictHostKeyChecking=no"
+      args << " -o ForwardAgent=yes" if ENV['VANAGON_SSH_AGENT']
       return ssh + args
     end
 

--- a/spec/lib/vanagon/utilities_spec.rb
+++ b/spec/lib/vanagon/utilities_spec.rb
@@ -117,6 +117,13 @@ describe "Vanagon::Utilities" do
       expect(Vanagon::Utilities).to receive(:find_program_on_path).with('ssh').and_return('/tmp/ssh')
       expect(Vanagon::Utilities.ssh_command).to include('-o UserKnownHostsFile=/dev/null')
     end
+
+    it 'adds the correct flags to the command if VANAGON_SSH_AGENT is set' do
+      expect(Vanagon::Utilities).to receive(:find_program_on_path).with('ssh').and_return('/tmp/ssh')
+      ENV['VANAGON_SSH_AGENT'] = 'true'
+      expect(Vanagon::Utilities.ssh_command).to include('-o ForwardAgent=yes')
+      ENV['VANAGON_SSH_AGENT'] = nil
+    end
   end
 
   describe '#retry_with_timeout' do


### PR DESCRIPTION
This commit adds support for enabling SSH agent forwarding by checking
for the existence of an environment variable, VANAGON_SSH_AGENT.  If
set, Vanagon will construct the ssh command with the option to forward
the authentication agent connection.