### PR TITLE
(RE-6551) Make vanagon builds retry on errors

### DIFF
--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -25,10 +25,7 @@ class Vanagon
       @platform = Vanagon::Platform.load_platform(platform, File.join(@@configdir, "platforms"))
       @project = Vanagon::Project.load_project(project, File.join(@@configdir, "projects"), @platform, components)
       @project.settings[:skipcheck] = options[:skipcheck]
-      @@logger = Logger.new('vanagon_hosts.log')
-      @@logger.progname = 'vanagon'
-      @timeout = @project.timeout || 3600
-      @retry_count = @project.retry_count || 3
+      loginit('vanagon_hosts.log')
 
       # If a target has been given, we don't want to make any assumptions about how to tear it down.
       engine = 'base' if target
@@ -119,8 +116,16 @@ class Vanagon
     end
 
     def retry_task(&block)
+      @timeout = @project.timeout || 3600
+      @retry_count = @project.retry_count || 3
       Vanagon::Utilities.retry_with_timeout(@retry_count, @timeout) { yield }
     end
     private :retry_task
+
+    def loginit(logfile)
+      @@logger = Logger.new(logfile)
+      @@logger.progname = 'vanagon'
+    end
+    private :loginit
   end
 end

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -115,6 +115,9 @@ class Vanagon
       raise e
     end
 
+    # Retry the provided block, use the retry count and timeout
+    # values from the project, if available, otherwise use some
+    # sane defaults.
     def retry_task(&block)
       @timeout = @project.timeout || 3600
       @retry_count = @project.retry_count || 3
@@ -122,6 +125,7 @@ class Vanagon
     end
     private :retry_task
 
+    # Initialize the logging instance
     def loginit(logfile)
       @@logger = Logger.new(logfile)
       @@logger.progname = 'vanagon'

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -11,7 +11,7 @@ class Vanagon
     attr_accessor :version, :directories, :license, :description, :vendor
     attr_accessor :homepage, :requires, :user, :repo, :noarch, :identifier
     attr_accessor :cleanup, :version_file, :release, :replaces, :provides
-    attr_accessor :bill_of_materials
+    attr_accessor :bill_of_materials, :retry_count, :timeout
 
     # Loads a given project from the configdir
     #

--- a/spec/lib/vanagon/utilities_spec.rb
+++ b/spec/lib/vanagon/utilities_spec.rb
@@ -154,5 +154,9 @@ describe "Vanagon::Utilities" do
       expect(Vanagon::Utilities).to receive(:remote_ssh_command).with(host, command, port).exactly(1).times.and_return(true)
       expect(Vanagon::Utilities.retry_with_timeout(tries, timeout) { Vanagon::Utilities.remote_ssh_command(host, command, port) }).to be(true)
     end
+
+    it 'raises a Vanagon::Error if the command times out' do
+      expect{ Vanagon::Utilities.retry_with_timeout(tries, timeout) { sleep 5 }.to raise_error(Vanagon::Error) }
+    end
   end
 end


### PR DESCRIPTION
Currently, vanagon builds will occasionally fail on
what turn out to be transient, short-lived issues.

This wraps the main build in the retry method to try
to reduce the impact of transient infrastructure issues.
As set, will retry up to 3 times with a 1-hour timeout.