### PR TITLE
(RE-6743) Vanagon generic registry entries

### DIFF
--- a/resources/windows/wix/registryEntries.wxs.erb
+++ b/resources/windows/wix/registryEntries.wxs.erb
@@ -1,15 +1,44 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi' xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+
+  <!--
+    Registry Entries
+    This is a suggested set of entries that can be used to record the Installation Directory for upgrade installs.
+    Any definitions in this will be over-ridden if the same file name is used in the Product Specific resouces directory.
+  -->
   <Fragment>
     <ComponentGroup Id="RegistryComponentGroup">
-        <Component Id="RegistryEntriesArchitectureDependent" Directory="TARGETDIR" Guid="E6D5AF4F-ACC4-4D11-AFCE-299A9ED2152C" Win64="<%= settings[:win64] %>" Permanent="yes">
-          <RegistryKey Root="HKLM" Key="SOFTWARE\<%= settings[:company_name] %>\<%= settings[:product_name] %>" ForceCreateOnInstall="yes" >
-            <RegistryValue Type="integer" Value="0"/>
+        <Component
+          Id="RegistryEntriesArchitectureDependent"
+          Directory="TARGETDIR"
+          Guid="*"
+          Win64="<%= settings[:win64] %>"
+          Permanent="yes">
+
+          <RegistryKey
+            Root="HKLM"
+            Key="SOFTWARE\<%= settings[:company_name] %>\<%= settings[:product_name] %>"
+            ForceCreateOnInstall="yes" >
+
+            <RegistryValue
+              Type="integer"
+              Value="0"/>
             <%- if @platform.architecture == "x64" -%>
-            <RegistryValue Name="RememberedInstallDir" Type="string" Value="[INSTALLDIR_X86]" />
-            <RegistryValue Name="RememberedInstallDir64" Type="string" Value="[INSTALLDIR]" KeyPath="yes" />
+              <RegistryValue
+                Name="RememberedInstallDir"
+                Type="string"
+                Value="[INSTALLDIR_X86]" />
+              <RegistryValue
+                Name="RememberedInstallDir64"
+                Type="string"
+                Value="[INSTALLDIR]"
+                KeyPath="yes" />
             <%- else %>
-            <RegistryValue Name="RememberedInstallDir" Type="string" Value="[INSTALLDIR]"  KeyPath="yes" />
+              <RegistryValue
+                Name="RememberedInstallDir"
+                Type="string"
+                Value="[INSTALLDIR]"
+                KeyPath="yes" />
             <%- end -%>
           </RegistryKey>
         </Component>


### PR DESCRIPTION
These entries are being over-ridden by a more Puppet-Agent specific set
of registry entries for puppet-agent.

Rather than deleting this file, it is being left in place with comments
to give guidance on how to set registry entries.

This model will also be applied to the properties and other common
files.