### PR TITLE
(QENG-3556) Add CLI for retrieving the type of build host

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -25,9 +25,5 @@ end
 platform_list.zip(target_list).each do |pair|
   platform, target = pair
   artifact = Vanagon::Driver.new(platform, project, options.merge({ :target => target }))
-
-  artifact.verbose = true if options[:verbose]
-  artifact.preserve = true if options[:preserve]
-
   artifact.run
 end

--- a/bin/build_host_info
+++ b/bin/build_host_info
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+require 'json'
+
+load File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "vanagon.rb"))
+
+optparse = Vanagon::OptParse.new("#{File.basename(__FILE__)} <project-name> <platform-name> [options]", [:workdir, :configdir, :engine])
+options = optparse.parse! ARGV
+
+project = ARGV[0]
+platforms = ARGV[1]
+
+if project.nil? or platforms.nil?
+  warn "project and platform are both required arguments."
+  puts optparse
+  exit 1
+end
+
+platforms.split(',').each do |platform|
+  driver = Vanagon::Driver.new(platform, project, options)
+  puts JSON.generate(driver.build_host_info)
+end

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -24,6 +24,7 @@ class Vanagon
 
       @platform = Vanagon::Platform.load_platform(platform, File.join(@@configdir, "platforms"))
       @project = Vanagon::Project.load_project(project, File.join(@@configdir, "projects"), @platform, components)
+      @project.settings[:verbose] = options[:verbose]
       @project.settings[:skipcheck] = options[:skipcheck]
       loginit('vanagon_hosts.log')
 

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -61,6 +61,10 @@ class Vanagon
       @@logger
     end
 
+    def build_host_info
+      { "name" => @engine.build_host_name, "engine" => @engine.name }
+    end
+
     # Returns the set difference between the build_requires and the components to get a list of external dependencies that need to be installed.
     def list_build_dependencies
       @project.components.map(&:build_requires).flatten.uniq - @project.components.map(&:name)

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -13,9 +13,9 @@ class Vanagon
     attr_accessor :platform, :project, :target, :workdir, :verbose, :preserve
     attr_accessor :timeout, :retry_count
 
-    def initialize(platform, project, options = { :configdir => nil, :target => nil, :engine => nil, :components => nil, :skipcheck => false })
-      @verbose = false
-      @preserve = false
+    def initialize(platform, project, options = { :configdir => nil, :target => nil, :engine => nil, :components => nil, :skipcheck => false, :verbose => false, :preserve => false })
+      @verbose = options[:verbose]
+      @preserve = options[:preserve]
 
       @@configdir = options[:configdir] || File.join(Dir.pwd, "configs")
       components = options[:components] || []

--- a/lib/vanagon/engine/base.rb
+++ b/lib/vanagon/engine/base.rb
@@ -18,6 +18,11 @@ class Vanagon
         'base'
       end
 
+      # Get the engine specific name of the host to build on
+      def build_host_name
+        raise Vanagon::Error, '#build_host_name has not been implemented for your engine.'
+      end
+
       # This method is used to obtain a vm to build upon
       # For the base class we just return the target that was passed in
       def select_target

--- a/lib/vanagon/engine/base.rb
+++ b/lib/vanagon/engine/base.rb
@@ -4,14 +4,18 @@ require 'vanagon/errors'
 class Vanagon
   class Engine
     class Base
-      attr_accessor :target, :remote_workdir, :name
+      attr_accessor :target, :remote_workdir
 
       def initialize(platform, target = nil)
         @platform = platform
         @required_attributes = ["ssh_port"]
         @target = target if target
         @target_user = @platform.target_user
-        @name = 'base'
+      end
+
+      # Get the engine name
+      def name
+        'base'
       end
 
       # This method is used to obtain a vm to build upon

--- a/lib/vanagon/engine/docker.rb
+++ b/lib/vanagon/engine/docker.rb
@@ -6,10 +6,15 @@ class Vanagon
       # Both the docker_image and the docker command itself are required for
       # the docker engine to work
       def initialize(platform, target = nil)
-        @docker_cmd = Vanagon::Utilities.find_program_on_path('docker')
-        @name = 'docker'
         super
+
+        @docker_cmd = Vanagon::Utilities.find_program_on_path('docker')
         @required_attributes << "docker_image"
