### PR TITLE
(MAINT) Confine aws-sdk gem to bundler group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,9 @@ def lock_manager_location_for(place)
   end
 end
 
-gem "aws-sdk", "~> 2.2.0"
+group "ec2-engine" do
+  gem "aws-sdk", "~> 2.2.0", :require => false
+end
 
 group(:development, :test) do
   gem 'rspec', '~> 3.0', :require => false

--- a/spec/lib/vanagon/engine/ec2_spec.rb
+++ b/spec/lib/vanagon/engine/ec2_spec.rb
@@ -1,25 +1,33 @@
-require 'vanagon/engine/ec2'
-require 'vanagon/platform'
+begin
+  require 'aws-sdk'
+rescue LoadError
+  $stderr.puts "Unable to load AWS SDK; skipping optional EC2 engine spec tests"
+end
 
-describe 'Vanagon::Engine::Ec2' do
-  let(:platform_ec2) do
-    plat = Vanagon::Platform::DSL.new('el-7-x86_64')
-    plat.instance_eval(<<-END)
-      platform 'el-7-x86_64' do |plat|
-        plat.aws_ami 'ami'
-        plat.target_user 'root'
-        plat.aws_subnet_id 'subnet_id'
-        plat.aws_user_data 'user_data'
-        plat.aws_region 'us-west-1'
-        plat.aws_key_name 'vanagon'
-        plat.aws_instance_type 't1.micro'
-        plat.ssh_port '22'
-      end
-    END
-    plat._platform
-  end
+if defined? ::Aws
+  require 'vanagon/engine/ec2'
+  require 'vanagon/platform'
 
-  it 'returns "ec2" name' do
-    expect(Vanagon::Engine::Ec2.new(platform_ec2).name).to eq('ec2')
+  describe 'Vanagon::Engine::Ec2' do
+    let(:platform_ec2) do
+      plat = Vanagon::Platform::DSL.new('el-7-x86_64')
+      plat.instance_eval(<<-END)
+        platform 'el-7-x86_64' do |plat|
+          plat.aws_ami 'ami'
+          plat.target_user 'root'
+          plat.aws_subnet_id 'subnet_id'
+          plat.aws_user_data 'user_data'
+          plat.aws_region 'us-west-1'
+          plat.aws_key_name 'vanagon'
+          plat.aws_instance_type 't1.micro'
+          plat.ssh_port '22'
+        end
+      END
+      plat._platform
+    end
+
+    it 'returns "ec2" name' do
+      expect(Vanagon::Engine::Ec2.new(platform_ec2).name).to eq('ec2')
+    end
   end
 end


### PR DESCRIPTION
It's currently an optinal engine, and it should specify an optional dependency. This also makes the spec test for the EC2 engine option depending on whether or not the aws-sdk is available.

When this engine is declared a prime-time engine, the dependency on AWS-SDK should be moved directly into the Gemspec and this confinement should be removed.