### PR TITLE
(GREAT IDEA IS GREAT) Implement registry for Engines

### DIFF
--- a/lib/vanagon/engine.rb
+++ b/lib/vanagon/engine.rb
@@ -1,0 +1,67 @@
+class Vanagon
+  class Engine
+    # Find all potential Engines bundled with Vanagon and save them for later
+    @default_engines = Dir.glob(File.join(File.dirname(__FILE__), "engine", "*rb"))
+    # Initialize a Hash to store information on registered Engines
+    # once they're successfully initialized
+    @registered_engines = {}
+
+    # Each Engine must define these parameters to pass validation.
+    # The Array is frozen after initialization because this is
+    # probably the closest we're going to get to anything resembling
+    # a Contract in Ruby.
+    @required_attributes = %w(engine_name desc remote teardown).freeze
+
+    # @param engine [Class] an instance of an Engine subclass to register
+    # @return [Hash] the new value of @registered_engines, containing the
+    #   Registry information for `engine`
+    def self.register(engine)
+      validate(engine)
+      @registered_engines[engine.engine_name.to_sym] = engine
+    end
+
+    # @return [Hash] all Engines currently registered
+    def self.registered_engines
+      @registered_engines
+    end
+
+    # Ensures that a new Engine defines the attributes required for registration.
+    # @param engine [Class] an instance of an Engine subclass to validate
+    # @return [True] if an engine passes validation
+    # @raise [Vanagon::Error] a list of errors that are raised if an engine
+    #   doesn't define a required attribute
+    def self.validate(engine)
+      attrs = check_required_attributes(engine)
+      return true if attrs.empty?
+      raise Vanagon::Error,
+            "The following required attributes were not set in '#{engine.engine_name}': #{attrs.join(', ')}."
+    end
+
+    def self.register_engines!(engines = @default_engines)
+      [*engines].flatten.each do |engine|
+        require engine
+      end
+    end
+
+    # def initialize(engine_type, platform, target)
+    #   self.class.registered_engines[engine_type]
+    # end
+
+    class << self
+      # Validate that all required attributes are defined for a given
+      # Engine instance. Will log a warning for each missing attribute.
+      # @param engine [Class] an instance of an Engine:: subclass to validate
+      # @return [Array] a list of all of an Engine's missing attributes
+      # @private
+      def check_required_attributes(engine)
+        @required_attributes.each_with_object([]) do |attr, arr|
+          if engine.send(attr).nil?
+            warn "#{engine.name} is missing required attributes #{attr}"
+            arr << attr
+          end
+        end
+      end
+      private :check_required_attributes
+    end
+  end
+end

--- a/lib/vanagon/engine/base.rb
+++ b/lib/vanagon/engine/base.rb
@@ -1,10 +1,54 @@
 require 'vanagon/utilities'
 require 'vanagon/errors'
+require 'vanagon/engine'
 
 class Vanagon
   class Engine
+    # Base is the Engine subclass that all other Engines subclasses should inherit from.
+    # It defines the general interface of an Engine, and gives them the ability to
+    # register themselves with the Vanagon::Engine class. Without inheriting from Base,
+    # a new Engine has to completely reimplement the loosely binding Constract of
+    # required attributes & methods.
     class Base
       attr_accessor :target, :remote_workdir, :name
+
+      class << self
+        attr_accessor :engine_name, :desc, :remote, :teardown
+
+        # # Provide a formatted hash that Vanagon::Engine will use
+        # # to add an Engine subclass to the global Engine registry.
+        # # @return [Hash] the Registry information for `engine`, derived
+        # #   from the values of @engine_name, @desc, @remote, and @teardown
+        # def registry
+        #   {
+        #     engine_name.to_sym => {
+        #       desc: desc, remote: remote, teardown: teardown
+        #     }
+        #   }
+        # end
+      end
+
+      # This Engine has a name, which will be used as an index key
+      # when this Engine is registered.
+      @engine_name = "base"
+      # A description of this Engine.
+      @desc = "Pure SSH backend; no teardown defined"
+      # Whether or not this Engine is remote/relies on a remote host.
+      @remote = true
+      # Whether or not this Engine supports teardown at the end
+      # of a build.
+      @teardown = false
+
+      # @return [Boolean] whether or not this engine relies
+      #   on a remote host
+      def self.remote?
+        !!remote
+      end
+      # @return [Boolean] whether or not this engine supports
+      #   teardown at the end of a build
+      def self.teardown?
+        !!teardown
+      end
 
       def initialize(platform, target = nil)
         @platform = platform