+      end
+
+      # Get the engine name
+      def name
+        'docker'
       end
 
       # This method is used to obtain a vm to build upon using

--- a/lib/vanagon/engine/docker.rb
+++ b/lib/vanagon/engine/docker.rb
@@ -17,11 +17,21 @@ class Vanagon
         'docker'
       end
 
+      # Return the docker image name to build on
+      def build_host_name
+        if @build_host_name.nil?
+          validate_platform
+          @build_host_name = @platform.docker_image
+        end
+
+        @build_host_name
+      end
+
       # This method is used to obtain a vm to build upon using
       # a docker container.
       # @raise [Vanagon::Error] if a target cannot be obtained
       def select_target
-        Vanagon::Utilities.ex("#{@docker_cmd} run -d --name #{@platform.docker_image}-builder -p #{@platform.ssh_port}:22 #{@platform.docker_image}")
+        Vanagon::Utilities.ex("#{@docker_cmd} run -d --name #{build_host_name}-builder -p #{@platform.ssh_port}:22 #{build_host_name}")
         @target = 'localhost'
 
         # Wait for ssh to come up in the container
@@ -35,10 +45,10 @@ class Vanagon
       # This method is used to tell the vmpooler to delete the instance of the
       # vm that was being used so the pool can be replenished.
       def teardown
-        Vanagon::Utilities.ex("#{@docker_cmd} stop #{@platform.docker_image}-builder")
-        Vanagon::Utilities.ex("#{@docker_cmd} rm #{@platform.docker_image}-builder")
+        Vanagon::Utilities.ex("#{@docker_cmd} stop #{build_host_name}-builder")
+        Vanagon::Utilities.ex("#{@docker_cmd} rm #{build_host_name}-builder")
       rescue Vanagon::Error => e
-        warn "There was a problem tearing down the docker container #{@platform.docker_image}-builder (#{e.message})."
+        warn "There was a problem tearing down the docker container #{build_host_name}-builder (#{e.message})."
       end
     end
   end

--- a/lib/vanagon/engine/hardware.rb
+++ b/lib/vanagon/engine/hardware.rb
@@ -64,6 +64,19 @@ class Vanagon
       def name
         'hardware'
       end
+
+      # Get the first build host name to build on
+      def build_host_name
+        if @build_host_name.nil?
+          validate_platform
+          # For now, get the first build host. In the future, lock management
+          # will be pushed into the pooler (or something that wraps it), and
+          # the hardware engine can go away.
+          @build_host_name = @build_hosts.first
+        end
+
+        @build_host_name
+      end
     end
   end
 end

--- a/lib/vanagon/engine/hardware.rb
+++ b/lib/vanagon/engine/hardware.rb
@@ -51,14 +51,18 @@ class Vanagon
       end
 
       def initialize(platform, target)
+        super
+
         Vanagon::Driver.logger.debug "Hardware engine invoked."
-        @name = 'hardware'
-        @platform = platform
         @build_hosts = platform.build_hosts
         # Redis is the only backend supported in lock_manager currently
         @lockman = LockManager.new(type: 'redis', server: LOCK_MANAGER_HOST)
-        super
         @required_attributes << "build_hosts"
+      end
+
+      # Get the engine name
+      def name
+        'hardware'
       end
     end
   end

--- a/lib/vanagon/engine/local.rb
+++ b/lib/vanagon/engine/local.rb
@@ -22,6 +22,16 @@ class Vanagon
         'local'
       end
 
+      # Return the target name to build on
+      def build_host_name
+        if @build_host_name.nil?
+          validate_platform
+          @build_host_name = @target
+        end
+
+        @build_host_name
+      end
+
       # Dispatches the command for execution
       def dispatch(command, return_output = false)
         Vanagon::Utilities.local_command(command, return_command_output: return_output)
@@ -35,6 +45,7 @@ class Vanagon
         FileUtils.mkdir_p("output")
         FileUtils.cp_r(Dir.glob("#{@remote_workdir}/output/*"), "output/")
       end
+
     end
   end
 end

--- a/lib/vanagon/engine/local.rb
+++ b/lib/vanagon/engine/local.rb
@@ -7,15 +7,19 @@ class Vanagon
     class Local < Base
 
       def initialize(platform, target = nil)
