### PR TITLE
(RE-6100) OS X Service Postinstall fixup

### DIFF
--- a/resources/osx/postinstall.erb
+++ b/resources/osx/postinstall.erb
@@ -11,6 +11,7 @@ else
 fi
 <%- end -%>
 
+<%- if get_services -%>
 if [ -d "/tmp/.<%= @name %>.upgrade" ]; then
 <%- get_services.each do |service| -%>
   if [ -f "/tmp/.<%= @name %>.upgrade/<%= service.name %>" ]; then
@@ -18,6 +19,7 @@ if [ -d "/tmp/.<%= @name %>.upgrade" ]; then
   fi
 <%- end -%>
 fi
+<%- end -%>
 
 <%= File.read("resources/osx/postinstall-extras") if File.exist?("resources/osx/postinstall-extras") %>
 


### PR DESCRIPTION
Vanagon should not try to generate postinstall service stanzas
for OS X packages when there are no services to worry about.
Vanagon::Project#get_services will return an empty array if there
are no services, which evaluates to falsey in an `if` statement
so this should be a safe way to prevent this script from accidentally
generating invalid syntax in the Bash if/then block.