### PR TITLE
RFC (RE-7015) Add cross_compiled and cross_compiled_linux platform flags

### DIFF
--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -3,7 +3,8 @@ require 'vanagon/platform/dsl'
 class Vanagon
   class Platform
     attr_accessor :make, :servicedir, :defaultdir, :provisioning, :num_cores, :tar
-    attr_accessor :build_dependencies, :name, :vmpooler_template, :cflags, :ldflags, :settings
+    attr_accessor :build_dependencies, :name, :cross_compiled, :cross_compiled_linux
+    attr_accessor :vmpooler_template, :cflags, :ldflags, :settings
     attr_accessor :servicetype, :patch, :architecture, :codename, :os_name, :os_version
     attr_accessor :docker_image, :ssh_port, :rpmbuild, :install, :platform_triple
     attr_accessor :target_user, :package_type, :find, :sort, :build_hosts, :copy

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -198,6 +198,20 @@ class Vanagon
       # Because single vs plural is annoying to remember
       alias_method :build_host, :build_hosts
 
+      # Set a flag whether this platform is cross-compiled
+      #
+      # @param type [Boolean] true if this platform is cross-compiled
+      def cross_compiled(flag)
+        @platform.cross_compiled = true unless flag.nil?
+      end
+
+      # Set a flag whether this is a cross-compiled Linux platform
+      #
+      # @param type [Boolean] true if this is a cross-compiled Linux platform
+      def cross_compiled_linux(flag)
+        @platform.cross_compiled_linux = true unless flag.nil?
+      end
+
       # Set the name of this platform as the vm pooler expects it
       #
       # @param name [String] name of the target template to use from the vmpooler


### PR DESCRIPTION
With all the cross-compiling we're now doing, these flags will help us
to refactor the puppet-agent component configs to improve readability.