### PR TITLE
(maint) Add license to components

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -12,7 +12,7 @@ class Vanagon
     attr_accessor :settings, :platform, :patches, :requires, :service, :options
     attr_accessor :directories, :replaces, :provides, :cleanup_source
     attr_accessor :sources, :preinstall_actions, :postinstall_actions
-    attr_accessor :preremove_actions, :postremove_actions
+    attr_accessor :preremove_actions, :postremove_actions, :license
 
     # Loads a given component from the configdir
     #

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -386,6 +386,10 @@ class Vanagon
         end
         @component.postremove_actions << OpenStruct.new(:pkg_state => pkg_state, :scripts => scripts)
       end
+
+      def license(license)
+        @component.license = license
+      end
     end
   end
 end


### PR DESCRIPTION
We should have the ability to specify what license each of our
components has. Although not all of the packaging formats we support
will be able to present all the component licenses, some do. For those
that do, we should make this piece of information available.