### PR TITLE
(RE-4120) inspectable components

### DIFF
--- a/bin/inspect
+++ b/bin/inspect
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 require 'json'
+require 'vanagon/extensions/ostruct/json'
+require 'vanagon/extensions/set/json'
 
 load File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "vanagon.rb"))
 

--- a/bin/inspect
+++ b/bin/inspect
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+require 'json'
+
+load File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "vanagon.rb"))
+
+optparse = Vanagon::OptParse.new("#{File.basename(__FILE__)} <project-name> <platform-name> [options]", [:workdir, :configdir, :engine])
+options = optparse.parse! ARGV
+
+project = ARGV[0]
+platforms = ARGV[1]
+
+unless project or platforms
+  warn "project and platform are both required arguments."
+  puts optparse
+  exit 1
+end
+
+platforms.split(',').each do |platform|
+  driver = Vanagon::Driver.new(platform, project, options)
+  puts JSON.generate(driver.project.components)
+end

--- a/bin/inspect
+++ b/bin/inspect
@@ -2,6 +2,7 @@
 require 'json'
 require 'vanagon/extensions/ostruct/json'
 require 'vanagon/extensions/set/json'
+require 'vanagon/extensions/hashable'
 
 load File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "vanagon.rb"))
 

--- a/bin/inspect
+++ b/bin/inspect
@@ -17,5 +17,6 @@ end
 
 platforms.split(',').each do |platform|
   driver = Vanagon::Driver.new(platform, project, options)
-  puts JSON.generate(driver.project.components)
+  components = driver.project.components.map(&:to_hash)
+  puts JSON.pretty_generate(components)
 end

--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -14,6 +14,12 @@ class Vanagon
     attr_accessor :sources, :preinstall_actions, :postinstall_actions
     attr_accessor :preremove_actions, :postremove_actions, :license
 
+    def to_hash
+      instance_variables.each_with_object({}) do |var, hash|
+        hash[var.to_s.delete("@")] = instance_variable_get(var)
+      end
+    end
+
     # Loads a given component from the configdir
     #
     # @param name [String] the name of the component

--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -14,12 +14,6 @@ class Vanagon
     attr_accessor :sources, :preinstall_actions, :postinstall_actions
     attr_accessor :preremove_actions, :postremove_actions, :license
 
-    def to_hash
-      instance_variables.each_with_object({}) do |var, hash|
-        hash[var.to_s.delete("@")] = instance_variable_get(var)
-      end
-    end
-
     # Loads a given component from the configdir
     #
     # @param name [String] the name of the component

--- a/lib/vanagon/extensions/hashable.rb
+++ b/lib/vanagon/extensions/hashable.rb
@@ -1,0 +1,41 @@
+# This is bad, and I feel bad. This will let you append
+# broadly useful Hash and JSON casting on any class that
+# includes it. But it's pretty naive, in that it just turns
+# attributes names into keys while retaining their
+# associated values.
+module HashableAttributes
+  # @return [Hash] Converts an object to a hash with keys representing
+  #   each attribute (as symbols) and their corresponding values
+  def to_hash
+    instance_variables.each_with_object({}) do |var, hash|
+      hash[var.to_s.delete("@")] = instance_variable_get(var)
+    end
+  end
+  alias_method :to_h, :to_hash
+
+  def to_json(*options)
+    to_hash.to_json options
+  end
+end
+
+# Vanagon classes generally don't implement JSON or Hash functionality
+# so those need to be monkey-patched for useful inspection.
+class Vanagon
+  class Platform
+    include HashableAttributes
+  end
+
+  class Common
+    class Pathname
+      include HashableAttributes
+    end
+  end
+
+  class Component
+    include HashableAttributes
+  end
+
+  class Patch
+    include HashableAttributes
+  end
+end

--- a/lib/vanagon/extensions/ostruct/json.rb
+++ b/lib/vanagon/extensions/ostruct/json.rb
@@ -1,0 +1,12 @@
+require 'ostruct'
+require 'json'
+
+module OpenStructJson
+  def to_json(*options)
+    to_h.to_json options
+  end
+end
+
+class OpenStruct
+  prepend OpenStructJson
+end

--- a/lib/vanagon/extensions/set/json.rb
+++ b/lib/vanagon/extensions/set/json.rb
@@ -1,0 +1,12 @@
+require 'set'
+require 'json'
+
+module SetJson
+  def to_json(*options)
+    to_a.to_json *options
+  end
+end
+
+class Set
+  prepend SetJson
+end

--- a/lib/vanagon/extensions/string.rb
+++ b/lib/vanagon/extensions/string.rb
@@ -6,6 +6,6 @@
 class String
   # @return [String]
   def undent
