### PR TITLE
(RE-6456) Allow vanagon to pull in project specific files

### DIFF
--- a/lib/vanagon/platform/windows.rb
+++ b/lib/vanagon/platform/windows.rb
@@ -117,7 +117,6 @@ class Vanagon
         end
       end
 
-
       # Method to generate the files required to build a nuget package for the project
       #
       # @param workdir [String] working directory to stage the evaluated templates in

--- a/lib/vanagon/platform/windows.rb
+++ b/lib/vanagon/platform/windows.rb
@@ -53,10 +53,70 @@ class Vanagon
       # @param name [String] name of the project
       # @param binding [Binding] binding to use in evaluating the packaging templates
       def generate_msi_packaging_artifacts(workdir, name, binding)
-        FileUtils.mkdir_p(File.join(workdir, "wix"))
-        erb_file(File.join(VANAGON_ROOT, "resources/windows/wix/project.wxs.erb"), File.join(workdir, "wix",  "#{name}.wxs"), false, { :binding => binding })
-        erb_file(File.join(VANAGON_ROOT, "resources/windows/wix/project.filter.xslt.erb"), File.join(workdir, "wix", "#{name}.filter.xslt"), false, { :binding => binding })
+        # Copy the project specific files first
+        copy_from_project("./resources/windows/wix", workdir)
+        merge_defaults_from_vanagon(File.join(VANAGON_ROOT, "resources/windows/wix"), "#{workdir}/wix")
+        process_templates("#{workdir}/wix", binding)
       end
+
+      # Method to recursively copy from a source project resource directory
+      # to a destination (wix) work directory.
+      # strongly suspect the original cp_r command would have done all of this.
+      #
+      # @param proj_resources [String] Project Resource File directory
+      # @param destination [String] Destination directory
+      # @param verbose [String] True or false
+      def copy_from_project(proj_resources, destination, verbose: false)
+        FileUtils.cp_r(proj_resources, destination, :verbose => verbose)
+      end
+
+      # Method to merge in the files from the Vanagon (generic) directories.
+      # Project Specific files take precedence, so since these are copied prior
+      # to this function, then this merge operation will ignore existing files
+      #
+      # @param vanagon_root [String] Vanagon wix resources directory
+      # @param destination [String] Destination directory
+      # @param verbose [String] True or false
+      def merge_defaults_from_vanagon(vanagon_root, destination, verbose: false)
+        # Will use this Pathname object for relative path calculations in loop below.
+        vanagon_path = Pathname.new(vanagon_root)
+        files = Dir.glob(File.join(vanagon_root, "**/*.*"))
+        files.each do |file|
+          # Get Pathname for incoming file using Pathname library
+          src_pathname = Pathname.new(file).dirname
+          # This Pathname method allows us to effectively "subtract" the leading vanagon_path
+          # from the source filename path. This gives us a pathname fragment that we can
+          # then append to the target directory, preserving the files place in the directory
+          # tree relative to the parent.
+          # See following article for example:
+          # http://stackoverflow.com/questions/12093770/ruby-removing-parts-a-file-path
+          # and http://ruby-doc.org/stdlib-2.1.0/libdoc/pathname/rdoc/Pathname.html#method-i-relative_path_from
+          dest_pathname_fragment = src_pathname.relative_path_from(vanagon_path)
+          target_dir = File.join(destination, dest_pathname_fragment.to_s)
+          # Create the target directory if necessary.
+          FileUtils.mkdir_p(target_dir) unless File.exists?(target_dir)
+          # Skip the file copy if either target file or ERB equivalent exists.
+          # This means that any files already in place in the work directory as a
+          # result of being copied from the project specific area will not be
+          # overritten.
+          next if File.exists?(Pathname.new(target_dir) + File.basename(file))
+          next if File.exists?(Pathname.new(target_dir) + File.basename(file, ".erb"))
+          FileUtils.cp(file, target_dir, :verbose => verbose)
+        end
+      end
+
+      # Method to transform ERB templates in the work directory.
+      #
+      # @param workdir [String] working directory to stage the evaluated templates in
+      # @param binding [Binding] binding to use in evaluating the packaging templates
+      def process_templates(wixworkdir, binding)
+        files = Dir.glob(File.join(wixworkdir, "**/*.erb"))
+        files.each do |file|
+          erb_file(file, File.join(File.dirname(file), File.basename(file, ".erb")), false, { :binding => binding })
+          FileUtils.rm(file)
+        end
+      end
+
 
       # Method to generate the files required to build a nuget package for the project
       #
@@ -124,7 +184,7 @@ class Vanagon
           #   -gg             - Generate GUIDS now
           #   -dr             - Directory reference to root directories (cannot contains spaces e.g. -dr MyAppDirRef)
           #   -sreg           - Suppress registry harvesting.
