### PR TITLE
(CPR-293) update local engine

### DIFF
--- a/lib/vanagon/engine/local.rb
+++ b/lib/vanagon/engine/local.rb
@@ -1,40 +1,31 @@
+require 'vanagon/engine/base'
 require 'vanagon/utilities'
 require 'vanagon/errors'
-require 'benchmark'
 
 class Vanagon
   class Engine
-    class Local
-      attr_accessor :target
+    class Local < Base
 
       def initialize(platform, target = nil)
         @platform = platform
         @target = "local machine"
         @name = 'local'
+        super
+        @required_attributes = Array.new
       end
 
       # Dispatches the command for execution
-      def dispatch(command)
-        puts Benchmark.measure { local_command(command, @workdir) }
-      end
-
-      # Steps needed to tear down or clean up the system after the build is
-      # complete
-      def teardown
-      end
-
-      # This method will take care of validation and target selection all at
-      # once as an easy shorthand to call from the driver
-      def startup(workdir)
-        @workdir = workdir
-        script = @platform.provisioning.join(' && ')
-        dispatch(script)
+      def dispatch(command, return_output = false)
+        Vanagon::Utilities.local_command(command, return_command_output: return_output)
       end
 
       def ship_workdir(workdir)
+        FileUtils.cp_r(Dir.glob("#{workdir}/*"), "#{@remote_workdir}")
       end
 
       def retrieve_built_artifact
+        FileUtils.mkdir_p("output")
+        FileUtils.cp_r(Dir.glob("#{@remote_workdir}/output/*"), "output/")
       end
     end
   end

--- a/lib/vanagon/engine/local.rb
+++ b/lib/vanagon/engine/local.rb
@@ -16,7 +16,13 @@ class Vanagon
 
       # Dispatches the command for execution
       def dispatch(command, return_output = false)
-        Vanagon::Utilities.local_command(command, return_command_output: return_output)
+        if defined?(Bundler)
+          Bundler.with_clean_env do
+            Vanagon::Utilities.local_command(command, return_command_output: return_output)
+          end
+        else
+          Vanagon::Utilities.local_command(command, return_command_output: return_output)
+        end
       end
 
       def ship_workdir(workdir)

--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -269,10 +269,19 @@ class Vanagon
     # @param command [String] command to run on the target
     # @return [true] Returns true if the command was successful
     # @raise [RuntimeError] If the command fails an exception is raised
-    def local_command(command, workdir)
-      puts "Executing '#{command}' locally in #{workdir}"
-      Kernel.system(command, :chdir => workdir)
-      $?.success? or raise "Local command (#{command}) failed."
+    def local_command(command, return_command_output: false)
+      puts "Executing '#{command}' locally"
+      if return_command_output
+        ret = %x(#{command}).chomp
+        if $?.success?
+          return ret
+        else
+          raise "Local command (#{command}) failed."
+        end
+      else
+        Kernel.system(command)
+        $?.success? or raise "Local command (#{command}) failed."
+      end
     end
 
     # Helper method that takes a template file and runs it through ERB


### PR DESCRIPTION
Builds currently fail when using the local engine, because @remote_dir
is not defined. Additionally, gem install fails due RUBY environment
variables being set by 'bundle exec build.'

Changes
- engine::local inherits from engine::base
- local_command function emulates remote_ssh_command behavior
- unset environment variables set by 'bundle exec build'