-    gsub(/^.{#{slice(/^ +/).length}}/, '')
+    gsub(/^.{#{slice(/^\s+/).length}}/, '')
   end
 end

--- a/spec/lib/vanagon/extensions/ostruct/json_spec.rb
+++ b/spec/lib/vanagon/extensions/ostruct/json_spec.rb
@@ -1,0 +1,16 @@
+require 'vanagon/extensions/ostruct/json'
+
+describe "OpenStruct" do
+  describe "with JSON mixins" do
+    let(:test_ostruct) { OpenStruct.new(size: "big", shape: "spherical", name: "rover") }
+    let(:json_ostruct) { %({"size":"big","shape":"spherical","name":"rover"}) }
+
+    it "responds to #to_json" do
+      expect(OpenStruct.new.respond_to?(:to_json)).to eq(true)
+    end
+
+    it "can be converted to a valid JSON object" do
+      expect(JSON.parse(test_ostruct.to_json)).to eq(JSON.parse(json_ostruct))
+    end
+  end
+end

--- a/spec/lib/vanagon/extensions/set/json_spec.rb
+++ b/spec/lib/vanagon/extensions/set/json_spec.rb
@@ -1,0 +1,17 @@
+require 'vanagon/extensions/set/json'
+
+describe "Set" do
+  describe "with JSON mixins" do
+    let(:test_set) { Set['a', 'a', 'b', 'c'] }
+    let(:json_set) { %(["a","b","c"]) }
+
+    it "responds to #to_json" do
+      expect(Set.new.respond_to?(:to_json)).to eq(true)
+    end
+
+    it "can be converted to a valid JSON object" do
+      expect(JSON.parse(test_set.to_json)).to eq(JSON.parse(json_set))
+    end
+  end
+end
+

--- a/spec/lib/vanagon/extensions/string_spec.rb
+++ b/spec/lib/vanagon/extensions/string_spec.rb
@@ -1,0 +1,30 @@
+require 'vanagon/extensions/string'
+
+describe "String" do
+  it "responds to #undent" do
+    expect(String.new.respond_to?(:undent)).to eq(true)
+  end
+end
+
+describe "Vanagon::Extensions::String" do
+  let (:basic_indented_string) { "\s\sa string" }
+  let (:basic_string) { "a string" }
+  let (:fancy_indented_string) { "\s\sleading line\n\s\s\s\s\s\strailing line\n\s\s\s\slast line" }
+  let (:fancy_string) { "leading line\n    trailing line\n  last line" }
+  let (:tab_indented_string) { "\t\t\ttab string" }
+  let (:tab_string) { "tab string" }
+
+  describe "#undent" do
+    it "trims trivial leading whitespace" do
+      expect(basic_indented_string.undent).to eq(basic_string)
+    end
+
+    it "trims more complex whitespace" do
+      expect(fancy_indented_string.undent).to eq(fancy_string)
+    end
+
+    it "trims leading tabs" do
+      expect(tab_indented_string.undent).to eq(tab_string)
+    end
+  end
+end

--- a/vanagon.gemspec
+++ b/vanagon.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('lock_manager', '>= 0')
   gem.require_path = 'lib'
   gem.bindir       = 'bin'
-  gem.executables  = ['build', 'ship', 'repo', 'devkit', 'build_host_info']
+  gem.executables  = ['build', 'inspect', 'ship', 'repo', 'devkit', 'build_host_info']
 
   # Ensure the gem is built out of versioned files
   gem.files = Dir['{bin,lib,spec,resources}/**/*', 'README*', 'LICENSE*'] & `git ls-files -z`.split("\0")


### PR DESCRIPTION
I haven't made a ticket for this yet; it's something I hacked together while working on refactoring how sources are handled. It seemed like it might be handy, so I thought I'd open up a PR and get some review on it before it's added to the code base.

---

This adds a new command to Vanagon, `inspect`. It takes two arguments: a project name, and a platform. It'll then dump a JSON formatted array of all of the components defined in the project. This can be filtered through `jq` for manual inspection or fed directly to other tools (if anyone writes then...).

```bash
# Filtered through `jq`
mckern@flexo puppet-agent (git:master) $ bundle exec inspect puppet-agent osx-10.10-x86_64 | jq '.[] | select(.name == "ruby")'
```
```json
{
  "name": "ruby",
  "settings": {
    "install_root": "/opt/puppetlabs",
    "sysconfdir": "/private/etc/puppetlabs",
    "logdir": "/var/log/puppetlabs",
    "piddir": "/var/run/puppetlabs",
    "tmpfilesdir": "/usr/lib/tmpfiles.d",
    "miscdir": "/opt/puppetlabs/misc",
    "prefix": "/opt/puppetlabs/puppet",
    "puppet_configdir": "/private/etc/puppetlabs/puppet",
    "puppet_codedir": "/private/etc/puppetlabs/code",
    "bindir": "/opt/puppetlabs/puppet/bin",
    "link_bindir": "/opt/puppetlabs/bin",
    "libdir": "/opt/puppetlabs/puppet/lib",
    "includedir": "/opt/puppetlabs/puppet/include",
    "datadir": "/opt/puppetlabs/puppet/share",
    "mandir": "/opt/puppetlabs/puppet/share/man",
    "gem_home": "/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0",
    "ruby_vendordir": "/opt/puppetlabs/puppet/lib/ruby/vendor_ruby",
    "host_ruby": "/opt/puppetlabs/puppet/bin/ruby",
    "host_gem": "/opt/puppetlabs/puppet/bin/gem",
    "gem_install": "/opt/puppetlabs/puppet/bin/gem install --no-rdoc --no-ri --local ",
    "platform_triple": null,
    "host": null,
    "cflags": "-march=core2 -msse4 -I/opt/puppetlabs/puppet/include",
    "ldflags": "-L/opt/puppetlabs/puppet/lib ",
    "java_available": false,
    "verbose": null,
    "skipcheck": null
  },
  "platform": {
    "name": "osx-10.10-x86_64",
    "make": "/usr/bin/make",
    "tar": "tar",
    "pkgbuild": "/usr/bin/pkgbuild",
    "productbuild": "/usr/bin/productbuild",
    "hdiutil": "/usr/bin/hdiutil",
    "patch": "/usr/bin/patch",
    "num_cores": "/usr/sbin/sysctl -n hw.physicalcpu",
    "os_name": "osx",
    "os_version": "10.10",
    "architecture": "x86_64",
    "ssh_port": 22,
    "provisioning": [
      "mkdir /usr/local; curl http://pl-build-tools.delivery.puppetlabs.net/osx/homebrew.tar.gz | tar -x --strip 1 -C /usr/local -f -",
      "ssh-keyscan github.delivery.puppetlabs.net >> ~/.ssh/known_hosts; /usr/local/bin/brew tap puppetlabs/brew-build-tools gitmirror@github.delivery.puppetlabs.net:puppetlabs-homebrew-build-tools",
      "/usr/local/bin/brew tap-pin puppetlabs/brew-build-tools",
      "curl -o /usr/local/bin/osx-deps http://pl-build-tools.delivery.puppetlabs.net/osx/osx-deps; chmod 755 /usr/local/bin/osx-deps",
      "/usr/local/bin/osx-deps apple-clt-7.2 pkg-config"
    ],
    "install": "install",
    "target_user": "root",
    "find": "find",
    "sort": "sort",
    "copy": "cp",
    "cross_compiled": false,
    "servicetype": "launchd",
    "servicedir": "/Library/LaunchDaemons",
    "codename": "yosemite",
    "build_dependencies": {
      "command": "/usr/local/bin/osx-deps ",
      "suffix": null
    },
    "vmpooler_template": "osx-1010-x86_64"
  },
  "options": {
    "sum": "d9d2109d3827789344cc3aceb8e1d697"
  },
  "build_requires": [
    "openssl"
  ],
  "requires": [],
  "configure": [
    [
      "bash configure         --prefix=/opt/puppetlabs/puppet         --with-opt-dir=/opt/puppetlabs/puppet         --enable-shared         --enable-bundled-libyaml         --disable-install-doc         --disable-install-rdoc                  "
    ]
  ],
  "install": [
    "/usr/bin/make -j$(shell expr $(shell /usr/sbin/sysctl -n hw.physicalcpu) + 1) install"
  ],
  "build": [
    "/usr/bin/make -j$(shell expr $(shell /usr/sbin/sysctl -n hw.physicalcpu) + 1)"
  ],
  "check": [],
  "patches": [
    {
      "path": "resources/patches/ruby/libyaml_cve-2014-9130.patch",
      "strip": 1,
      "fuzz": 0,
      "after": "unpack",
      "destination": null
    }
  ],
  "files": [],
  "directories": [],
  "replaces": [
    {
      "replacement": "pe-ruby",
      "version": null
    },
    {
      "replacement": "pe-ruby-mysql",
      "version": null
    },
    {
      "replacement": "pe-rubygems",
      "version": null
    },
    {
      "replacement": "pe-libyaml",
      "version": null
    },
    {
      "replacement": "pe-libldap",
      "version": null
    },
    {
      "replacement": "pe-ruby-ldap",
      "version": null
    },
    {
      "replacement": "pe-rubygem-gem2rpm",
      "version": null
    }
  ],
  "provides": [],
  "conflicts": [],
  "environment": {
    "optflags": "-march=core2 -msse4 -I/opt/puppetlabs/puppet/include"
  },
  "sources": [],
  "preinstall_actions": [],
  "postinstall_actions": [],
  "preremove_actions": [],
  "postremove_actions": [],
  "url": "http://buildsources.delivery.puppetlabs.net/ruby-2.1.9.tar.gz",
  "version": "2.1.9"
}
```