### PR TITLE
Reject empty strings so we dont get bad versions

### DIFF
--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -138,7 +138,7 @@ class Vanagon
       #
       def version_from_git
         version = Vanagon::Utilities.git_version(File.expand_path("..", Vanagon::Driver.configdir))
-        @project.version = version.split('-').reject{ |s| s.empty? }.join('.')
+        @project.version = version.split('-').reject(&:empty?).join('.')
       end
 
       # Sets the vendor for the project. Used in packaging artifacts.

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -137,7 +137,8 @@ class Vanagon
       # and reachable from the current commit in that repository.
       #
       def version_from_git
-        @project.version = Vanagon::Utilities.git_version(File.expand_path("..", Vanagon::Driver.configdir)).gsub('-', '.')
+        version = Vanagon::Utilities.git_version(File.expand_path("..", Vanagon::Driver.configdir))
+        @project.version = version.split('-').reject{ |s| s.empty? }.join('.')
       end
 
       # Sets the vendor for the project. Used in packaging artifacts.

--- a/spec/lib/vanagon/project/dsl_spec.rb
+++ b/spec/lib/vanagon/project/dsl_spec.rb
@@ -17,6 +17,14 @@ end" }
       proj.version_from_git
       expect(proj._project.version).to eq('1.2.3.1234')
     end
+    it 'sets the version based on the git describe with multiple dashes' do
+      expect(Vanagon::Driver).to receive(:configdir).and_return(configdir)
+      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj.instance_eval(project_block)
+      expect(Vanagon::Utilities).to receive(:git_version).with(File.expand_path('..', configdir)).and_return('1.2.3---1234')
+      proj.version_from_git
+      expect(proj._project.version).to eq('1.2.3.1234')
+    end
   end
 
   describe '#directory' do


### PR DESCRIPTION
We have tags that use double dashes, so this will make a version of .. so this fails when trying to make the RPM. 