### PR TITLE
(maint) update the WiX toolset

### DIFF
--- a/resources/windows/wix/project.wxs.erb
+++ b/resources/windows/wix/project.wxs.erb
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="windows-1252"?>
-  <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
-    <Product
-      Id="*"
-      UpgradeCode="<%= settings[:upgrade_code] %>"
-      Name="<%= settings[:product_name] %>"
-      Language="1033"
-      Codepage="1252"
-      Version="<%= @version.sub(/\.g[0-9a-z]{7}$/, '') %>"
-      Manufacturer="<%= settings[:company_name] %>" >
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+  <Product
+    Id="*"
+    UpgradeCode="<%= settings[:upgrade_code] %>"
+    Name="<%= settings[:product_name] %>"
+    Language="1033"
+    Codepage="1252"
+    Version="<%= @version.sub(/\.g[0-9a-z]{7}$/, '') %>"
+    Manufacturer="<%= settings[:company_name] %>" >
 
     <Package
       InstallerVersion="300"
@@ -26,13 +26,10 @@
       <ComponentGroupRef Id="ProductComponentGroup" />
     </Feature>
 
-    <!-- All heat runs and WiX Fragment files containing Component elements will reference this ComponentGroup -->
-    <ComponentGroup Id="ProductComponentGroup" Directory="INSTALLDIR"/>
-
     <!-- We will use DirectoryRef at the project level to hook in the project directory structure -->
     <Directory Id='TARGETDIR' Name='SourceDir' >
       <Component Id="RegistryEntriesArchitectureDependent" Guid="E6D5AF4F-ACC4-4D11-AFCE-299A9ED2152C" Win64="<%= settings[:win64] %>" Permanent="yes">
-        <RegistryKey Root="HKLM" Key="SOFTWARE\<%= settings[:company_name] %>\<%= settings[:product_name] %>" Action="create" >
+        <RegistryKey Root="HKLM" Key="SOFTWARE\<%= settings[:company_name] %>\<%= settings[:product_name] %>" ForceCreateOnInstall="yes" >
           <RegistryValue Type="integer" Value="0"/>
           <%- if @platform.architecture == "x64" -%>
           <RegistryValue Name="RememberedInstallDir" Type="string" Value="[INSTALLDIR_X86]" />


### PR DESCRIPTION
This commit updates the light commands to do the following:

* rename "staging" to SourceDir, since light looks specifically
for a directory called SourceDir

* remove the -dr flag from heat.exe, as we want all the defaults
from heat (as we will use these defaults in light.exe)

* add the -srd flag to heat.exe to ignore the source directory
because again, we want to use the defaults in light

* add the -b flag to light.exe to point it to where we are
putting SourceDir (which is in the temp folder)

* remove INSTALLDIR, we are no longer using it as its set in
the defaults.

* remove the componentgroup element from the project .wxs file
as this is created in heat already

* Update the registrykey element to use ForceCreateOnInstall
instead of action, as action is deprecated now

With all these changes light will now successfully compile an
MSI