### PR TITLE
(RE-6739) Load services unconditionally on osx

### DIFF
--- a/resources/osx/postinstall.erb
+++ b/resources/osx/postinstall.erb
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-foundpkg=`/usr/sbin/pkgutil --volume "$3" --pkgs=<%= @identifier-%>.<%= @name -%>`
-
 # Move any new configfiles into place
 <%- get_configfiles.each do |config|
 dest_file = config.path.gsub(/\.pristine$/, '') -%>
@@ -13,12 +11,8 @@ else
 fi
 <%- end -%>
 
-# If we appear to be in an upgrade load services.
-
-if [ -n "$foundpkg" ]; then
 <%- get_services.each do |service| -%>
   /bin/launchctl load -F "<%= service.service_file %>"
 <%- end -%>
-fi
 
 <%= File.read("resources/osx/postinstall-extras") if File.exist?("resources/osx/postinstall-extras") %>

--- a/resources/osx/preinstall.erb
+++ b/resources/osx/preinstall.erb
@@ -10,7 +10,7 @@ if [ -n "$foundpkg" ]; then
   if /bin/launchctl list "<%= service.name %>" &> /dev/null; then
     /bin/launchctl unload "<%= service.service_file %>"
   fi
-  if [ -f "$oldbom"]; then
+  if [ -f "$oldbom" ]; then
     /bin/rm "$oldbom"
   fi
 <%- end -%>


### PR DESCRIPTION
Currently, osx will only load services if the pkgutil check
detects a previous package installed. I think this is failing
because, in the postinstall, the package is no longer installed.

This changes the postinstall to unconditionally load services
on OSX.

Also fixes a whitespace typo in the preinstall script