-        @target = target || "local machine"
-        @name = 'local'
-        super
+        # local engine can't be used with a target
+        super(platform, 'local machine')
 
         # We inherit a set of required attributes from Base,
         # and rather than instantiate a new empty array for
         # required attributes, we can just clear out the
         # existing ones.
         @required_attributes.clear
+      end
+
+      # Get the engine name
+      def name
+        'local'
       end
 
       # Dispatches the command for execution

--- a/lib/vanagon/engine/pooler.rb
+++ b/lib/vanagon/engine/pooler.rb
@@ -7,11 +7,16 @@ class Vanagon
 
       # The vmpooler_template is required to use the pooler engine
       def initialize(platform, target = nil)
+        super
+
         @pooler = "http://vmpooler.delivery.puppetlabs.net"
         @token = load_token
-        super
         @required_attributes << "vmpooler_template"
-        @name = 'pooler'
+      end
+
+      # Get the engine name
+      def name
+        'pooler'
       end
 
       # This method loads the pooler token from one of two locations

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -194,7 +194,7 @@ class Vanagon
       #
       # @param name [String] name of component to add. must be present in configdir/components and named $name.rb currently
       def component(name)
-        puts "Loading #{name}"
+        puts "Loading #{name}" if @project.settings[:verbose]
         if @include_components.empty? or @include_components.include?(name)
           component = Vanagon::Component.load_component(name, File.join(Vanagon::Driver.configdir, "components"), @project.settings, @project.platform)
           @project.components << component

--- a/spec/lib/vanagon/driver_spec.rb
+++ b/spec/lib/vanagon/driver_spec.rb
@@ -1,0 +1,88 @@
+require 'vanagon/driver'
+require 'vanagon/project'
+require 'vanagon/platform'
+
+describe 'Vanagon::Driver' do
+  let (:project) { double(:project, :settings => {} ) }
+
+  let (:redhat) do
+    eval_platform('el-7-x86_64', <<-END)
+      platform 'el-7-x86_64' do |plat|
+        plat.vmpooler_template 'centos-7-x86_64'
+      end
+    END
+  end
+
+  def eval_platform(name, definition)
+    plat = Vanagon::Platform::DSL.new(name)
+    plat.instance_eval(definition)
+    plat._platform
+  end
+
+  def create_driver(platform, options = {})
+    allow(Vanagon::Project).to receive(:load_project).and_return(project)
+    allow(Vanagon::Platform).to receive(:load_platform).and_return(platform)
+
+    Vanagon::Driver.new(platform, project, options)
+  end
+
+  describe 'when resolving build host info' do
+    it 'returns the vmpooler_template using the pooler engine' do
+      info = create_driver(redhat).build_host_info
+
+      expect(info).to match({ 'name'   => 'centos-7-x86_64',
+                              'engine' => 'pooler' })
+    end
+
+    it 'returns the vmpooler template with an explicit engine' do
+      info = create_driver(redhat, :engine => 'pooler').build_host_info
+
+      expect(info).to match({ 'name'   => 'centos-7-x86_64',
+                              'engine' => 'pooler' })
+    end
+
+    it 'returns the first build_host using the hardware engine' do
+      platform = eval_platform('aix-7.1-ppc', <<-END)
+        platform 'aix-7.1-ppc' do |plat|
+          plat.build_host ["pe-aix-71-01", "pe-aix-71-02"]
+        end
+      END
+
+      info = create_driver(platform).build_host_info
+
+      expect(info).to match({ 'name'   => 'pe-aix-71-01',
+                              'engine' => 'hardware' })
+    end
+
+    it 'returns the docker_image using the docker engine' do
+      platform = eval_platform('el-7-x86_64', <<-END)
+        platform 'el-7-x86_64' do |plat|
+          plat.docker_image 'centos7'
+        end
+      END
+
+      expect(Vanagon::Utilities).to receive(:find_program_on_path).with('docker').and_return('/usr/bin/docker')
+      info = create_driver(platform, :engine => 'docker').build_host_info
+
+      expect(info).to match({ 'name'   => 'centos7',
+                              'engine' => 'docker' })
+    end
+
+    it 'returns "local machine" using the local engine' do
+      info = create_driver(redhat, :engine => 'local').build_host_info
+
+      expect(info).to match({ 'name'   => 'local machine',
+                              'engine' => 'local' })
+    end
+
+    it 'raises when using the base engine' do
+      driver = create_driver(redhat, :engine => 'base')
+
+      expect {
+        driver.build_host_info
+      }.to raise_error(Vanagon::Error,
+                       /build_host_name has not been implemented for your engine/)
+    end
+  end
+end
+

