### PR TITLE
(MAINT) Fix service_file for windows service def

### DIFF
--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -184,7 +184,7 @@ class Vanagon
           # Return here because there is no file to install, just a string read in
           return
         when "windows"
-          @component.service = OpenStruct.new(:name => service_name, :id => "#{service_name.gsub(/([^A-Za-z0-9])/, '').upcase}", :service_file => target_service_file)
+          @component.service = OpenStruct.new(:id => "#{service_name.gsub(/[^A-Za-z0-9]/, '').upcase}", :service_file => service_file)
           # return here as we are just collecting the name of the service file to put into the harvest filter list.
           return
         else


### PR DESCRIPTION
This corrects a Typo that was spotted in PR #308
The service_file argument is incorrect.
Have also removed :name as this is no longer needed for either service
table or associated directory list creation (see #307)