### PR TITLE
(maint) add retry_count to dsl

### DIFF
--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -230,6 +230,11 @@ class Vanagon
       def bill_of_materials(target)
         @project.bill_of_materials = Vanagon::Common::Pathname.new(target)
       end
+
+      # Counter for the number of times a project should retry a task
+      def retry_count(retry_count)
+        @project.retry_count = retry_count
+      end
     end
   end
 end


### PR DESCRIPTION
Because of the way we are using dsl objects in vanagon,
if you want an attribute to be accessible you need to
add a corresponding function to the dsl.rb in order to
set the attribute.

project.retry_count had no such function and so it was
not accessible