### PR TITLE
(PA-390) On AIX, stop services also on upgrade

### DIFF
--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -241,9 +241,7 @@ fi
       chkconfig --del <%= service.name %> || :
     fi
   <%- elsif @platform.servicetype == "aix" -%>
-    if [ "$1" -eq 0 ]; then
       /usr/bin/stopsrc -s <%= service.name -%> > /dev/null 2>&1 || :
-    fi
   <%- end -%>
 <%- end -%>
 

--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -123,6 +123,7 @@ done
 
 
 %pre
+<%- unless @platform.is_aix? || (@platform.is_el? && @platform.os_version.to_i == 4) -%>
 # Save state so we know later if this is an upgrade or an install
 mkdir -p %{_localstatedir}/lib/rpm-state/%{name}
 if [ "$1" -eq 1 ] ; then
@@ -131,6 +132,7 @@ fi
 if [ "$1" -gt 1 ] ; then
   touch %{_localstatedir}/lib/rpm-state/%{name}/upgrade
 fi
+<%- end -%>
 
 <%- if @user -%>
 # Add our user and group


### PR DESCRIPTION
Prior to this, services on AIX are not restarted on upgrade, so
the old puppet and mcollective services may be left running.

This updates the RPM `%preun` to stop AIX services also on upgrade.

In addition, prior to this, vanagon creates empty "install" and "upgrade"
files in the RPM localstatedir on all platforms. These files are created
for use by `%posttrans` scriptlets.

AIX and EL4 use an older version of RPM that does not support use of
`%posttrans`, so the state files are not needed on those platforms.

This also updates vanagon's rpm spec template so the empty "install"
and "upgrade" files are not created on AIX and EL4.