### PR TITLE
(CPR-369) Don't create "install", "upgrade" files on AIX, EL4.

### DIFF
--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -123,6 +123,7 @@ done
 
 
 %pre
+<%- unless @platform.is_aix? || (@platform.is_el? && @platform.os_version.to_i == 4) -%>
 # Save state so we know later if this is an upgrade or an install
 mkdir -p %{_localstatedir}/lib/rpm-state/%{name}
 if [ "$1" -eq 1 ] ; then
@@ -131,6 +132,7 @@ fi
 if [ "$1" -gt 1 ] ; then
   touch %{_localstatedir}/lib/rpm-state/%{name}/upgrade
 fi
+<%- end -%>
 
 <%- if @user -%>
 # Add our user and group


### PR DESCRIPTION
Prior to this commit, vanagon creates empty "install" and "upgrade"
files in the RPM localstatedir on all platforms. These files are created
for use by `%posttrans` scriptlets.

AIX and EL4 use an older version of RPM that does not support use of
`%posttrans`, so the state files are not needed on those platforms.

This commit updates vanagon's rpm spec template so the empty "install"
and "upgrade" files are not created on AIX and EL4.