### PR TITLE
(RE-6794) Add conflicts capabilities to our deb and rpm packages

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -10,7 +10,7 @@ class Vanagon
     attr_accessor :name, :version, :source, :url, :configure, :build, :check, :install
     attr_accessor :environment, :extract_with, :dirname, :build_requires, :build_dir
     attr_accessor :settings, :platform, :patches, :requires, :service, :options
-    attr_accessor :directories, :replaces, :provides, :cleanup_source
+    attr_accessor :directories, :replaces, :provides, :conflicts, :cleanup_source
     attr_accessor :sources, :preinstall_actions, :postinstall_actions
     attr_accessor :preremove_actions, :postremove_actions, :license
 
@@ -57,6 +57,7 @@ class Vanagon
       @directories = []
       @replaces = []
       @provides = []
+      @conflicts = []
       @environment = {}
       @sources = []
       @preinstall_actions = []

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -151,6 +151,16 @@ class Vanagon
         @component.provides << OpenStruct.new(:provide => provide, :version => version)
       end
 
+      # Indicates that this component conflicts with another package,
+      # so both cannot be installed at the same time. Conflicts can be
+      # collected and used by the project and package.
+      #
+      # @param pkgname [String] name of the package which conflicts with this component
+      # @param version [String] the version of the package that conflicts with this component
+      def conflicts(pkgname, version = nil)
+        @component.conflicts << OpenStruct.new(:pkgname => pkgname, :version => version)
+      end
+
       # install_service adds the commands to install the various files on
       # disk during the package build and registers the service with the project
       #

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -11,7 +11,7 @@ class Vanagon
     attr_accessor :version, :directories, :license, :description, :vendor
     attr_accessor :homepage, :requires, :user, :repo, :noarch, :identifier
     attr_accessor :cleanup, :version_file, :release, :replaces, :provides
-    attr_accessor :bill_of_materials, :retry_count, :timeout
+    attr_accessor :conflicts, :bill_of_materials, :retry_count, :timeout
 
     # Loads a given project from the configdir
     #
@@ -50,6 +50,7 @@ class Vanagon
       @release = "1"
       @replaces = []
       @provides = []
+      @conflicts = []
     end
 
     # Magic getter to retrieve settings in the project
@@ -99,6 +100,15 @@ class Vanagon
       replaces.push @replaces.flatten
       replaces.push @components.map(&:replaces).flatten
       replaces.flatten.uniq
+    end
+
+    # Collects all of the conflicts for the project and its components
+    def get_conflicts
+      # Including get_replaces in the conflicts list to provide backwards
+      # compatibility with previous behavior
+      conflicts = @components.flat_map(&:conflicts) + @conflicts + get_replaces
+      # Mash the whole thing down into a flat Array
+      conflicts.flatten.uniq
     end
 
     # Grabs a specific service based on which name is passed in

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -108,6 +108,16 @@ class Vanagon
         @project.provides << OpenStruct.new(:provide => provide, :version => version)
       end
 
+      # Indicates that this component conflicts with another package,
+      # so both cannot be installed at the same time. Conflicts can be
+      # collected and used by the project and package.
+      #
+      # @param pkgname [String] name of the package which conflicts with this component
+      # @param version [String] the version of the package that conflicts with this component
+      def conflicts(pkgname, version = nil)
+        @project.conflicts << OpenStruct.new(:pkgname => pkgname, :version => version)
+      end
+
       # Sets the version for the project. Mainly for use in packaging.
       #
       # @param ver [String] version of the project

