### PR TITLE
(RE-6492) Add ability to choose user

### DIFF
--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -228,6 +228,13 @@ class Vanagon
         @platform.ssh_port = port
       end
 
+      # Set the targetuser to use to connect
+      #
+      # @param type [String] user for the platform ('vagrant' for example)
+      def targetuser(user)
+        @platform.targetuser = user
+      end
+
       # Set the platform_triple for the platform
       #
       # @param triple[String] platform_triple for use in building out compiled


### PR DESCRIPTION
Add ability to choose the ssh user that connects to the target VM. This allows
choosing different usernames than the default provided in the platform
files.