### PR TITLE
(RE-6440) Add Service Component References

### DIFF
--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -184,7 +184,7 @@ class Vanagon
           # Return here because there is no file to install, just a string read in
           return
         when "windows"
-          @component.service = OpenStruct.new(:name => service_name, :service_file => service_file)
+          @component.service = OpenStruct.new(:name => service_name, :id => "#{service_name.gsub(/([^A-Za-z0-9])/, '').upcase}", :service_file => target_service_file)
           # return here as we are just collecting the name of the service file to put into the harvest filter list.
           return
         else

--- a/resources/windows/wix/componentrefs.wxs.erb
+++ b/resources/windows/wix/componentrefs.wxs.erb
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='windows-1252'?>
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi' xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+
+  <Fragment>
+    <ComponentGroup Id="ServiceListGroup">
+      <%- get_services.each do |service| -%>
+      <ComponentGroupRef Id="Service_<%= service.id %>" />
+      <%- end -%>
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/resources/windows/wix/project.wxs.erb
+++ b/resources/windows/wix/project.wxs.erb
@@ -25,6 +25,7 @@
       <!-- We can add all components by referencing this one thing -->
       <ComponentGroupRef Id="ProductComponentGroup" />
       <ComponentGroupRef Id="RegistryComponentGroup" />
+      <ComponentGroupRef Id="ServiceListGroup" />
     </Feature>
     <!-- We will use DirectoryRef at the project level to hook in the project directory structure -->
     <Directory Id='TARGETDIR' Name='SourceDir' />


### PR DESCRIPTION
The service component reference is generated from "service_name" using
the Wix rules, i.e. only legal characters are Alphanumeric and _.
This is used to generate a table of service references to ensure the
service components are loaded into the MSI.