### PR TITLE
(MAINT) Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,17 @@
+# Now that there is a gemfile, RVM ignores rvmrc in parent directories, so a local one is required
+# to work around that.  Which we don't want committed, so we can ignore it here.
+/.rvmrc
+
+.bundle/
 Gemfile.lock
+Gemfile.local
+.bundle/
+.rspec
+
+/.project
+.idea/
+.ruby-version
+.ruby-gemset
+
+# emacs backup files
+*~


### PR DESCRIPTION
This commit updates the gitignore to be more inline with other Puppetlabs
projects e.g. ignoring .bundle and Gemfile.local

Obsoletes: #294