### PR TITLE
(RE-6520) Specify arch when generating Debian pkgs

### DIFF
--- a/lib/vanagon/platform/deb.rb
+++ b/lib/vanagon/platform/deb.rb
@@ -7,6 +7,7 @@ class Vanagon
       # @return [Array] list of commands required to build a debian package for the given project from a tarball
       def generate_package(project)
         target_dir = project.repo ? output_dir(project.repo) : output_dir
+        pkg_arch_opt = project.noarch ? "" : "-a#{@architecture}"
         ["mkdir -p output/#{target_dir}",
         "mkdir -p $(tempdir)/#{project.name}-#{project.version}",
         "cp #{project.name}-#{project.version}.tar.gz $(tempdir)/#{project.name}_#{project.version}.orig.tar.gz",
@@ -14,7 +15,7 @@ class Vanagon
         "cp -pr debian $(tempdir)/#{project.name}-#{project.version}",
         "gunzip -c #{project.name}-#{project.version}.tar.gz | '#{@tar}' -C '$(tempdir)/#{project.name}-#{project.version}' --strip-components 1 -xf -",
         "sed -i 's/\ /?/g' $(tempdir)/#{project.name}-#{project.version}/debian/install",
-        "(cd $(tempdir)/#{project.name}-#{project.version}; debuild --no-lintian -uc -us)",
+        "(cd $(tempdir)/#{project.name}-#{project.version}; debuild --no-lintian #{pkg_arch_opt} -uc -us)",
         "cp $(tempdir)/*.deb ./output/#{target_dir}"]
       end
 


### PR DESCRIPTION
This allows cross-compiled packages to use correct tools (such as the
target arch strip command) when generating the package. When
project.noarch is set, this becomes a no-op.

Note: you cannot have a space between the -a and the arch, which
only works for the dpkg-buildpackage in Debian 8 and later.