### PR TITLE
(maint) add windows style version function

### DIFF
--- a/lib/vanagon/platform/windows.rb
+++ b/lib/vanagon/platform/windows.rb
@@ -402,6 +402,14 @@ class Vanagon
         string
       end
 
+      # Grab only the first three values from the version input
+      # and strip off any non-digit characters.\
+      #
+      # @param [string] version, the original version number
+      def windows_style_version(version)
+        version.split("\.").first(3).collect { |value| value.gsub(/[^0-9]/, '') }.join("\.")
+      end
+
       # Constructor. Sets up some defaults for the windows platform and calls the parent constructor
       #
       # Mingw varies on where it is installed based on architecture. We want to use which ever is on the system.

--- a/spec/lib/vanagon/platform/windows_spec.rb
+++ b/spec/lib/vanagon/platform/windows_spec.rb
@@ -68,6 +68,15 @@ HERE
         end
       end
 
+      describe '#windows_style_version' do
+        it "returns first three digits only" do
+          expect(cur_plat._platform.windows_style_version("1.0.0.1")).to eq("1.0.0")
+        end
+
+        it "returns only numbers" do
+          expect(cur_plat._platform.windows_style_version("1.0.g0")).to eq("1.0.0")
+        end
+      end
       describe '#generate_msi_packaging_artifacts' do
         before(:each) do
           # Create Workdir and temp root directory


### PR DESCRIPTION
This function is necessary to facilitate the
windows vanagon work as WiX and windows require
only three digit versions with no non-digit chars.

This will also add rspec for the new function.