### PR TITLE
(RE-7015) Add is_cross_compiled utility matcher methods

### DIFF
--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -6,7 +6,7 @@ class Vanagon
     attr_accessor :build_dependencies, :name, :vmpooler_template, :cflags, :ldflags, :settings
     attr_accessor :servicetype, :patch, :architecture, :codename, :os_name, :os_version
     attr_accessor :docker_image, :ssh_port, :rpmbuild, :install, :platform_triple
-    attr_accessor :target_user, :package_type, :find, :sort, :build_hosts, :copy
+    attr_accessor :target_user, :package_type, :find, :sort, :build_hosts, :copy, :cross_compiled
 
     # Platform names currently contain some information about the platform. Fields
     # within the name are delimited by the '-' character, and this regex can be used to
@@ -105,6 +105,7 @@ class Vanagon
       @find ||= "find"
       @sort ||= "sort"
       @copy ||= "cp"
+      @cross_compiled ||= false
     end
 
     # This allows instance variables to be accessed using the hash lookup syntax
@@ -238,6 +239,22 @@ class Vanagon
     # @return [true, false] true if it is a linux variety, false otherwise
     def is_linux?
       return (!is_windows? && !is_unix?)
+    end
+
+    # Utility matcher to determine if the platform is a cross-compiled variety
+    #
+    # @return [true, false] true if it is a cross-compiled variety, false otherwise
+    def is_cross_compiled?
+      return @cross_compiled
+    end
+
+    # Utility matcher to determine if the platform is a cross-compiled Linux variety.
+    # Many of the customizations needed to cross-compile for Linux are similar, so it's
+    # useful to group them together vs. other cross-compiled OSes.
+    #
+    # @return [true, false] true if it is a cross-compiled Linux variety, false otherwise
+    def is_cross_compiled_linux?
+      return (is_cross_compiled? && is_linux?)
     end
   end
 end

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -121,6 +121,13 @@ class Vanagon
         @platform.copy = copy_cmd
       end
 
+      # Set the cross_compiled flag for the platform
+      #
+      # @param cxx_flag [Boolean] True if this is a cross-compiled platform
+      def cross_compiled(cxx_flag)
+        @platform.cross_compiled = cxx_flag
+      end
+
       # Set the path to rpmbuild for the platform
       #
       # @param rpmbuild_cmd [String] Full path to rpmbuild with arguments to be used by default


### PR DESCRIPTION
With all the cross-compiling we're now doing, these methods will help us
to refactor vanagon-based component configs to improve readability.

Will remove the don't merge label once I've thoroughly tested this.