### PR TITLE
(maint) Disable brp-strip-static-archive from RPM builds

### DIFF
--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -2,6 +2,10 @@
 
 # Turn off the brp-python-bytecompile script
 %global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
+# Disable brp-strip-static-archive, which on EL platforms causes
+# cross-compiled static libs to end up with "no machine" as their
+# architure, breaking builds:
+%global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-strip-static-archive[[:space:]].*$!!g')
 #
 
 Name:           <%= @name %>


### PR DESCRIPTION
brp-strip-static-archive causes cross-compiled static libs to end up
with "no machine" as their architecture, breaking builds.

With this fix, I'm now able to build all of the pl-build-tools targets for el-6-s390x. Going to run this through jenkins to ensure there are no regressions.