### PR TITLE
(CPR-293, CPR-294) Fix Local engine, unbundle local commands

### DIFF
--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -267,13 +267,22 @@ class Vanagon
     # Runs the command on the local host
     #
     # @param command [String] command to run on the target
+    # @param workdir [String] change to directory <workdir> before running <command>
     # @return [true] Returns true if the command was successful
     # @raise [RuntimeError] If the command fails an exception is raised
-    def local_command(command, workdir)
-      puts "Executing '#{command}' locally in #{workdir}"
-      Kernel.system(command, :chdir => workdir)
-      $?.success? or raise "Local command (#{command}) failed."
+    def local_command(command, workdir: Dir.pwd)
+      clean_environment do
+        puts "Executing '#{command}' locally in #{workdir}"
+        Kernel.system(command, chdir: workdir)
+        $?.success? or raise "Local command (#{command}) failed."
+      end
     end
+
+    def clean_environment(&block)
+      return Bundler.with_clean_env { yield } if defined?(Bundler)
+      yield
+    end
+    private :clean_environment
 
     # Helper method that takes a template file and runs it through ERB
     #

--- a/spec/lib/vanagon/engine/local_spec.rb
+++ b/spec/lib/vanagon/engine/local_spec.rb
@@ -1,0 +1,15 @@
+require 'vanagon/engine/local'
+
+describe 'Vanagon::Engine::Local' do
+  let (:platform) {
+    plat = Vanagon::Platform::DSL.new('debian-6-i386')
+    plat.instance_eval("platform('debian-6-i386') {  }")
+    plat._platform
+  }
+
+  describe '#validate_platform' do
+    it 'succeeds' do
+      expect(Vanagon::Engine::Local.new(platform).validate_platform).to be(true)
+    end
+  end
+end

--- a/spec/lib/vanagon/utilities_spec.rb
+++ b/spec/lib/vanagon/utilities_spec.rb
@@ -41,6 +41,17 @@ describe "Vanagon::Utilities" do
     end
   end
 
+  describe '#local_command' do
+    it 'runs commands in an unpolluted environment' do
+      cmd = lambda { |arg| %(echo 'if [ "$#{arg}" = "" ]; then exit 0; else exit 1; fi' | /bin/sh) }
+      vars = %w(BUNDLE_BIN_PATH BUNDLE_GEMFILE)
+      vars.each do |var|
+        Vanagon::Utilities.local_command(cmd.call(var))
+        expect($?.exitstatus).to eq(0)
+      end
+    end
+  end
+
   describe "#is_git_repo?" do
     let(:dir) { Dir.mktmpdir }
     after(:each) { FileUtils.rm_rf(dir) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,6 @@
+RSpec.configure do |c|
+  c.before do
+    allow($stdout).to receive(:puts)
+    allow($stderr).to receive(:puts)
+  end
+end


### PR DESCRIPTION
This PR replaces PR #284.

Builds currently fail when using the local engine, because `@remote_dir` is not defined. Additionally, `gem install` fails due to numerous `RUBY_` and `BUNDLER_` environment variables being set when running `bundle exec build`.

I worked with @pyther to bang his initial work into something solid, and wrote some spec tests to cover the initial scope of the work done. `Vanagon::Utilities#local_command` now runs in a clean, unbundled environment and the Local build engine produces usable builds. There's still room for improvement (test coverage is still not 100% on the new work) but this should be in sturdy, workable shape now.

Thanks to @MikaelSmith and @pyther for their work on the original PRs.