-          "cd $(tempdir); \"$$WIX/bin/heat.exe\" dir staging -v -ke -indent 2 -cg #{cg_name} -gg -dr #{dir_ref} -t wix/#{project.name}.filter.xslt -sreg -out wix/#{project.name}-harvest.wxs",
+          "cd $(tempdir); \"$$WIX/bin/heat.exe\" dir staging -v -ke -indent 2 -cg #{cg_name} -gg -dr #{dir_ref} -t wix/project.filter.xslt -sreg -out wix/#{project.name}-harvest.wxs",
           # Apply Candle command to all *.wxs files - generates .wixobj files in wix directory.
           # cygpath conversion is necessary as candle is unable to handle posix path specs
           "cd $(tempdir)/wix/wixobj; for wix_file in `find $(tempdir)/wix -name \'*.wxs\'`; do \"$$WIX/bin/candle.exe\" #{candle_flags} $$(cygpath -aw $$wix_file) ; done",

--- a/spec/fixtures/wix/resources/windows/wix/file-1.wxs
+++ b/spec/fixtures/wix/resources/windows/wix/file-1.wxs
@@ -1,0 +1,1 @@
+# Wix Test File 1

--- a/spec/fixtures/wix/resources/windows/wix/file-2.wxs
+++ b/spec/fixtures/wix/resources/windows/wix/file-2.wxs
@@ -1,0 +1,1 @@
+# Wix Test File 2

--- a/spec/fixtures/wix/resources/windows/wix/file-3.wxs.erb
+++ b/spec/fixtures/wix/resources/windows/wix/file-3.wxs.erb
@@ -1,0 +1,1 @@
+# ERB Wix Test File 3

--- a/spec/fixtures/wix/resources/windows/wix/file-4.wxs.erb
+++ b/spec/fixtures/wix/resources/windows/wix/file-4.wxs.erb
@@ -1,0 +1,1 @@
+# ERB Wix Test File 4

--- a/spec/fixtures/wix/resources/windows/wix/include/include-sample-1.wxs
+++ b/spec/fixtures/wix/resources/windows/wix/include/include-sample-1.wxs
@@ -1,0 +1,1 @@
+# Sample Include file

--- a/spec/fixtures/wix/resources/windows/wix/project.filter.xslt.erb
+++ b/spec/fixtures/wix/resources/windows/wix/project.filter.xslt.erb
@@ -1,0 +1,1 @@
+# Null ERB File for testing

--- a/spec/fixtures/wix/resources/windows/wix/project.wxs
+++ b/spec/fixtures/wix/resources/windows/wix/project.wxs
@@ -1,0 +1,2 @@
+# Test file for Vanagon/Wix unit testing.
+# This file will "over-ride" the generic Product.wix.erb file

--- a/spec/fixtures/wix/resources/windows/wix/ui/ui-sample-1.wxs
+++ b/spec/fixtures/wix/resources/windows/wix/ui/ui-sample-1.wxs
@@ -1,0 +1,1 @@
+# This is a sample UI wxs file

--- a/spec/lib/vanagon/platform/windows_spec.rb
+++ b/spec/lib/vanagon/platform/windows_spec.rb
@@ -18,6 +18,11 @@ describe "Vanagon::Platform::Windows" do
     context "on #{plat[:name]} we should behave ourselves" do
       let(:platform) { plat }
       let(:cur_plat) { Vanagon::Platform::DSL.new(plat[:name]) }
+<<<<<<< HEAD
+=======
+      let (:workdir) { "#{WORK_BASE}/workdir" }
+      let (:wixtestfiles) { "spec/fixtures/wix/resources/windows/wix" }
+>>>>>>> 1c3d70e... (RE-6464) Simplify Copy function
 
       before do
         cur_plat.instance_eval(plat[:block])

--- a/spec/lib/vanagon/platform/windows_spec.rb
+++ b/spec/lib/vanagon/platform/windows_spec.rb
@@ -1,5 +1,20 @@
 require 'vanagon/platform'
 
+# These constants are defined for the purpose of the project/generic file merge tests
+# to point these directories to test areas under the /tmp directory.
+# This allows individual test cases to be specified accurately.
+# The actual resources/windows/wix files under vanagon are avoided, as the necessary
+# data structures are not available under the test conditions causing failures in the
+# ERB template translation
+
+WORK_BASE = "/tmp/vanwintest"
+VANAGON_ROOT = "#{WORK_BASE}/generic"
+PROJ_ROOT = "#{WORK_BASE}/project"
+WORKDIR = "#{WORK_BASE}/workdir"
+# Admittedly this might not be the best placed statement, but my limited rspec
+# started to defeat me when it came to using "let" for wixtestfiles
+WIXTESTFILES = File.expand_path("./spec/fixtures/wix/resources/windows/wix")
+
 describe "Vanagon::Platform::Windows" do
   platforms =[
     {
@@ -10,6 +25,7 @@ describe "Vanagon::Platform::Windows" do
       :output_dir             => "windows/x64",
       :output_dir_with_target => "windows/thing/x64",
       :target_user            => "Administrator",
+      :projname               => "test-proj",
       :block                  => %Q[ platform "windows-2012r2-x64" do |plat| end ]
     },
   ]
