### PR TITLE
(RE-6455) Create directorylist.wxs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -489,6 +489,7 @@ Lint/UnderscorePrefixedVariableName:
 
 Metrics/ParameterLists:
   Enabled: true
+  CountKeywordArgs: false
 
 Lint/RequireParentheses:
   Enabled: true

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -315,8 +315,12 @@ class Vanagon
       # @param mode [String] octal mode to apply to the directory
       # @param owner [String] owner of the directory
       # @param group [String] group of the directory
-      def directory(dir, mode: nil, owner: nil, group: nil)
-        @component.directories << Vanagon::Common::Pathname.new(dir, mode: mode, owner: owner, group: group)
+      def directory(dir, mode: nil, owner: nil, group: nil, wix_id: nil)
+        if @component.platform.is_windows?
+          @component.directories << Vanagon::Windows::Pathname.new(dir, mode: mode, owner: owner, group: group, wix_id: wix_id)
+        else
+          @component.directories << Vanagon::Common::Pathname.new(dir, mode: mode, owner: owner, group: group)
+        end
       end
 
       # Adds a set of environment overrides to the environment for a component.

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -4,6 +4,7 @@ require 'vanagon/component'
 require 'vanagon/utilities'
 require 'vanagon/common'
 require 'vanagon/errors'
+require 'vanagon/windows'
 require 'tmpdir'
 require 'logger'
 

--- a/lib/vanagon/platform/windows.rb
+++ b/lib/vanagon/platform/windows.rb
@@ -56,6 +56,7 @@ class Vanagon
         FileUtils.mkdir_p(File.join(workdir, "wix"))
         erb_file(File.join(VANAGON_ROOT, "resources/windows/wix/project.wxs.erb"), File.join(workdir, "wix",  "#{name}.wxs"), false, { :binding => binding })
         erb_file(File.join(VANAGON_ROOT, "resources/windows/wix/project.filter.xslt.erb"), File.join(workdir, "wix", "#{name}.filter.xslt"), false, { :binding => binding })
+        erb_file(File.join(VANAGON_ROOT, "resources/windows/wix/directorylist.wxs.erb"), File.join(workdir, "wix", "directorylist.#{name}.wxs"), false, { :binding => binding })
       end
 
       # Method to generate the files required to build a nuget package for the project
@@ -221,6 +222,91 @@ class Vanagon
       # @return [String] relative path to where windows packages should be staged
       def output_dir(target_repo = "")
         File.join("windows", target_repo, @architecture)
