### PR TITLE
(maint) Add unit test for ec2 engine

### DIFF
--- a/lib/vanagon/engine/ec2.rb
+++ b/lib/vanagon/engine/ec2.rb
@@ -7,12 +7,11 @@ class Vanagon
   class Engine
     class Ec2 < Base
       attr_accessor :ami, :key_name, :userdata, :key, :key_name, :shutdown_behavior
-      attr_accessor :subnet_id, :instance_type,
+      attr_accessor :subnet_id, :instance_type
 
       def initialize(platform, target = nil)
         super
-        @name = 'ec2'
-        @platform = platform
+
         @ami = @platform.aws_ami
         @target_user = @platform.target_user
         @subnet_id = @platform.aws_subnet_id
@@ -28,7 +27,11 @@ class Vanagon
         @resource = ::Aws::EC2::Resource.new(client: @ec2)
       end
 
-      def get_userdata()
+      def name
+        'ec2'
+      end
+
+      def get_userdata
         unless @userdata.nil?
           Base64.encode64(ERB.new(@userdata).result(binding))
         end

--- a/spec/lib/vanagon/engine/ec2_spec.rb
+++ b/spec/lib/vanagon/engine/ec2_spec.rb
@@ -1,0 +1,25 @@
+require 'vanagon/engine/ec2'
+require 'vanagon/platform'
+
+describe 'Vanagon::Engine::Ec2' do
+  let(:platform_ec2) do
+    plat = Vanagon::Platform::DSL.new('el-7-x86_64')
+    plat.instance_eval(<<-END)
+      platform 'el-7-x86_64' do |plat|
+        plat.aws_ami 'ami'
+        plat.target_user 'root'
+        plat.aws_subnet_id 'subnet_id'
+        plat.aws_user_data 'user_data'
+        plat.aws_region 'us-west-1'
+        plat.aws_key_name 'vanagon'
+        plat.aws_instance_type 't1.micro'
+        plat.ssh_port '22'
+      end
+    END
+    plat._platform
+  end
+
+  it 'returns "ec2" name' do
+    expect(Vanagon::Engine::Ec2.new(platform_ec2).name).to eq('ec2')
+  end
+end


### PR DESCRIPTION
Commit bab55a46 had a trailing comma after `:instance_type`, which seems
to cause the following `initialize` method to be ignored. So trying to
create an EC2 engine and passing in a platform didn't work:

    irb(main):033:0> Vanagon::Engine::Ec2.new(plat._platform)
    ArgumentError: wrong number of arguments (1 for 0)

Commit b8f537a74 changed how engines return their name, so it's no
longer an instance variable. That combined with bab55a46, caused the
Ec2 engine to report its name as 'base':

    irb(main):035:0> Vanagon::Engine::Ec2.new.name
    => "base"

This commit removes the trailing comma, fixes the engine name, and adds
a unit test to make sure we can create an EC2 engine and get the correct
name.