### PR TITLE
(RE-6640) Filter out service files from harvest

### DIFF
--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -184,7 +184,8 @@ class Vanagon
           # Return here because there is no file to install, just a string read in
           return
         when "windows"
-          # Placeholder for Windows
+          @component.service = OpenStruct.new(:name => service_name, :service_file => service_file)
+          # return here as we are just collecting the name of the service file to put into the harvest filter list.
           return
         else
           fail "Don't know how to install the #{@component.platform.servicetype}. Please teach #install_service how to do this."

--- a/lib/vanagon/platform/windows.rb
+++ b/lib/vanagon/platform/windows.rb
@@ -183,7 +183,7 @@ class Vanagon
           #   -gg             - Generate GUIDS now
           #   -dr             - Directory reference to root directories (cannot contains spaces e.g. -dr MyAppDirRef)
           #   -sreg           - Suppress registry harvesting.
-          "cd $(tempdir); \"$$WIX/bin/heat.exe\" dir staging -v -ke -indent 2 -cg #{cg_name} -gg -dr #{dir_ref} -t wix/project.filter.xslt -sreg -out wix/#{project.name}-harvest.wxs",
+          "cd $(tempdir); \"$$WIX/bin/heat.exe\" dir staging -v -ke -indent 2 -cg #{cg_name} -gg -dr #{dir_ref} -t wix/filter.xslt -sreg -out wix/#{project.name}-harvest.wxs",
           # Apply Candle command to all *.wxs files - generates .wixobj files in wix directory.
           # cygpath conversion is necessary as candle is unable to handle posix path specs
           "cd $(tempdir)/wix/wixobj; for wix_file in `find $(tempdir)/wix -name \'*.wxs\'`; do \"$$WIX/bin/candle.exe\" #{candle_flags} $$(cygpath -aw $$wix_file) ; done",

--- a/resources/windows/wix/filter.xslt.erb
+++ b/resources/windows/wix/filter.xslt.erb
@@ -15,11 +15,9 @@
   <!-- The list of component service files are collected in an array so that a set of unique names can be extracted -->
   <%- service_files = Array.new -%>
   <%- get_services.each do |service| -%>
-    <%- service.options.each do |service_option| -%>
-      <%- service_files << service_option[:file][:source] -%>
-    <%- end -%>
+    <%- service_files << service.service_file -%>
   <%- end -%>
   <%- service_files.uniq.each do |service_file|  -%>
-        <xsl:template match="wix:Component[wix:File[@Source='<%= service_file %>']]" />
+    <xsl:template match="wix:Component[wix:File[@Source='<%= service_file %>']]" />
   <%- end -%>
 </xsl:stylesheet>


### PR DESCRIPTION
This updates the service file handling to for product specific wix
service file fragments. The service .exe still needs to be filtered out
from the harvest, so the list of service .exe's are placed in the filter
file.

The project.filter.xslt file has also been renamed to simply
filter.xslt.  This file is given a generic name as there may be a need
in the future to filter out other files from the harvest.

The nssm.exe file is not being correctly matched in the harvest - this
appears to be an issue with the build itself (the nssm and some other
files are not being dropped in the correct folder). This issue will be
checked, ticketed if necessary and handled in seperate PR.