### PR TITLE
(MAINT) Finesse retries a little bit

### DIFF
--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -138,8 +138,8 @@ class Vanagon
     # values from the project, if available, otherwise use some
     # sane defaults.
     def retry_task(&block)
-      @timeout = @project.timeout || 3600
-      @retry_count = @project.retry_count || 3
+      @timeout = @project.timeout || ENV["TIMEOUT"] || 3600
+      @retry_count = @project.retry_count || ENV["RETRY_COUNT"] || 1
       Vanagon::Utilities.retry_with_timeout(@retry_count, @timeout) { yield }
     end
     private :retry_task

--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -130,8 +130,8 @@ class Vanagon
     # @raise [Vanagon::Error] if the block fails after the retries are exhausted, an error is raised
     def retry_with_timeout(tries = 5, timeout = 1, &blk)
       error = nil
-      tries.times do
-        Timeout::timeout(timeout) do
+      tries.to_i.times do
+        Timeout::timeout(timeout.to_i) do
           begin
             blk.call
             return true


### PR DESCRIPTION
Retries and timeouts can now be defined with the environment variables `RETRY_COUNT` and `TIMEOUT`. Useful for turning them up or down without having to commit a new value to a project every time you change it.

Also, the default retry count has been changed from 3 to 1. For _**reasons**_.