### PR TITLE
(ORCH-1293)add remote_workdir flag and support workdir with build

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ target. If more targets are specified than platforms, the extra will be ignored.
 Specifies a directory where the sources should be placed and builds performed.
 Defaults to a temporary directory created with Ruby's Dir.mktmpdir.
 
+##### --remote_workdir DIR
+Specifies a directory where the sources should be placed and builds performed
+on the target. Defaults to a temporary directory created with
+mktemp.
+
 ##### -c DIR, --configdir DIR
 Specifies where project configuration is found. Defaults to $pwd/configs.
 

--- a/bin/build
+++ b/bin/build
@@ -2,7 +2,7 @@
 load File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "vanagon.rb"))
 
 optparse = Vanagon::OptParse.new("#{File.basename(__FILE__)} <project-name> <platform-name> [<target>] [options]",
-                                 [:workdir, :configdir, :engine, :preserve, :verbose, :skipcheck])
+                                 [:workdir, :remote_workdir, :configdir, :engine, :preserve, :verbose, :skipcheck])
 options = optparse.parse! ARGV
 
 project = ARGV[0]

--- a/bin/devkit
+++ b/bin/devkit
@@ -2,7 +2,7 @@
 load File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "vanagon.rb"))
 
 optparse = Vanagon::OptParse.new("#{File.basename(__FILE__)} <project-name> <platform-name> [<component-name>...] [options]",
-                                 [:workdir, :configdir, :target, :engine])
+                                 [:workdir, :remote_workdir, :configdir, :target, :engine])
 options = optparse.parse! ARGV
 
 project = ARGV[0]

--- a/lib/vanagon/engine/docker.rb
+++ b/lib/vanagon/engine/docker.rb
@@ -5,7 +5,7 @@ class Vanagon
     class Docker < Base
       # Both the docker_image and the docker command itself are required for
       # the docker engine to work
-      def initialize(platform, target = nil)
+      def initialize(platform, target = nil, opts = {})
         @docker_cmd = Vanagon::Utilities.find_program_on_path('docker')
         @name = 'docker'
         super

--- a/lib/vanagon/engine/hardware.rb
+++ b/lib/vanagon/engine/hardware.rb
@@ -50,7 +50,7 @@ class Vanagon
         @lockman.unlock(@target, VANAGON_LOCK_USER)
       end
 
-      def initialize(platform, target)
+      def initialize(platform, target, opts = {})
         Vanagon::Driver.logger.debug "Hardware engine invoked."
         @name = 'hardware'
         @platform = platform

--- a/lib/vanagon/engine/local.rb
+++ b/lib/vanagon/engine/local.rb
@@ -6,7 +6,7 @@ class Vanagon
   class Engine
     class Local < Base
 
-      def initialize(platform, target = nil)
+      def initialize(platform, target = nil, opts = {})
         @target = target || "local machine"
         @name = 'local'
         super

--- a/lib/vanagon/engine/pooler.rb
+++ b/lib/vanagon/engine/pooler.rb
@@ -6,7 +6,7 @@ class Vanagon
       attr_reader :token
 
       # The vmpooler_template is required to use the pooler engine
-      def initialize(platform, target = nil)
+      def initialize(platform, target = nil, opts = {})
         @pooler = "http://vmpooler.delivery.puppetlabs.net"
         @token = load_token
         super

--- a/lib/vanagon/optparse.rb
+++ b/lib/vanagon/optparse.rb
@@ -5,6 +5,7 @@ class Vanagon
 
     FLAGS = {
         :workdir => ['-w DIR', '--workdir DIR', "Working directory where build source should be put (defaults to a tmpdir)"],
+        :remote_workdir => ['--remote_workdir DIR', "Working directory where build source should be put on the remote host (defaults to a tmpdir)"],
         :configdir => ['-c', '--configdir DIR', 'Configs dir (defaults to $pwd/configs)'],
         :target => ['-t HOST', '--target HOST', 'Configure a target machine for build and packaging (defaults to grabbing one from the pooler)'],
         :engine => ['-e ENGINE', '--engine ENGINE', "A custom engine to use (defaults to the pooler) [base, local, docker, pooler currently supported]"],


### PR DESCRIPTION
Previously the build command would ignore the workdir this is now fixed.
This commit also adds a remote_workdir flag to allow users to specify
the workdir on the target. This workdir will not be cleaned up since the
main reason to specify a workdir is to preserve it.