### PR TITLE
(MAINT) Convert filter.wxs.erb file to Unix Mode

### DIFF
--- a/resources/windows/wix/filter.xslt.erb
+++ b/resources/windows/wix/filter.xslt.erb
@@ -17,7 +17,7 @@
   <%- get_services.each do |service| -%>
     <%- service_files << service.service_file -%>
   <%- end -%>
-  <%- service_files.uniq.each do |service_file|  -%>
+  <%- service_files.uniq.each do |service_file| -%>
     <xsl:template match="wix:Component[wix:File[@Source='<%= service_file %>']]" />
   <%- end -%>
 </xsl:stylesheet>


### PR DESCRIPTION
This fixes an irritant in the ERB translation which leads to multiple
blank lines in the filter file. While not affecting functionality, it
represented an untidyness that "made me sad" in the PDX vernacular.

Although it looks like all lines have changed, in fact all that was done
was to run the :set fileformat=unix in vi.

And yes - I also removed an unneeded space.