### PR TITLE
(RE-6739) Add service type for Solaris services

### DIFF
--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -214,7 +214,7 @@ class Vanagon
         end
 
         # Register the service for use in packaging
-        @component.service = OpenStruct.new(:name => service_name, :service_file => target_service_file)
+        @component.service = OpenStruct.new(:name => service_name, :service_file => target_service_file, :type => service_type)
       end
 
       # Copies a file from source to target during the install phase of the component

--- a/resources/solaris/11/p5m.erb
+++ b/resources/solaris/11/p5m.erb
@@ -44,7 +44,7 @@ depend fmri=pkg:/<%= requirement %> type=require
   <transform dir path=<%= strip_and_escape(File.dirname(service.service_file)) -%>$ -> drop>
 <%- end -%>
 <transform dir path=(var|lib)/svc/manifest$ -> drop>
-set name=org.opensolaris.smf.fmri <%= get_services.map {|service| "value=svc:/#{service.name}"}.join(" ") %>
+set name=org.opensolaris.smf.fmri <%= get_services.map {|service| "value=svc:/#{service.type}/#{service.name}"}.join(" ") %>
 <%- end -%>
 
 <%- unless @bill_of_materials -%>
@@ -56,7 +56,7 @@ set name=org.opensolaris.smf.fmri <%= get_services.map {|service| "value=svc:/#{
 # Preserve the old conf file on upgrade, restart services on config file change
 <transform file path=<%= strip_and_escape(config.path) %>$ -> add preserve renamenew>
   <%- get_services.each do |service| -%>
-    <transform file path=<%= strip_and_escape(config.path) %>$ -> add restart_fmri <%= "svc:/#{service.name}:*" %> >
+    <transform file path=<%= strip_and_escape(config.path) %>$ -> add restart_fmri <%= "svc:/#{service.type}/#{service.name}:*" %> >
   <%- end -%>
 <%- end -%>
 


### PR DESCRIPTION
Currently, the solaris smf service uses a service type,
but the type is not being referenced in the calls to
the smf service handler.

This adds the service type to the service data structure
and uses it in the solaris smf service calls.