@@ -77,6 +121,11 @@ class Vanagon
         else
           raise Vanagon::Error, "The following required attributes were not set in '#{@platform.name}': #{missing_attrs.join(', ')}."
         end
+
+        # This should be the last thing that an Engine declares because
+        # if it's too early in the call-stack, then the attr_accessors
+        # that registration relies on aren't defined yet.
+        Vanagon::Engine.register self
       end
     end
   end

--- a/lib/vanagon/engine/docker.rb
+++ b/lib/vanagon/engine/docker.rb
@@ -3,6 +3,11 @@ require 'vanagon/engine/base'
 class Vanagon
   class Engine
     class Docker < Base
+      @engine_name = "docker"
+      @desc = "Build inside of a docker container"
+      @remote = false
+      @teardown = true
+
       # Both the docker_image and the docker command itself are required for
       # the docker engine to work
       def initialize(platform, target = nil)
@@ -35,6 +40,8 @@ class Vanagon
       rescue Vanagon::Error => e
         warn "There was a problem tearing down the docker container #{@platform.docker_image}-builder (#{e.message})."
       end
+
+      Vanagon::Engine.register self
     end
   end
 end

--- a/lib/vanagon/engine/hardware.rb
+++ b/lib/vanagon/engine/hardware.rb
@@ -6,12 +6,15 @@ LOCK_MANAGER_HOST = ENV['LOCK_MANAGER_HOST'] || 'redis'
 LOCK_MANAGER_PORT = ENV['LOCK_MANAGER_PORT'] || 6379
 VANAGON_LOCK_USER = ENV['USER']
 
-
 class Vanagon
   class Engine
     # Class to use when building on a hardware device (e.g. AIX, Switch, etc)
-    #
     class Hardware < Base
+
+      @engine_name = "base"
+      @desc = "Build on a specific remote taget host (uses lock_manager to lock the host)"
+      @remote = true
+      @teardown = true
 
       # This method is used to obtain a vm to build upon
       # For the base class we just return the target that was passed in
@@ -60,6 +63,8 @@ class Vanagon
         super
         @required_attributes << "build_hosts"
       end
+
+      Vanagon::Engine.register self
     end
   end
 end

--- a/lib/vanagon/engine/local.rb
+++ b/lib/vanagon/engine/local.rb
@@ -6,6 +6,11 @@ class Vanagon
   class Engine
     class Local < Base
 
+      @engine_name = "local"
+      @desc = "Build on the local machine (will pollute the file system); platform name must match the local machine"
+      @remote = false
+      @teardown = false
+
       def initialize(platform, target = nil)
         @target = target || "local machine"
         @name = 'local'
@@ -31,6 +36,8 @@ class Vanagon
         FileUtils.mkdir_p("output")
         FileUtils.cp_r(Dir.glob("#{@remote_workdir}/output/*"), "output/")
       end
+
+      Vanagon::Engine.register self
     end
   end
 end

--- a/lib/vanagon/engine/pooler.rb
+++ b/lib/vanagon/engine/pooler.rb
@@ -5,6 +5,11 @@ class Vanagon
     class Pooler < Base
       attr_reader :token
 
+      @engine_name = "pooler"
+      @desc = "Check out a VM from Puppet's VM Pooler and build on it"
+      @remote = true
+      @teardown = true
+
       # The vmpooler_template is required to use the pooler engine
       def initialize(platform, target = nil)
         @pooler = "http://vmpooler.delivery.puppetlabs.net"
@@ -81,6 +86,8 @@ class Vanagon
         Vanagon::Driver.logger.info "#{@target} could not be destroyed (#{e.message})"
         warn "#{@target} could not be destroyed (#{e.message})"
       end
+
+      Vanagon::Engine.register self
     end
   end
 end

--- a/spec/lib/vanagon/engine/hardware_spec.rb
+++ b/spec/lib/vanagon/engine/hardware_spec.rb
@@ -6,7 +6,7 @@ require 'logger'
 # Haus, I added this, cause it prevented errors.
 class Vanagon
   class Driver
-    @@logger = Logger.new('/dev/null')
+    @logger = Logger.new('/dev/null')
   end
 end
 


### PR DESCRIPTION
This is something I talked about with @McdonaldSeanp on Friday. I thought maybe it had some legs,
so I hacked it out over a couple of nights. As each Engine is defined, it will register itself and a rough outline of its capabilities with `Vanagon::Engine` (as well as allow Engines to be validated).

I'm still working on this, but it's a potentially breaking change so I've opened it up for comments and iteration.