+      end
+
+      # Generate correctly formatted wix elements that match the
+      # structure of the directory input
+      #
+      # @param directories, Array of hashes including at least :path
+      # and optionally:
+      # @return [string] correctly formatted wix element string
+      def generate_wix_dirs(project)
+        if project.get_directories.empty?
+          raise Vanagon::Error, 'ERROR No directories specified!'
+        else
+          directories = []
+          project.get_directories.map { |dir| directories.push({ :path => dir.path, :id => dir.wix_id }) }
+
+          root = { :children => [] }
+
+          # iterate over all paths specified and break each one
+          # in to its specific directories. This will generate_wix_dirs
+          # an n-ary tree structure matching the specs from the input
+          directories.each do |dir|
+            # Always start at the beginning
+            curr = root
+            names = strip_path(dir[:path])
+            names.each do |name|
+              #The Id field will default to name, but be overridden later
+              new_obj = { :name => name, :id => name, :children => [] }
+              if (child_index = includes_child(new_obj, curr[:children]))
+                curr = curr[:children][child_index]
+              else
+                curr[:children].push(new_obj)
+                curr = new_obj
+              end
+            end
+            # at this point, curr will be the top dir, override the id if
+            # id exists
+            if dir[:id]
+              curr[:id] = dir[:id]
+            end
+          end
+          return generate_wix_from_graph(root)
+        end
+      end
+
+      # strip and split the directory path into single names
+      # @param [string] path string of directory
+      def strip_path(path)
+        if path.include?("/") || path.include?("\\")
+          # The regex in the last part of this if warrants some
+          # explanation. Specifically it matches any combinations
+          # of any letters, then the : char, then finally either
+          # the char / or the char \. it's menat to parse out drive
+          # roots on windows
+          if path.start_with?("/") || path.start_with?("\\") || path =~ (/([A-Za-z])*\:(\/|\\)/)
+            path = path.sub(/\/|\\|([A-Za-z])*\:(\/|\\)/, '')
+          end
+          names = path.split(/\/|\\/)
+        end
+        return names
+      end
+
+      # Find if child element is the same as one of
+      # the old_children elements, return that child
+      def includes_child(new_child, old_children)
+        old_children.each_with_index do |curr_old_child, index|
+          return index if curr_old_child[:name] == new_child[:name]
+        end unless old_children.empty?
+        return nil
+      end
+
+      # Recursively generate wix element structure
+      #
+      # @param root, the (empty) root of an n-ary tree containing the
+      # structure of directories
+      def generate_wix_from_graph(root)
+        string = ''
+        unless root[:children].empty?
+          root[:children].each do |child|
+            string += ("<Directory Name=\"#{child[:name]}\" Id=\"#{child[:id]}\">\n")
+            string += generate_wix_from_graph(child)
+            string += ("</Directory>\n")
+          end
+          return string
+        end
+        return ''
       end
 
       # Constructor. Sets up some defaults for the windows platform and calls the parent constructor

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -143,8 +143,12 @@ class Vanagon
       # @param mode [String] octal mode to apply to the directory
       # @param owner [String] owner of the directory
       # @param group [String] group of the directory
-      def directory(dir, mode: nil, owner: nil, group: nil)
-        @project.directories << Vanagon::Common::Pathname.new(dir, mode: mode, owner: owner, group: group)
+      def directory(dir, mode: nil, owner: nil, group: nil, wix_id: nil)
+        if @project.platform.is_windows?
+          @project.directories << Vanagon::Windows::Pathname.new(dir, mode: mode, owner: owner, group: group, wix_id: wix_id)
+        else
+          @project.directories << Vanagon::Common::Pathname.new(dir, mode: mode, owner: owner, group: group)
+        end
       end
 
       # Add a user to the project

--- a/lib/vanagon/windows.rb
+++ b/lib/vanagon/windows.rb
@@ -1,0 +1,1 @@
+require 'vanagon/windows/pathname.rb'

--- a/lib/vanagon/windows/pathname.rb
+++ b/lib/vanagon/windows/pathname.rb
@@ -1,0 +1,32 @@
+require 'pathname'
+
+class Vanagon
+  class Windows
+    class Pathname < Vanagon::Common::Pathname
+
+      # @!attribute wix_id
+      #   @return [String] Returns the wix_id representing the id representing
+      #   a file or directory in wix
+      attr_accessor :wix_id
+
+      # Extension of the VANAGON::COMMON::PATHNAME class specifially for windows
+      # @param [String, Integer] mode the UNIX Octal permission string to use when this file is archived
+      # @param [String, Integer] owner the username or UID to use when this file is archived
+      # @param [String, Integer] group the groupname or GID to use when this file is archived
+      # @param [Boolean] options => {config} mark this file as a configuration file, stored as private state
+      #   and exposed through the {#configfile?} method.
+      # @param [string] options => {id} the id to pass to wix objects during directory generation
+      # @return [Vanagon::Common::Pathname] Returns a new Pathname instance.
+      def initialize(path, mode: nil, owner: nil, group: nil, config: false, wix_id: nil)
+        super(path, mode: nil, owner: nil, group: nil, config: false)
+        # When the wix actually gets generated the "id" field in the wix elements
+        # will already default to whatever the name field indicates. this is only
+        # if you want to override that
+        if wix_id
+          @wix_id ||= wix_id
+        end
+      end
+
+    end
+  end
+end

