### PR TITLE
(RE-6100) Rub some booleans on the erb

### DIFF
--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -102,6 +102,10 @@ class Vanagon
       replaces.flatten.uniq
     end
 
+    def has_replaces?
+      !get_replaces.empty?
+    end
+
     # Collects all of the conflicts for the project and its components
     def get_conflicts
       # Including get_replaces in the conflicts list to provide backwards
@@ -109,6 +113,10 @@ class Vanagon
       conflicts = @components.flat_map(&:conflicts) + @conflicts + get_replaces
       # Mash the whole thing down into a flat Array
       conflicts.flatten.uniq
+    end
+
+    def has_conflicts?
+      !get_conflicts.empty?
     end
 
     # Grabs a specific service based on which name is passed in
@@ -135,6 +143,10 @@ class Vanagon
       provides.push @provides.flatten
       provides.push @components.map(&:provides).flatten
       provides.flatten.uniq
+    end
+
+    def has_provides?
+      !get_provides.empty?
     end
 
     # Collects the preinstall packaging actions for the project and it's components
@@ -207,6 +219,10 @@ class Vanagon
     # @return [Array] array of configfiles installed by components of the project
     def get_configfiles
       @components.map(&:configfiles).flatten.uniq
+    end
+
+    def has_configfiles?
+      !get_configfiles.empty?
     end
 
     # Collects any directories declared by the project and components

--- a/resources/osx/postinstall.erb
+++ b/resources/osx/postinstall.erb
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+<%- if has_configfiles? -%>
 # Move any new configfiles into place
 <%- get_configfiles.each do |config|
 dest_file = config.path.gsub(/\.pristine$/, '') -%>
@@ -10,8 +11,9 @@ else
   mv '<%= config.path %>' '<%= dest_file %>'
 fi
 <%- end -%>
+<%- end -%>
 
-<%- if get_services -%>
+<%- if has_services? -%>
 if [ -d "/tmp/.<%= @name %>.upgrade" ]; then
 <%- get_services.each do |service| -%>
   if [ -f "/tmp/.<%= @name %>.upgrade/<%= service.name %>" ]; then

--- a/resources/osx/preinstall.erb
+++ b/resources/osx/preinstall.erb
@@ -13,6 +13,7 @@ if [ -n "$foundpkg" ]; then
   mkdir -p "/tmp/.<%= @name %>.upgrade"
   chmod 0700 "/tmp/.<%= @name %>.upgrade"
 
+<%- if has_services? -%>
 <%- get_services.each do |service| -%>
   if /bin/launchctl list "<%= service.name %>" &> /dev/null; then
     touch "/tmp/.<%= @name %>.upgrade/<%= service.name %>"
@@ -22,6 +23,8 @@ if [ -n "$foundpkg" ]; then
     /bin/rm "$oldbom"
   fi
 <%- end -%>
+<%- end -%>
 fi
+
 
 <%= File.read("resources/osx/preinstall-extras") if File.exist?("resources/osx/preinstall-extras") %>


### PR DESCRIPTION
My previous OS X post-install fix was incomplete. This expands the use of the `#has_<values>?` boolean methods to help ensure that we don't accidentally construct empty `if`/`else` stanzas in our pre & post install scripts.

This is needed to help the PE Client Tools .pkg install successfully on OS X.