### PR TITLE
(maint) Allow zip archives to be unpacked with 7za

### DIFF
--- a/lib/vanagon/component/source/http.rb
+++ b/lib/vanagon/component/source/http.rb
@@ -101,7 +101,7 @@ class Vanagon
             when ".tar.gz", ".tgz"
               return "gunzip -c '#{@file}' | '#{tar}' xf -"
             when ".zip"
-              return "unzip '#{@file}'"
+              return "unzip '#{@file}' || 7za x -r -tzip -o'#{File.basename(@file, ".zip")}' '#{@file}'"
             end
           else
             # Extension does not appear to be an archive


### PR DESCRIPTION
On windows, we need to use 7za to unpack zip archives. We don't have
`unzip` available and `gunzip` throws an error. The only problem is we
don't have any guarantees 7za will be on the path. It is installed as a
part of chocolatey, but we need to set path in the component in order to
ensure we have access to it.