### PR TITLE
(MAINT) Specify ruby version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ components, then rebuild the project and test the installed artifacts.
 
 Runtime Requirements
 ---
-Vanagon is self-contained. A recent version of ruby should be all that is
-required. Beyond that, ssh, rsync and git are also required on the host, and
-ssh-server and rsync is required on the target (package installation for the
-target can be customized in the platform config for the target).
+Vanagon is self-contained. A recent version of ruby (2.1 or greater) should be
+all that is required. Beyond that, ssh, rsync and git are also required on the
+host, and ssh-server and rsync is required on the target (package installation
+for the target can be customized in the platform config for the target).
 
 Configuration and Usage
 ---


### PR DESCRIPTION
The readme is vague in its description of what a recent version is. This commit
explicitly details the minimum version required of 2.1.x.  This is due to gem
 dependencies.