--- a/resources/deb/control.erb
+++ b/resources/deb/control.erb
@@ -11,7 +11,7 @@ Architecture: <%= @noarch ? 'all' : 'any' %>
 Section: admin
 Priority: optional
 Replaces: <%= get_replaces.map { |replace| "#{replace.replacement} #{replace.version ? "(<< #{replace.version})" : ""}" }.join(", ") %>
-Conflicts: <%= get_replaces.map { |replace| "#{replace.replacement} #{replace.version ? "(<< #{replace.version})" : ""}" }.join(", ") %>
+Conflicts: <%= get_conflicts.map { |conflict| "#{conflict.pkgname} #{conflict.version ? "(<< #{conflict.version})" : ""}" }.join(", ") %>
 Depends: <%= get_requires.join(", ") %>
 Provides: <%= get_provides.map { |prov| prov.provide }.join(", ") %>
 Description: <%= @description.lines.first.chomp %>

--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -48,8 +48,11 @@ Requires: chkconfig
 <%- end -%>
 
 <%- get_replaces.each do |replace| -%>
-Conflicts: <%= replace.replacement %><%= replace.version ? " < #{replace.version}" : "" %>
 Obsoletes: <%= replace.replacement %><%= replace.version ? " < #{replace.version}" : "" %>
+<%- end -%>
+
+<%- get_conflicts.each do |conflict| -%>
+Conflicts: <%= conflict.pkgname %><%= conflict.version ? " < #{conflict.version}" : "" %>
 <%- end -%>
 
 <%- get_provides.each do |prov| -%>

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -269,6 +269,23 @@ end" }
     end
   end
 
+  describe '#conflicts' do
+    it 'adds the package conflict to the list of conflicts' do
+      comp = Vanagon::Component::DSL.new('conflicts-test', {}, {})
+      comp.conflicts('thing1')
+      comp.conflicts('thing2')
+      expect(comp._component.conflicts.first.pkgname).to eq('thing1')
+      expect(comp._component.conflicts.last.pkgname).to eq('thing2')
+    end
+
+    it 'supports versioned conflicts' do
+      comp = Vanagon::Component::DSL.new('conflicts-test', {}, {})
+      comp.conflicts('thing1', '1.2.3')
+      expect(comp._component.conflicts.first.pkgname).to eq('thing1')
+      expect(comp._component.conflicts.first.version).to eq('1.2.3')
+    end
+  end
+
   describe '#add_actions' do
     it 'adds the corect preinstall action to the component' do
       comp = Vanagon::Component::DSL.new('action-test', {}, dummy_platform_sysv)

--- a/spec/lib/vanagon/project/dsl_spec.rb
+++ b/spec/lib/vanagon/project/dsl_spec.rb
@@ -167,6 +167,37 @@ end" }
     end
   end
 
+  describe "#conflicts" do
+    it 'adds the package conflict to the list of conflicts' do
+      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj.instance_eval(project_block)
+      proj.conflicts('thing1')
+      proj.conflicts('thing2')
+      expect(proj._project.get_conflicts.count).to eq(2)
+      expect(proj._project.get_conflicts.first.pkgname).to eq('thing1')
+      expect(proj._project.get_conflicts.last.pkgname).to eq('thing2')
+     end
+
+    it 'supports versioned conflicts' do
+      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj.instance_eval(project_block)
+      proj.conflicts('thing1', '1.2.3')
+      expect(proj._project.get_conflicts.count).to eq(1)
+      expect(proj._project.get_conflicts.first.pkgname).to eq('thing1')
+      expect(proj._project.get_conflicts.first.version).to eq('1.2.3')
+     end
+
+    it 'gets rid of duplicates' do
+      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj.instance_eval(project_block)
+      proj.conflicts('thing1', '1.2.3')
+      proj.conflicts('thing1', '1.2.3')
+      expect(proj._project.get_conflicts.count).to eq(1)
+      expect(proj._project.get_conflicts.first.pkgname).to eq('thing1')
+      expect(proj._project.get_conflicts.first.version).to eq('1.2.3')
+    end
+  end
+
   describe "#component" do
     let(:project_block) {
 "project 'test-fixture' do |proj|


### PR DESCRIPTION
Tested by adding conflicts to pl-tar and verifying with the dpkg and rpm commands that Conflicts were set appropriately.