### PR TITLE
(CPR-336) Retry was not printing out error messages

### DIFF
--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -129,18 +129,24 @@ class Vanagon
     # @return [true] If the block succeeds, true is returned
     # @raise [Vanagon::Error] if the block fails after the retries are exhausted, an error is raised
     def retry_with_timeout(tries = 5, timeout = 1, &blk)
+      error = nil
       tries.times do
         Timeout::timeout(timeout) do
           begin
             blk.call
             return true
-          rescue
+          rescue => e
             warn 'An error was encountered evaluating block. Retrying..'
+            error = e
           end
         end
       end
 
-      raise Vanagon::Error, "Block failed maximum of #{tries} tries. Exiting.."
+      message = "Block failed maximum number of #{tries} tries"
+      message += "\n with error #{error.message}" unless error.nil?
+      message += "\nExiting..."
+      raise error, message unless error.nil?
+      raise Vanagon::Error, "Block failed maximum number of #{tries} tries"
     end
 
     # Simple wrapper around git command line executes the given commands and

--- a/spec/lib/vanagon/utilities_spec.rb
+++ b/spec/lib/vanagon/utilities_spec.rb
@@ -146,7 +146,7 @@ describe "Vanagon::Utilities" do
 
     it 'raises a Vanagon::Error if the command fails n times' do
       expect(Vanagon::Utilities).to receive(:remote_ssh_command).with(host, command, port).exactly(tries).times.and_raise(RuntimeError)
-      expect{ Vanagon::Utilities.retry_with_timeout(tries, timeout) { Vanagon::Utilities.remote_ssh_command(host, command, port) } }.to raise_error(Vanagon::Error)
+      expect{ Vanagon::Utilities.retry_with_timeout(tries, timeout) { Vanagon::Utilities.remote_ssh_command(host, command, port) } }.to raise_error(RuntimeError)
     end
 
     it 'returns true if the command succeeds within n times' do


### PR DESCRIPTION
Also, it seems like retry should raise the same error type as the
underlying command when available to avoid rogue rescues.