### PR TITLE
(maint) fix broken load_engine_object method

### DIFF
--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -43,7 +43,7 @@ class Vanagon
 
     def load_engine_object(engine_type, platform, target)
       require "vanagon/engine/#{engine_type}"
-      Object::const_get("Vanagon::Engine::#{engine_type.capitalize}").new(platform, target)
+      @engine = Object::const_get("Vanagon::Engine::#{engine_type.capitalize}").new(platform, target)
     rescue
       fail "No such engine '#{engine_type.capitalize}'"
     end


### PR DESCRIPTION
As pointed out by @cwood , the load_engine_object method is missing an
assignment to engine.