### PR TITLE
OSX pre and post scripts should actually be shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.5.6] - 2016-3-21
+### Fixed
+- Re-added the previous Debian architecture change, fixed for all
+Debian and Ubuntu platforms.
+- Fixed syntax issues in the osx pre and post install scripts
+
 ## [0.5.5] - 2016-3-21
 ### Fixed
 - Reverted the change to specify debian architectures, the option was breaking
@@ -196,7 +202,8 @@ on Debian < 8 and needs more work and testing.
 
 ## Versions <= 0.3.9 do not have a change log entry
 
-[Unreleased]: https://github.com/puppetlabs/vanagon/compare/0.5.5...HEAD
+[Unreleased]: https://github.com/puppetlabs/vanagon/compare/0.5.6...HEAD
+[0.5.6]: https://github.com/puppetlabs/vanagon/compare/0.5.5...0.5.6
 [0.5.5]: https://github.com/puppetlabs/vanagon/compare/0.5.4...0.5.5
 [0.5.4]: https://github.com/puppetlabs/vanagon/compare/0.5.3...0.5.4
 [0.5.3]: https://github.com/puppetlabs/vanagon/compare/0.5.2...0.5.3

--- a/resources/osx/postinstall.erb
+++ b/resources/osx/postinstall.erb
@@ -11,9 +11,9 @@ else
 fi
 <%- end -%>
 
-if [ -d "/tmp/.<%= @name %>.upgrade" ]
+if [ -d "/tmp/.<%= @name %>.upgrade" ]; then
 <%- get_services.each do |service| -%>
-  if [ -f "/tmp/.<%= @name %>.upgrade/<%= service.name %>" ]
+  if [ -f "/tmp/.<%= @name %>.upgrade/<%= service.name %>" ]; then
     /bin/launchctl load -F "<%= service.service_file %>"
   fi
 <%- end -%>
@@ -22,6 +22,6 @@ fi
 <%= File.read("resources/osx/postinstall-extras") if File.exist?("resources/osx/postinstall-extras") %>
 
 # Cleanup after ourselves
-if [ -e "/tmp/.<%= @name %>.upgrade" ]
+if [ -e "/tmp/.<%= @name %>.upgrade" ]; then
   rm -rf "/tmp/.<%= @name %>.upgrade"
 fi

--- a/resources/osx/preinstall.erb
+++ b/resources/osx/preinstall.erb
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Cleanup previous operations
-if [ -e "/tmp/.<%= @name %>.upgrade" ]
+if [ -e "/tmp/.<%= @name %>.upgrade" ]; then
   rm -rf "/tmp/.<%= @name %>.upgrade"
 fi
 


### PR DESCRIPTION
The previous fix for the osx install scripts had some
syntax errors.

This fixes those and should actually produce a valid
shell script