### PR TITLE
(RE-7395) Update MSI output to remove _VANAGON from artifact

### DIFF
--- a/lib/vanagon/platform/windows.rb
+++ b/lib/vanagon/platform/windows.rb
@@ -213,10 +213,7 @@ class Vanagon
       # @return [String] name of the windows package for this project
       def msi_package_name(project)
         # Decided to use native project version in hope msi versioning doesn't have same resrictions as nuget
-        # SPECIAL NOTE: as a way for us to create two side by side msis for comparison between
-        # pftw and vanagon, we are putting in VANAGON to the filename so the names will
-        # be different. When pftw is deprecated, so should this convention
-        "#{project.name}-#{project.version}.#{project.release}-#{@architecture}_VANAGON.msi"
+        "#{project.name}-#{project.version}.#{project.release}-#{@architecture}.msi"
       end
 
       # Method to derive the package name for the project.


### PR DESCRIPTION
During development of vanagon for windows platforms we added _VANAGON to the
output artifact names to differentiate between artifacts built by vanagon and
artifacts built elsewhere. remove this temporary change from production