--- a/resources/windows/wix/directorylist.wxs.erb
+++ b/resources/windows/wix/directorylist.wxs.erb
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='windows-1252'?>
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi' xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+
+  <Fragment>
+    <DirectoryRef Id='TARGETDIR'>
+      <%= @platform.generate_wix_dirs(self) %>
+    </DirectoryRef>
+  </Fragment>
+</Wix>

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -1,5 +1,6 @@
 require 'vanagon/component/dsl'
 require 'vanagon/common'
+require 'vanagon/windows'
 require 'json'
 
 describe 'Vanagon::Component::DSL' do
@@ -599,32 +600,39 @@ end" }
   end
 
   describe '#directory' do
+    let(:cur_plat) { Vanagon::Platform::DSL.new('el-7-x86_64')}
+
     it 'adds a directory with the desired path to the directory collection for the component' do
-      comp = Vanagon::Component::DSL.new('directory-test', {}, {})
+      cur_plat.instance_eval('platform "el-7-x86_64" do |plat| end')
+      comp = Vanagon::Component::DSL.new('directory-test', {}, cur_plat._platform)
       comp.directory('/a/b/c')
       expect(comp._component.directories).to include(Vanagon::Common::Pathname.new('/a/b/c'))
     end
 
     it 'adds a directory with the desired mode to the directory collection for the component' do
-      comp = Vanagon::Component::DSL.new('directory-test', {}, {})
+      cur_plat.instance_eval('platform "el-7-x86_64" do |plat| end')
+      comp = Vanagon::Component::DSL.new('directory-test', {}, cur_plat._platform)
       comp.directory('/a/b/c', mode: '0755')
       expect(comp._component.directories.first).to eq(Vanagon::Common::Pathname.new('/a/b/c', mode: '0755'))
     end
 
     it 'adds a directory with the desired owner to the directory collection for the component' do
-      comp = Vanagon::Component::DSL.new('directory-test', {}, {})
+      cur_plat.instance_eval('platform "el-7-x86_64" do |plat| end')
+      comp = Vanagon::Component::DSL.new('directory-test', {}, cur_plat._platform)
       comp.directory('/a/b/c', owner: 'olivia')
       expect(comp._component.directories.first).to eq(Vanagon::Common::Pathname.new('/a/b/c', owner: 'olivia'))
     end
 
     it 'adds a directory with the desired group to the directory collection for the component' do
-      comp = Vanagon::Component::DSL.new('directory-test', {}, {})
+      cur_plat.instance_eval('platform "el-7-x86_64" do |plat| end')
+      comp = Vanagon::Component::DSL.new('directory-test', {}, cur_plat._platform)
       comp.directory('/a/b/c', group: 'release-engineering')
       expect(comp._component.directories.first).to eq(Vanagon::Common::Pathname.new('/a/b/c', group: 'release-engineering'))
     end
 
     it 'adds a directory with the desired attributes to the directory collection for the component' do
-      comp = Vanagon::Component::DSL.new('directory-test', {}, {})
+      cur_plat.instance_eval('platform "el-7-x86_64" do |plat| end')
+      comp = Vanagon::Component::DSL.new('directory-test', {}, cur_plat._platform)
       comp.directory('/a/b/c', mode: '0400', owner: 'olivia', group: 'release-engineering')
       expect(comp._component.directories.first).to eq(Vanagon::Common::Pathname.new('/a/b/c', mode: '0400', owner: 'olivia', group: 'release-engineering'))
     end

--- a/spec/lib/vanagon/platform/windows_spec.rb
+++ b/spec/lib/vanagon/platform/windows_spec.rb
@@ -1,4 +1,8 @@
 require 'vanagon/platform'
+require 'vanagon/project'
+require 'vanagon/common'
+require 'vanagon/windows'
+
 
 describe "Vanagon::Platform::Windows" do
   platforms =[
@@ -15,9 +19,12 @@ describe "Vanagon::Platform::Windows" do
   ]
 
   platforms.each do |plat|
