### PR TITLE
(RE-6506) Change MSI Product Version to 3 digits.

### DIFF
--- a/resources/windows/wix/project.wxs.erb
+++ b/resources/windows/wix/project.wxs.erb
@@ -6,7 +6,7 @@
     Name="<%= settings[:product_name] %>"
     Language="1033"
     Codepage="1252"
-    Version="<%= @version.sub(/\.g[0-9a-z]{7}$/, '') %>"
+    Version="<%= @platform.windows_style_version(@version) %>"
     Manufacturer="<%= settings[:company_name] %>" >
 
     <Package


### PR DESCRIPTION
As per the original pxp-agent build, the Version for the MSI should be 3
digits and not 4. Use the new windows_style_version method provided by
PR: https://github.com/puppetlabs/vanagon/pull/326 to use the
first 3 digits only in the ERB project template.