### PR TITLE
(RE-6455) Create directorylist.wxs

### DIFF
--- a/resources/windows/wix/directorylist.wxs.erb
+++ b/resources/windows/wix/directorylist.wxs.erb
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='windows-1252'?>
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi' xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+
+  <Fragment>
+    <DirectoryRef Id='TARGETDIR'>
+      <%= @platform.generate_wix_dirs(self.get_services) %>
+    </DirectoryRef>
+  </Fragment>
+</Wix>

--- a/spec/lib/vanagon/platform/windows_spec.rb
+++ b/spec/lib/vanagon/platform/windows_spec.rb
@@ -1,4 +1,7 @@
 require 'vanagon/platform'
+require 'vanagon/project'
+require 'vanagon/common'
+
 
 # These constants are defined for the purpose of the project/generic file merge tests
 # to point these directories to test areas under the /tmp directory.
@@ -26,14 +29,17 @@ describe "Vanagon::Platform::Windows" do
       :output_dir_with_target => "windows/thing/x64",
       :target_user            => "Administrator",
       :projname               => "test-proj",
-      :block                  => %Q[ platform "windows-2012r2-x64" do |plat| end ]
+      :block                  => %Q[ platform "windows-2012r2-x64" do |plat| plat.servicetype 'windows' end ]
     },
   ]
 
   platforms.each do |plat|
-    context "on #{plat[:name]} we should behave ourselves" do
+    context "on #{plat[:name]}" do
       let(:platform) { plat }
       let(:cur_plat) { Vanagon::Platform::DSL.new(plat[:name]) }
+      let (:project_block) {
+"project 'test-fixture' do |proj|
+end" }
 
       before do
         cur_plat.instance_eval(plat[:block])
@@ -159,6 +165,123 @@ describe "Vanagon::Platform::Windows" do
           expect(File).not_to exist("#{WORKDIR}/wix/project.filter.xslt.erb")
           expect(File).not_to exist("#{WORKDIR}/wix/file-3.wxs.erb")
           expect(File).not_to exist("#{WORKDIR}/wix/file-4.wxs.erb")
+        end
+
+
+        describe "generate_wix_dirs" do
+
+          it "returns one directory with install_service defaults" do
+            cur_plat.instance_eval(plat[:block])
+            comp = Vanagon::Component::DSL.new('service-test', {}, cur_plat._platform)
+            comp.install_service('/opt/bin.exe')
+            expect(cur_plat._platform.generate_wix_dirs([comp._component.service].flatten.compact)).to eq( \
+<<-HERE
+<Directory Name="opt" Id="opt">
+<Directory Id="SERVICETESTBINDIR" />
+</Directory>
+HERE
+            )
+          end
+
+          it "returns one directory with non-default name" do
+            cur_plat.instance_eval(plat[:block])
+            comp = Vanagon::Component::DSL.new('service-test', {}, cur_plat._platform)
+            comp.install_service('/opt/bin.exe', nil, "service-test-2")
+            expect(cur_plat._platform.generate_wix_dirs([comp._component.service].flatten.compact)).to eq( \
+<<-HERE
+<Directory Name="opt" Id="opt">
+<Directory Id="SERVICETEST2BINDIR" />
+</Directory>
+HERE
+            )
+          end
+
+          it "returns nested directory correctly with \\" do
+            cur_plat.instance_eval(plat[:block])
+            comp = Vanagon::Component::DSL.new('service-test', {}, cur_plat._platform)
+            comp.install_service('root\\programfiles\\bin.exe')
+            expect(cur_plat._platform.generate_wix_dirs([comp._component.service].flatten.compact)).to eq( \
+<<-HERE
+<Directory Name="root" Id="root">
+<Directory Name="programfiles" Id="programfiles">
+<Directory Id="SERVICETESTBINDIR" />
+</Directory>
+</Directory>
+HERE
+            )
+          end
+
+          it "removes any drive roots" do
+            cur_plat.instance_eval(plat[:block])
+            comp = Vanagon::Component::DSL.new('service-test', {}, cur_plat._platform)
+            comp.install_service('C:\\programfiles\\bin.exe')
+            expect(cur_plat._platform.generate_wix_dirs([comp._component.service].flatten.compact)).to eq( \
+<<-HERE
+<Directory Name="programfiles" Id="programfiles">
+<Directory Id="SERVICETESTBINDIR" />
+</Directory>
+HERE
+            )
+          end
+
+          it "removes SourceDir" do
+            cur_plat.instance_eval(plat[:block])
+            comp = Vanagon::Component::DSL.new('service-test', {}, cur_plat._platform)
+            comp.install_service('SourceDir\\programfiles\\bin.exe')
+            expect(cur_plat._platform.generate_wix_dirs([comp._component.service].flatten.compact)).to eq( \
+<<-HERE
+<Directory Name="programfiles" Id="programfiles">
+<Directory Id="SERVICETESTBINDIR" />
+</Directory>
+HERE
+            )
+          end
+
+
+          it "adds a second directory for the same input but different components" do
+            cur_plat.instance_eval(plat[:block])
+            comp = Vanagon::Component::DSL.new('service-test', {}, cur_plat._platform)
+            comp.install_service('/programfiles/bin.exe')
+            comp2 = Vanagon::Component::DSL.new('service-test-2', {}, cur_plat._platform)
+            comp2.install_service('/programfiles/bin.exe')
+            expect(cur_plat._platform.generate_wix_dirs([comp._component.service, comp2._component.service].flatten.compact)).to eq( \
+<<-HERE
+<Directory Name="programfiles" Id="programfiles">
+<Directory Id="SERVICETESTBINDIR" />
+<Directory Id="SERVICETEST2BINDIR" />
+</Directory>
+HERE
+            )
+          end
+
+          it "returns correctly formatted multiple nested directories" do
+            cur_plat.instance_eval(plat[:block])
+            comp1 = Vanagon::Component::DSL.new('service-test1', {}, cur_plat._platform)
+            comp1.install_service('/opt/oneUp/twoUp/bin.exe')
+            comp2 = Vanagon::Component::DSL.new('service-test2', {}, cur_plat._platform)
+            comp2.install_service('/opt/oneUpAgain/twoUp/bin.exe')
+            comp3 = Vanagon::Component::DSL.new('service-test3', {}, cur_plat._platform)
+            comp3.install_service('/opt/oneUpAgain/twoUpAgain/bin.exe')
+            expect(cur_plat._platform.generate_wix_dirs([comp1._component.service, comp2._component.service, comp3._component.service].flatten.compact)).to eq( \
+<<-HERE
+<Directory Name="opt" Id="opt">
+<Directory Name="oneUp" Id="oneUp">
+<Directory Name="twoUp" Id="twoUp">
+<Directory Id="SERVICETEST1BINDIR" />
+</Directory>
+</Directory>
+<Directory Name="oneUpAgain" Id="oneUpAgain">
+<Directory Name="twoUp" Id="twoUp">
+<Directory Id="SERVICETEST2BINDIR" />
+</Directory>
+<Directory Name="twoUpAgain" Id="twoUpAgain">
+<Directory Id="SERVICETEST3BINDIR" />
+</Directory>
+</Directory>
+</Directory>
+HERE
+            )
+          end
         end
       end
     end


### PR DESCRIPTION
This commit will add functionality to use the existing
get_services functionality for a project to generate
a directorylist.wxs file that contains the wix structure
of directories containing binaries for the project.

Because more than one service can point to the same binary
the directorylist may contain more than one directory wix
element at the top of the directory tree. In WiX this is
fine as long as any elements that are supposed to point
to the same directory have different IDs and no "name"
attribute.