-    context "on #{plat[:name]} we should behave ourselves" do
+    context "on #{plat[:name]}" do
       let(:platform) { plat }
       let(:cur_plat) { Vanagon::Platform::DSL.new(plat[:name]) }
+      let (:project_block) {
+"project 'test-fixture' do |proj|
+end" }
 
       before do
         cur_plat.instance_eval(plat[:block])
@@ -37,6 +44,120 @@ describe "Vanagon::Platform::Windows" do
         it "sets the target_user to 'Administrator'" do
           expect(cur_plat._platform.target_user).to eq(plat[:target_user])
         end
+      end
+
+      describe "generate_wix_dirs" do
+
+        it "raises error with no direcotries" do
+          proj = Vanagon::Project::DSL.new('test-fixture', cur_plat._platform)
+          proj.instance_eval(project_block)
+          expect { cur_plat._platform.generate_wix_dirs(proj._project) }.to raise_error(Vanagon::Error, "ERROR No directories specified!")
+        end
+
+
+        it "returns one directory" do
+          proj = Vanagon::Project::DSL.new('test-fixture', cur_plat._platform)
+          proj.instance_eval(project_block)
+          proj.directory('/opt', mode: '0755')
+          expect(cur_plat._platform.generate_wix_dirs(proj._project)).to eq( \
+<<-HERE
+<Directory Name="opt" Id="opt">
+</Directory>
+HERE
+          )
+        end
+
+        it "returns one directory with an id" do
+          proj = Vanagon::Project::DSL.new('test-fixture', cur_plat._platform)
+          proj.instance_eval(project_block)
+          proj.directory('/opt', mode: '0755', wix_id: "root")
+          expect(cur_plat._platform.generate_wix_dirs(proj._project)).to eq( \
+<<-HERE
+<Directory Name="opt" Id="root">
+</Directory>
+HERE
+          )
+        end
+
+        it "returns nested directory correctly with \\" do
+          proj = Vanagon::Project::DSL.new('test-fixture', cur_plat._platform)
+          proj.instance_eval(project_block)
+          proj.directory('root\\programfiles', mode: '0755', wix_id: "root")
+          expect(cur_plat._platform.generate_wix_dirs(proj._project)).to eq( \
+<<-HERE
+<Directory Name="root" Id="root">
+<Directory Name="programfiles" Id="root">
+</Directory>
+</Directory>
+HERE
+          )
+        end
+
+        it "removes any drive roots" do
+          proj = Vanagon::Project::DSL.new('test-fixture', cur_plat._platform)
+          proj.instance_eval(project_block)
+          proj.directory('C:\\programfiles', mode: '0755', wix_id: "root")
+          expect(cur_plat._platform.generate_wix_dirs(proj._project)).to eq( \
+<<-HERE
+<Directory Name="programfiles" Id="root">
+</Directory>
+HERE
+          )
+        end
+
+        it "returns correctly formatted nested directories with id in last dir" do
+          proj = Vanagon::Project::DSL.new('test-fixture', cur_plat._platform)
+          proj.instance_eval(project_block)
+          proj.directory('/opt/oneUp', mode: '0755', wix_id: "OU")
+          expect(cur_plat._platform.generate_wix_dirs(proj._project)).to eq( \
+<<-HERE
+<Directory Name="opt" Id="opt">
+<Directory Name="oneUp" Id="OU">
+</Directory>
+</Directory>
+HERE
+          )
+        end
+
+        it "returns correctly formatted nested directories" do
+          proj = Vanagon::Project::DSL.new('test-fixture', cur_plat._platform)
+          proj.instance_eval(project_block)
+          proj.directory('/opt/oneUp', mode: '0755')
+          expect(cur_plat._platform.generate_wix_dirs(proj._project)).to eq( \
+<<-HERE
+<Directory Name="opt" Id="opt">
+<Directory Name="oneUp" Id="oneUp">
+</Directory>
+</Directory>
+HERE
+          )
+        end
+
+
+        it "returns correctly formatted multiple nested directories" do
+          proj = Vanagon::Project::DSL.new('test-fixture', cur_plat._platform)
+          proj.instance_eval(project_block)
+          proj.directory('/opt/oneUp/twoUp', mode: '0755')
+          proj.directory('/opt/oneUpAgain/twoUp', mode: '0755')
+          proj.directory('/opt/oneUpAgain/twoUpAgain', mode: '0755', wix_id: 'TUA')
+          expect(cur_plat._platform.generate_wix_dirs(proj._project)).to eq( \
+<<-HERE
+<Directory Name="opt" Id="opt">
+<Directory Name="oneUp" Id="oneUp">
+<Directory Name="twoUp" Id="twoUp">
+</Directory>
+</Directory>
+<Directory Name="oneUpAgain" Id="oneUpAgain">
+<Directory Name="twoUp" Id="twoUp">
+</Directory>
+<Directory Name="twoUpAgain" Id="TUA">
+</Directory>
+</Directory>
+</Directory>
+HERE
+          )
+        end
+
       end
     end
   end

--- a/spec/lib/vanagon/project/dsl_spec.rb
+++ b/spec/lib/vanagon/project/dsl_spec.rb
@@ -1,12 +1,14 @@
 require 'vanagon/project/dsl'
 require 'vanagon/driver'
 require 'vanagon/common'
+require 'vanagon/common'
 
 describe 'Vanagon::Project::DSL' do
   let (:project_block) {
 "project 'test-fixture' do |proj|
 end" }
   let (:configdir) { '/a/b/c' }
+  let(:cur_plat) { Vanagon::Platform::DSL.new('el-7-x86_64')}
 
   describe '#version_from_git' do
     it 'sets the version based on the git describe' do
@@ -21,7 +23,8 @@ end" }
 
   describe '#directory' do
     it 'adds a directory to the list of directories' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      cur_plat.instance_eval('platform "el-7-x86_64" do |plat| end')
+      proj = Vanagon::Project::DSL.new('test-fixture', cur_plat._platform)
       proj.instance_eval(project_block)
       proj.directory('/a/b/c/d', mode: '0755')
       expect(proj._project.directories).to include(Vanagon::Common::Pathname.new('/a/b/c/d', mode: '0755'))

--- a/spec/lib/vanagon/project_spec.rb
+++ b/spec/lib/vanagon/project_spec.rb
@@ -3,6 +3,7 @@ require 'vanagon/driver'
 
 describe 'Vanagon::Project' do
   let(:component) { double(Vanagon::Component) }
+  let(:cur_plat) { Vanagon::Platform::DSL.new('el-7-x86_64') }
   let(:configdir) { '/a/b/c' }
 
   let(:project_block) {
@@ -34,8 +35,12 @@ describe 'Vanagon::Project' do
     it 'returns only the highest level directories' do
       test_sets.each do |set|
         expect(component).to receive(:directories).and_return([])
-        proj = Vanagon::Project::DSL.new('test-fixture', {}, [])
+
+
+        cur_plat.instance_eval('platform "el-7-x86_64" do |plat| end')
+        proj = Vanagon::Project::DSL.new('test-fixture', cur_plat._platform)
         proj.instance_eval(project_block)
+
         set[:directories].each {|dir| proj.directory dir }
         expect(proj._project.get_root_directories.sort).to eq(set[:results].sort)
       end


### PR DESCRIPTION
This commit will add functionality to use the existing
get_directories functionality for a project to generate
a directorylist.wxs file that contains the wix structure
of directories for the project.

As part of this feature this commit also extends the current
VANAGON::COMMON::PATHNAME structure to include "id" for
use in the wix structure. it does not specifically extend
the actual COMMON::PATHNAME class but instead creates a
new class to extend pathname under the namespace
VANAGON::WINDOWS:PATHNAME

finally this commit adds rspec tests for the new functionality
and updates any old rspec that would break with the new
functionality

Note that in order to get everything working in a way that doesn't
look confusing we had to update params on one specific rubocop
rule