### PR TITLE
(CPR-293) Fix local engine again

### DIFF
--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -266,15 +266,25 @@ class Vanagon
 
     # Runs the command on the local host
     #
-    # @param command [String] command to run on the target
-    # @param workdir [String] change to directory <workdir> before running <command>
-    # @return [true] Returns true if the command was successful
+    # @param command [String] command to run locally
+    # @param return_command_output [Boolean] whether or not command output should be returned
+    # @return [true, String] Returns true if the command was successful or the
+    #                        output of the command if return_command_output is true
     # @raise [RuntimeError] If the command fails an exception is raised
-    def local_command(command, workdir: Dir.pwd)
+    def local_command(command, return_command_output: false)
       clean_environment do
-        puts "Executing '#{command}' locally in #{workdir}"
-        Kernel.system(command, chdir: workdir)
-        $?.success? or raise "Local command (#{command}) failed."
+        puts "Executing '#{command}' locally"
+        if return_command_output
+          ret = %x(#{command}).chomp
+          if $?.success?
+            return ret
+          else
+            raise "Local command (#{command}) failed."
+          end
+        else
+          Kernel.system(command)
+          $?.success? or raise "Local command (#{command}) failed."
+        end
       end
     end
 

--- a/spec/lib/vanagon/engine/hardware_spec.rb
+++ b/spec/lib/vanagon/engine/hardware_spec.rb
@@ -4,7 +4,11 @@ require 'vanagon/platform'
 require 'logger'
 
 # Haus, I added this, cause it prevented errors.
-@@logger = Logger.new('/dev/null')
+class Vanagon
+  class Driver
+    @@logger = Logger.new('/dev/null')
+  end
+end
 
 describe 'Vanagon::Engine::Hardware' do
 

--- a/spec/lib/vanagon/engine/local_spec.rb
+++ b/spec/lib/vanagon/engine/local_spec.rb
@@ -12,4 +12,16 @@ describe 'Vanagon::Engine::Local' do
       expect(Vanagon::Engine::Local.new(platform).validate_platform).to be(true)
     end
   end
+
+  describe '#dispatch' do
+    it 'execs successfully' do
+      engine = Vanagon::Engine::Local.new(platform)
+      expect(engine.dispatch('true')).to be(true)
+    end
+
+    it 'returns the result if return_output is true' do
+      engine = Vanagon::Engine::Local.new(platform)
+      expect(engine.dispatch('true', true)).to eq('')
+    end
+  end
 end


### PR DESCRIPTION
The previous commit for CPR-293 left out some updates to the
`local_command` method that were required by `get_remote_workdir`.
Since the local engine doesn't do anything special to initialize
`remote_workdir`, and it's used when calling make to build the project
and in the local engine for `ship_workdir` and
`retrieve_built_artifact`, update `local_command` to handle the
`return_command_output` option.