### PR TITLE
(maint) timeout not set in project dsl

### DIFF
--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -85,6 +85,13 @@ class Vanagon
         @project.homepage = page
       end
 
+      # Sets the timeout for the project retry logic
+      #
+      # @param page [Integer] timeout in seconds
+      def timeout(to)
+        @project.timeout = to
+      end
+
       # Sets the run time requirements for the project. Mainly for use in packaging.
       #
       # @param req [String] of requirements of the project


### PR DESCRIPTION
for any attribute of the project object we require a subsequent method in the
dsl for project. This was missing for the timeout attribute