### PR TITLE
(maint) Increase default timeout

### DIFF
--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -138,7 +138,7 @@ class Vanagon
     # values from the project, if available, otherwise use some
     # sane defaults.
     def retry_task(&block)
-      @timeout = @project.timeout || ENV["TIMEOUT"] || 3600
+      @timeout = @project.timeout || ENV["TIMEOUT"] || 7200
       @retry_count = @project.retry_count || ENV["RETRY_COUNT"] || 1
       Vanagon::Utilities.retry_with_timeout(@retry_count, @timeout) { yield }
     end

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -96,7 +96,7 @@ class Vanagon
 
       puts "Target is #{@engine.target}"
       retry_task { install_build_dependencies }
-      @project.fetch_sources(@workdir)
+      retry_task { @project.fetch_sources(@workdir) }
       @project.make_makefile(@workdir)
       @project.make_bill_of_materials(@workdir)
       @project.generate_packaging_artifacts(@workdir)

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -101,7 +101,7 @@ class Vanagon
       @project.make_bill_of_materials(@workdir)
       @project.generate_packaging_artifacts(@workdir)
       @engine.ship_workdir(@workdir)
-      retry_task { @engine.dispatch("(cd #{@engine.remote_workdir}; #{@platform.make})") }
+      @engine.dispatch("(cd #{@engine.remote_workdir}; #{@platform.make})")
       @engine.retrieve_built_artifact
       @engine.teardown unless @preserve
       cleanup_workdir unless @preserve


### PR DESCRIPTION
When building toolchain components such as GCC, it takes more than 1
hours. This ups the default timeout to 2 hours since our jenkins configs
don't pass timeout as a parameter.