### PR TITLE
(maint) Redo project.wxs

### DIFF
--- a/resources/windows/wix/project.wxs.erb
+++ b/resources/windows/wix/project.wxs.erb
@@ -25,21 +25,8 @@
       <!-- We can add all components by referencing this one thing -->
       <ComponentGroupRef Id="ProductComponentGroup" />
     </Feature>
-
     <!-- We will use DirectoryRef at the project level to hook in the project directory structure -->
-    <Directory Id='TARGETDIR' Name='SourceDir' >
-      <Component Id="RegistryEntriesArchitectureDependent" Guid="E6D5AF4F-ACC4-4D11-AFCE-299A9ED2152C" Win64="<%= settings[:win64] %>" Permanent="yes">
-        <RegistryKey Root="HKLM" Key="SOFTWARE\<%= settings[:company_name] %>\<%= settings[:product_name] %>" ForceCreateOnInstall="yes" >
-          <RegistryValue Type="integer" Value="0"/>
-          <%- if @platform.architecture == "x64" -%>
-          <RegistryValue Name="RememberedInstallDir" Type="string" Value="[INSTALLDIR_X86]" />
-          <RegistryValue Name="RememberedInstallDir64" Type="string" Value="[INSTALLDIR]" KeyPath="yes" />
-          <%- else %>
-          <RegistryValue Name="RememberedInstallDir" Type="string" Value="[INSTALLDIR]"  KeyPath="yes" />
-          <%- end -%>
-        </RegistryKey>
-      </Component>
-    </Directory>
+    <Directory Id='TARGETDIR' Name='SourceDir' />
 
   </Product>
 </Wix>

--- a/resources/windows/wix/registryEntries.wxs.erb
+++ b/resources/windows/wix/registryEntries.wxs.erb
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='windows-1252'?>
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi' xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+  <Fragment>
+    <ComponentGroupRef Id="ProductComponentGroup">
+      <Directoryref Id='TARGETDIR' Name='SourceDir' >
+        <Component Id="RegistryEntriesArchitectureDependent" Guid="E6D5AF4F-ACC4-4D11-AFCE-299A9ED2152C" Win64="<%= settings[:win64] %>" Permanent="yes">
+          <RegistryKey Root="HKLM" Key="SOFTWARE\<%= settings[:company_name] %>\<%= settings[:product_name] %>" ForceCreateOnInstall="yes" >
+            <RegistryValue Type="integer" Value="0"/>
+            <%- if @platform.architecture == "x64" -%>
+            <RegistryValue Name="RememberedInstallDir" Type="string" Value="[INSTALLDIR_X86]" />
+            <RegistryValue Name="RememberedInstallDir64" Type="string" Value="[INSTALLDIR]" KeyPath="yes" />
+            <%- else %>
+            <RegistryValue Name="RememberedInstallDir" Type="string" Value="[INSTALLDIR]"  KeyPath="yes" />
+            <%- end -%>
+          </RegistryKey>
+        </Component>
+      </Directory>
+    </ComponentGroupRef>
+  </Fragment>
+</Wix>


### PR DESCRIPTION
This commit refactors project.wxs to remove a component
that was causing problems with the WiX build. The component
doesn't actually need to be removed, only moved outside
the "product" element and put inside a "ComponentGroupRef"
element in another WiX fragment.

Following this commit the WiX compiler will successfully
compile and the sanitary checks done by WiX at the end
of compilation will not fail out. Meaning Vanagon now
successfully completes.