### PR TITLE
(PA-390) On AIX, stop services also on upgrade.

### DIFF
--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -241,9 +241,7 @@ fi
       chkconfig --del <%= service.name %> || :
     fi
   <%- elsif @platform.servicetype == "aix" -%>
-    if [ "$1" -eq 0 ]; then
       /usr/bin/stopsrc -s <%= service.name -%> > /dev/null 2>&1 || :
-    fi
   <%- end -%>
 <%- end -%>
 


### PR DESCRIPTION
Prior to this commit, on upgrade, services on AIX are not restarted, so
the old puppet and mcollective services may be left running.

This commit updates the `%preun` to stop AIX services also on upgrade.