### PR TITLE
(maint) adding a vanagon_devkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ communications. This will be used instead of whatever defaults are configured
 in .ssh/config.
 
 ##### VANAGON\_SSH\_AGENT
-When set, Vanagon will forward the ssh authentication agent connection. 
+When set, Vanagon will forward the ssh authentication agent connection.
 
 ##### VMPOOLER\_TOKEN
 Used in conjunction with the pooler engine, this is a token to pass to the

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ have a docker\_image defined in its config).
 
 ### `devkit` usage
 
+NOTE** The vanagon devkit is under development, and thus may be unreliable.
 The devkit command has positional arguments and position independent flagged
 arguments.
 
@@ -154,6 +155,43 @@ Supports all flagged arguments from the `build` command.
 
 ##### -t HOST, --target HOST
 As in the `build` target host optional argument.
+
+#### Flags (can be anywhere in the command)
+
+##### -h, --help
+Display command-line help.
+
+### `dev_build` usage
+
+NOTE** dev_build is under development, and thus may be unreliable.
+dev_build builds a project the same as build with the available options
+of stopping execution and resuming a running engine.
+
+#### Arguments (position dependent)
+
+##### project name
+As in `build` arguments.
+
+##### platform name
+As in `build` arguments.
+
+##### component names [optional]
+Specifies specific components that should be built. If components are not
+specified, then all components in the project will be built. If components
+are specified as arguments, then any in the project that aren't specified
+as arguments will be retrieved from packages rather than built from source.
+
+#### Flagged arguments (can be anywhere in the command)
+
+Supports all flagged arguments from the `build` command.
+
+##### -t HOST, --target HOST
+As in the `build` target host optional argument.
+
+##### -r, --resume
+This will resume an engine that is currently running,
+it equates to disabling @engine.startup. Note that
+in order to resume a host, --target must be specified
 
 #### Flags (can be anywhere in the command)
 

--- a/bin/dev_build
+++ b/bin/dev_build
@@ -25,4 +25,4 @@ artifact = Vanagon::Driver.new(platform, project, options.merge({ :components =>
 artifact.verbose = true if options[:verbose]
 artifact.resume = true if options[:resume]
 
-artifact.devkit_run
+artifact.dev_run

--- a/bin/vanagon_devkit
+++ b/bin/vanagon_devkit
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+
+# *****NOTE:
+# This is functionally almost identical to the devkit binary. and should be deprecated
+# in the near future by just updating devkit
+#
+
+require 'vanagon'
+
+optparse = Vanagon::OptParse.new("#{File.basename(__FILE__)} <project-name> <platform-name> [<component-name>...] [options]",
+                                 [:workdir, :configdir, :target, :engine, :resume])
+options = optparse.parse! ARGV
+
+project = ARGV[0]
+platform = ARGV[1]
+components = ARGV.drop(2)
+
+if project.nil? or platform.nil?
+  warn "project and platform are both required arguments."
+  puts optparse
+  exit 1
+end
+
+artifact = Vanagon::Driver.new(platform, project, options.merge({ :components => components }))
+artifact.verbose = true if options[:verbose]
+artifact.resume = true if options[:resume]
+
+artifact.devkit_run

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -121,7 +121,7 @@ class Vanagon
     # This function is temporary and should be used with care. It is meant to
     # facilitate vanagon development and should be deprecated
     #     Sean M.    3/28/16
-    def devkit_run
+    def dev_run
           # Simple sanity check for the project
       if @project.version.nil? or @project.version.empty?
         raise Vanagon::Error, "Project requires a version set, all is lost."

--- a/lib/vanagon/optparse.rb
+++ b/lib/vanagon/optparse.rb
@@ -10,6 +10,7 @@ class Vanagon
         :engine => ['-e ENGINE', '--engine ENGINE', "A custom engine to use (defaults to the pooler) [base, local, docker, pooler currently supported]"],
         :skipcheck => ['--skipcheck', 'Skip the `check` stage when building components'],
         :preserve => ['-p', '--preserve', 'Whether to tear down the VM on success or not (defaults to false)'],
+        :resume => ['-r', '--resume', 'Resumes a currently setup engine in dev_build'],
         :verbose => ['-v', '--verbose', 'Verbose output (does nothing)'],
       }
 

--- a/vanagon.gemspec
+++ b/vanagon.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('lock_manager', '>= 0')
   gem.require_path = 'lib'
   gem.bindir       = 'bin'
-  gem.executables  = ['build', 'ship', 'repo', 'devkit']
+  gem.executables  = ['build', 'ship', 'repo', 'devkit', 'vanagon_devkit']
 
   # Ensure the gem is built out of versioned files
   gem.files = Dir['{bin,lib,spec,resources}/**/*', 'README*', 'LICENSE*'] & `git ls-files -z`.split("\0")

--- a/vanagon.gemspec
+++ b/vanagon.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('lock_manager', '>= 0')
   gem.require_path = 'lib'
   gem.bindir       = 'bin'
-  gem.executables  = ['build', 'ship', 'repo', 'devkit', 'vanagon_devkit']
+  gem.executables  = ['build', 'ship', 'repo', 'devkit', 'dev_build']
 
   # Ensure the gem is built out of versioned files
   gem.files = Dir['{bin,lib,spec,resources}/**/*', 'README*', 'LICENSE*'] & `git ls-files -z`.split("\0")


### PR DESCRIPTION
#As to not deprecate the current devkit
binary (that others may be using) I have
created a new dev_build that allows the
following:

* @engine.startup no longer has to run
every time, if you specify --target and -r
vanagon will just skip startup with
the assumption this target is an already running
engine. This essentially allows you to "resume"
a vanagon run

* for every step in driver the devkit will
ask if you want to execute the step "y/yes"
skip the step "s/skip" or stop running "n/no"

* The preserve flag is unecessary for the
devkit since it will ask before doing
@engine.teardown

usage for vanagon_devkit is the same as always with
the optional --target doing something different:

bundle exec vanagon_devkit <project> <platform> < --target will
resume an engine>