### PR TITLE
(RE-6882) do not copy package Replaces into Conflicts

### DIFF
--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -104,9 +104,7 @@ class Vanagon
 
     # Collects all of the conflicts for the project and its components
     def get_conflicts
-      # Including get_replaces in the conflicts list to provide backwards
-      # compatibility with previous behavior
-      conflicts = @components.flat_map(&:conflicts) + @conflicts + @replaces
+      conflicts = @components.flat_map(&:conflicts) + @conflicts
       # Mash the whole thing down into a flat Array
       conflicts.flatten.uniq
     end


### PR DESCRIPTION
There was no need to follow previous behavior of making Conflicts
include packages specified in Replaces, so we are now keeping each
definition separate.