--- a/spec/lib/vanagon/engine/docker_spec.rb
+++ b/spec/lib/vanagon/engine/docker_spec.rb
@@ -1,4 +1,5 @@
 require 'vanagon/engine/docker'
+require 'vanagon/platform'
 
 describe 'Vanagon::Engine::Docker' do
   let (:platform_with_docker_image) {
@@ -36,5 +37,10 @@ describe 'Vanagon::Engine::Docker' do
       expect(Vanagon::Utilities).to receive(:find_program_on_path).with('docker').and_return('/usr/bin/docker')
       expect(Vanagon::Engine::Docker.new(platform_with_docker_image).validate_platform).to be(true)
     end
+  end
+
+  it 'returns "docker" name' do
+    expect(Vanagon::Utilities).to receive(:find_program_on_path).with('docker').and_return('/usr/bin/docker')
+    expect(Vanagon::Engine::Docker.new(platform_with_docker_image).name).to eq('docker')
   end
 end

--- a/spec/lib/vanagon/engine/hardware_spec.rb
+++ b/spec/lib/vanagon/engine/hardware_spec.rb
@@ -49,4 +49,8 @@ describe 'Vanagon::Engine::Hardware' do
       expect(Vanagon::Engine::Hardware.new(platform, nil).validate_platform).to be(true)
     end
   end
+
+  it 'returns "hardware" name' do
+    expect(Vanagon::Engine::Hardware.new(platform, nil).name).to eq('hardware')
+  end
 end

--- a/spec/lib/vanagon/engine/local_spec.rb
+++ b/spec/lib/vanagon/engine/local_spec.rb
@@ -1,4 +1,5 @@
 require 'vanagon/engine/local'
+require 'vanagon/platform'
 
 describe 'Vanagon::Engine::Local' do
   let (:platform) {
@@ -23,5 +24,9 @@ describe 'Vanagon::Engine::Local' do
       engine = Vanagon::Engine::Local.new(platform)
       expect(engine.dispatch('true', true)).to eq('')
     end
+  end
+
+  it 'returns "local" name' do
+    expect(Vanagon::Engine::Local.new(platform).name).to eq('local')
   end
 end

--- a/spec/lib/vanagon/engine/pooler_spec.rb
+++ b/spec/lib/vanagon/engine/pooler_spec.rb
@@ -1,4 +1,5 @@
 require 'vanagon/engine/pooler'
+require 'vanagon/platform'
 
 describe 'Vanagon::Engine::Pooler' do
   let (:platform) { double(Vanagon::Platform, :target_user => 'root') }
@@ -52,5 +53,9 @@ describe 'Vanagon::Engine::Pooler' do
     it 'returns true if the platform has the required attributes' do
       expect(Vanagon::Engine::Pooler.new(platform_with_vcloud_name).validate_platform).to be(true)
     end
+  end
+
+  it 'returns "pooler" name' do
+    expect(Vanagon::Engine::Pooler.new(platform_with_vcloud_name).name).to eq('pooler')
   end
 end

--- a/vanagon.gemspec
+++ b/vanagon.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('lock_manager', '>= 0')
   gem.require_path = 'lib'
   gem.bindir       = 'bin'
-  gem.executables  = ['build', 'ship', 'repo', 'devkit']
+  gem.executables  = ['build', 'ship', 'repo', 'devkit', 'build_host_info']
 
   # Ensure the gem is built out of versioned files
   gem.files = Dir['{bin,lib,spec,resources}/**/*', 'README*', 'LICENSE*'] & `git ls-files -z`.split("\0")


### PR DESCRIPTION
Adds a `build_host` CLI for retrieving the type of build host for a vanagon project and platform to enable the following workflow:

```
$ bundle exec build_host puppet-agent el-7-x86_64
centos-7-x86_64
$ ~/bin/vmpooler.py -g centos-7-x86_64
vwoafc8cxlc8u03
$ bundle exec build puppet-agent el-7-x86_64 vwoafc8cxlc8u03
Executing 'rpm -q curl > /dev/null || yum -y install curl && ...
```