### PR TITLE
(maint) Update the directorylist creation for windows to use uniq id

### DIFF
--- a/lib/vanagon/platform/windows.rb
+++ b/lib/vanagon/platform/windows.rb
@@ -335,12 +335,14 @@ class Vanagon
         # iterate over all paths specified and break each one
         # in to its specific directories. This will generate_wix_dirs
         # an n-ary tree structure matching the specs from the input
-        items.each do |item|
+        items.each_with_index do |item, item_idx|
           # Always start at the beginning
           curr = root
           names = item[:path].split(File::SEPARATOR)
-          names.each do |name|
-            curr = insert_child(curr, name)
+          names.each_with_index do |name, names_idx|
+            # We concat the indexes of each loop to name to ensure the ids of all
+            # elements will be unique.
+            curr = insert_child(curr, name, "#{name}_#{item_idx}_#{names_idx}")
           end
           # at this point, curr will be the top dir, override the id if
           # id exists
@@ -356,9 +358,9 @@ class Vanagon
       # @param [HASH] curr, current object we are on
       # @param [string] name, name of new object we are to search for and
       #                 create if necessary
-      def insert_child(curr, name)
+      def insert_child(curr, name, id)
         #The Id field will default to name, but be overridden later
-        new_obj = { :name => name, :id => name, :elements_to_add => [], :children => [] }
+        new_obj = { :name => name, :id => id, :elements_to_add => [], :children => [] }
         if (child_index = index_of_child(new_obj, curr[:children]))
           curr = curr[:children][child_index]
         else

--- a/spec/lib/vanagon/platform/windows_spec.rb
+++ b/spec/lib/vanagon/platform/windows_spec.rb
@@ -194,7 +194,7 @@ HERE
             comp.install_service('SourceDir/ProgramFilesFolder/TestID/TestProduct/opt/bin.exe')
             expect(cur_plat._platform.generate_service_bin_dirs([comp._component.service].flatten.compact, proj._project)).to eq( \
 <<-HERE
-<Directory Name="opt" Id="opt">
+<Directory Name="opt" Id="opt_0_0">
 <Directory Id="SERVICETESTBINDIR" />
 </Directory>
 HERE
@@ -210,7 +210,7 @@ HERE
             expect(cur_plat._platform.generate_service_bin_dirs([comp._component.service].flatten.compact, proj._project)).to eq( \
 
 <<-HERE
-<Directory Name="opt" Id="opt">
+<Directory Name="opt" Id="opt_0_0">
 <Directory Id="SERVICETEST2BINDIR" />
 </Directory>
 HERE
@@ -226,8 +226,8 @@ HERE
             expect(cur_plat._platform.generate_service_bin_dirs([comp._component.service].flatten.compact, proj._project)).to eq( \
 
 <<-HERE
-<Directory Name="somedir" Id="somedir">
-<Directory Name="someotherdir" Id="someotherdir">
+<Directory Name="somedir" Id="somedir_0_0">
+<Directory Name="someotherdir" Id="someotherdir_0_1">
 <Directory Id="SERVICETESTBINDIR" />
 </Directory>
 </Directory>
@@ -247,7 +247,7 @@ HERE
             comp2.install_service('SourceDir\\ProgramFilesFolder\\TestID\\TestProduct\\somedir\\bin.exe')
             expect(cur_plat._platform.generate_service_bin_dirs([comp._component.service, comp2._component.service].flatten.compact, proj._project)).to eq( \
 <<-HERE
-<Directory Name="somedir" Id="somedir">
+<Directory Name="somedir" Id="somedir_0_0">
 <Directory Id="SERVICETESTBINDIR" />
 <Directory Id="SERVICETEST2BINDIR" />
 </Directory>
@@ -267,17 +267,17 @@ HERE
             comp3.install_service('SourceDir\\ProgramFilesFolder\\TestID\\TestProduct\\somedir\\oneUpAgain\\twoUpAgain\\bin.exe')
             expect(cur_plat._platform.generate_service_bin_dirs([comp._component.service, comp2._component.service, comp3._component.service].flatten.compact, proj._project)).to eq( \
 <<-HERE
-<Directory Name="somedir" Id="somedir">
-<Directory Name="oneUp" Id="oneUp">
-<Directory Name="twoUp" Id="twoUp">
+<Directory Name="somedir" Id="somedir_0_0">
+<Directory Name="oneUp" Id="oneUp_0_1">
+<Directory Name="twoUp" Id="twoUp_0_2">
 <Directory Id="SERVICETEST1BINDIR" />
 </Directory>
 </Directory>
-<Directory Name="oneUpAgain" Id="oneUpAgain">
-<Directory Name="twoUp" Id="twoUp">
+<Directory Name="oneUpAgain" Id="oneUpAgain_1_1">
+<Directory Name="twoUp" Id="twoUp_1_2">
 <Directory Id="SERVICETEST2BINDIR" />
 </Directory>
-<Directory Name="twoUpAgain" Id="twoUpAgain">
+<Directory Name="twoUpAgain" Id="twoUpAgain_2_2">
 <Directory Id="SERVICETEST3BINDIR" />
 </Directory>
 </Directory>


### PR DESCRIPTION
It's posible to cause a failure in WiX by registering two services on paths
that are different but have the same named dir somewhere, for example,
registering two services under:

    /dir/bin

    /other_dir/bin

will cause a failure because when we create the directorylist.wxs file the
"bin" directories will both have the same "Id" field because we just used
name there. This commit appends values to the Id field that will ensure
uniqueness.

This commit upates both the windows platform object and rspec