### PR TITLE
(RE-6739) Make service load conditional on upgrade for osx

### DIFF
--- a/resources/osx/postinstall.erb
+++ b/resources/osx/postinstall.erb
@@ -11,8 +11,17 @@ else
 fi
 <%- end -%>
 
+if [ -d "/tmp/.<%= @name %>.upgrade" ]
 <%- get_services.each do |service| -%>
-  /bin/launchctl load -F "<%= service.service_file %>"
+  if [ -f "/tmp/.<%= @name %>.upgrade/<%= service.name %>" ]
+    /bin/launchctl load -F "<%= service.service_file %>"
+  fi
 <%- end -%>
+fi
 
 <%= File.read("resources/osx/postinstall-extras") if File.exist?("resources/osx/postinstall-extras") %>
+
+# Cleanup after ourselves
+if [ -e "/tmp/.<%= @name %>.upgrade" ]
+  rm -rf "/tmp/.<%= @name %>.upgrade"
+fi

--- a/resources/osx/preinstall.erb
+++ b/resources/osx/preinstall.erb
@@ -1,13 +1,21 @@
 #!/bin/bash
 
-# If we appear to be in an upgrade unload services.
+# Cleanup previous operations
+if [ -e "/tmp/.<%= @name %>.upgrade" ]
+  rm -rf "/tmp/.<%= @name %>.upgrade"
+fi
 
+# If we appear to be in an upgrade unload services.
 foundpkg=`/usr/sbin/pkgutil --volume "$3" --pkgs=<%= @identifier-%>.<%= @name -%>`
 oldbom="/usr/share/doc/<%= @name %>/bill-of-materials"
 
 if [ -n "$foundpkg" ]; then
+  mkdir -p "/tmp/.<%= @name %>.upgrade"
+  chmod 0700 "/tmp/.<%= @name %>.upgrade"
+
 <%- get_services.each do |service| -%>
   if /bin/launchctl list "<%= service.name %>" &> /dev/null; then
+    touch "/tmp/.<%= @name %>.upgrade/<%= service.name %>"
     /bin/launchctl unload "<%= service.service_file %>"
   fi
   if [ -f "$oldbom" ]; then


### PR DESCRIPTION
In a previous commit, service reloads were made unconditional,
as the test for loading them was failing. This updates the logic
to reload the services if they were loaded at the beginning of
the package operation.