@@ -18,11 +34,6 @@ describe "Vanagon::Platform::Windows" do
     context "on #{plat[:name]} we should behave ourselves" do
       let(:platform) { plat }
       let(:cur_plat) { Vanagon::Platform::DSL.new(plat[:name]) }
-<<<<<<< HEAD
-=======
-      let (:workdir) { "#{WORK_BASE}/workdir" }
-      let (:wixtestfiles) { "spec/fixtures/wix/resources/windows/wix" }
->>>>>>> 1c3d70e... (RE-6464) Simplify Copy function
 
       before do
         cur_plat.instance_eval(plat[:block])
@@ -41,6 +52,113 @@ describe "Vanagon::Platform::Windows" do
       describe '#target_user' do
         it "sets the target_user to 'Administrator'" do
           expect(cur_plat._platform.target_user).to eq(plat[:target_user])
+        end
+      end
+
+      describe '#generate_msi_packaging_artifacts' do
+        before(:each) do
+          # Create Workdir and temp root directory
+          FileUtils.mkdir_p("#{WORKDIR}/wix")
+          FileUtils.mkdir_p("#{VANAGON_ROOT}/resources/windows/wix")
+          FileUtils.mkdir_p("#{PROJ_ROOT}/resources/windows/wix")
+          # Switch directory so that project specific folder points to tmp area
+          @pwd = Dir.pwd
+          Dir.chdir(PROJ_ROOT)
+        end
+        after(:each) do
+          # Cleanup the complete work directory tree
+          FileUtils.rm_rf("#{WORK_BASE}")
+          Dir.chdir(@pwd)
+        end
+
+        it "Copies Wix File from product specific directory to output directory" do
+          # setup source directories and run artifact generation
+          FileUtils.cp("#{WIXTESTFILES}/file-1.wxs", "#{PROJ_ROOT}/resources/windows/wix/file-1.wxs")
+          cur_plat._platform.generate_msi_packaging_artifacts(WORKDIR, plat[:projname], binding)
+          # check the result
+          expect(File).to exist("#{WORKDIR}/wix/file-1.wxs")
+        end
+
+        it "Copies Wix File from Vanagon directory to work directory" do
+          # setup source directories and run artifact generation
+          FileUtils.cp("#{WIXTESTFILES}/file-1.wxs", "#{VANAGON_ROOT}/resources/windows/wix/file-1.wxs")
+          cur_plat._platform.generate_msi_packaging_artifacts(WORKDIR, plat[:projname], binding)
+          # check the result
+          expect(File).to exist("#{WORKDIR}/wix/file-1.wxs")
+        end
+
+        it "Picks Project Specific Wix File in favour of Generic Wix file" do
+          # setup source directories and run artifact generation
+          FileUtils.cp("#{WIXTESTFILES}/file-1.wxs", "#{PROJ_ROOT}/resources/windows/wix/file-wix.wxs")
+          FileUtils.cp("#{WIXTESTFILES}/file-2.wxs", "#{VANAGON_ROOT}/resources/windows/wix/file-wix.wxs")
+          cur_plat._platform.generate_msi_packaging_artifacts(WORKDIR, plat[:projname], binding)
+          # check the result
+          expect(FileUtils.compare_file("#{WIXTESTFILES}/file-1.wxs", "#{WORKDIR}/wix/file-wix.wxs")).to be_truthy
+        end
+
+        it "Picks Project Specific Wix File in favour of Generic ERB file" do
+          # setup source directories and run artifact generation
+          FileUtils.cp("#{WIXTESTFILES}/file-1.wxs", "#{PROJ_ROOT}/resources/windows/wix/file-wix.wxs")
+          FileUtils.cp("#{WIXTESTFILES}/file-3.wxs.erb", "#{VANAGON_ROOT}/resources/windows/wix/file-wix.wxs.erb")
+          cur_plat._platform.generate_msi_packaging_artifacts(WORKDIR, plat[:projname], binding)
+          # check the result
+          expect(FileUtils.compare_file("#{WIXTESTFILES}/file-1.wxs", "#{WORKDIR}/wix/file-wix.wxs")).to be_truthy
+        end
+
+        it "Picks Project Specific ERB File in favour of Generic Wix file" do
+          # setup source directories and run artifact generation
+          FileUtils.cp("#{WIXTESTFILES}/file-3.wxs.erb", "#{PROJ_ROOT}/resources/windows/wix/file-wix.wxs.erb")
+          FileUtils.cp("#{WIXTESTFILES}/file-2.wxs", "#{VANAGON_ROOT}/resources/windows/wix/file-wix.wxs")
+          cur_plat._platform.generate_msi_packaging_artifacts(WORKDIR, plat[:projname], binding)
+          # check the result
+          expect(FileUtils.compare_file("#{WIXTESTFILES}/file-3.wxs.erb", "#{WORKDIR}/wix/file-wix.wxs")).to be_truthy
+        end
+
+        it "Picks Project Specific ERB File in favour of Generic ERB file" do
+          # setup source directories and run artifact generation
+          FileUtils.cp("#{WIXTESTFILES}/file-3.wxs.erb", "#{PROJ_ROOT}/resources/windows/wix/file-wix.wxs.erb")
+          FileUtils.cp("#{WIXTESTFILES}/file-4.wxs.erb", "#{VANAGON_ROOT}/resources/windows/wix/file-wix.wxs.erb")
+          cur_plat._platform.generate_msi_packaging_artifacts(WORKDIR, plat[:projname], binding)
+          # check the result
+          expect(FileUtils.compare_file("#{WIXTESTFILES}/file-3.wxs.erb", "#{WORKDIR}/wix/file-wix.wxs")).to be_truthy
+        end
+
+        it "Copies Hierarchy of files from Product Specific Directory to output directory with ERB translation as necessary" do
+          # setup source directories and run artifact generation
+          FileUtils.cp_r("#{WIXTESTFILES}/", "#{PROJ_ROOT}/resources/windows/", :verbose => true)
+          cur_plat._platform.generate_msi_packaging_artifacts(WORKDIR, plat[:projname], binding)
+          # check the result
+          expect(File).to exist("#{WORKDIR}/wix/file-1.wxs")
+          expect(File).to exist("#{WORKDIR}/wix/file-2.wxs")
+          expect(File).to exist("#{WORKDIR}/wix/file-3.wxs")
+          expect(File).to exist("#{WORKDIR}/wix/file-4.wxs")
+          expect(File).to exist("#{WORKDIR}/wix/project.filter.xslt")
+          expect(File).to exist("#{WORKDIR}/wix/project.wxs")
+          expect(File).to exist("#{WORKDIR}/wix/include/include-sample-1.wxs")
+          expect(File).to exist("#{WORKDIR}/wix/ui/ui-sample-1.wxs")
+          expect(File).to exist("#{WORKDIR}/wix/ui/bitmaps/bitmap.bmp")
+          expect(File).not_to exist("#{WORKDIR}/wix/project.filter.xslt.erb")
+          expect(File).not_to exist("#{WORKDIR}/wix/file-3.wxs.erb")
+          expect(File).not_to exist("#{WORKDIR}/wix/file-4.wxs.erb")
+        end
+
+        it "Copies Hierarchy of files from vanagon directory to output directory with ERB translation as necessary" do
+          # setup source directories and run artifact generation
+          FileUtils.cp_r("#{WIXTESTFILES}/", "#{VANAGON_ROOT}/resources/windows/", :verbose => true)
+          cur_plat._platform.generate_msi_packaging_artifacts(WORKDIR, plat[:projname], binding)
+          # check the result
+          expect(File).to exist("#{WORKDIR}/wix/file-1.wxs")
+          expect(File).to exist("#{WORKDIR}/wix/file-2.wxs")
+          expect(File).to exist("#{WORKDIR}/wix/file-3.wxs")
+          expect(File).to exist("#{WORKDIR}/wix/file-4.wxs")
+          expect(File).to exist("#{WORKDIR}/wix/project.filter.xslt")
+          expect(File).to exist("#{WORKDIR}/wix/project.wxs")
+          expect(File).to exist("#{WORKDIR}/wix/include/include-sample-1.wxs")
+          expect(File).to exist("#{WORKDIR}/wix/ui/ui-sample-1.wxs")
+          expect(File).to exist("#{WORKDIR}/wix/ui/bitmaps/bitmap.bmp")
+          expect(File).not_to exist("#{WORKDIR}/wix/project.filter.xslt.erb")
+          expect(File).not_to exist("#{WORKDIR}/wix/file-3.wxs.erb")
+          expect(File).not_to exist("#{WORKDIR}/wix/file-4.wxs.erb")
         end
       end
     end


### PR DESCRIPTION
As noted in discussion, this is now focussing in RE-6456, i.e. allowing Vanagon to include project specific files as well as a generic set of wix files.

/cc @melissa, @jpogran and @McdonaldSeanp 