### PR TITLE
(maint) Update platform output directory

### DIFF
--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -8,7 +8,7 @@ class Vanagon
     attr_accessor :docker_image, :ssh_port, :rpmbuild, :install, :platform_triple
     attr_accessor :target_user, :package_type, :find, :sort, :build_hosts, :copy, :cross_compiled
     attr_accessor :aws_ami, :aws_user_data, :aws_shutdown_behavior, :aws_key_name, :aws_region, :aws_key
-    attr_accessor :aws_instance_type, :aws_vpc_id, :aws_subnet_id
+    attr_accessor :aws_instance_type, :aws_vpc_id, :aws_subnet_id, :output_dir
 
     # Platform names currently contain some information about the platform. Fields
     # within the name are delimited by the '-' character, and this regex can be used to
@@ -115,6 +115,16 @@ class Vanagon
       if instance_variable_get("@#{key}")
         instance_variable_get("@#{key}")
       end
+    end
+
+    # Get the output dir for packages. If the output_dir was defined already (by
+    # the platform config) then don't change it.
+    #
+    # @param target_repo [String] optional repo target for built packages defined
+    #   at the project level
+    # @return [String] relative path to where packages should be output to
+    def output_dir(target_repo = "")
+      @output_dir ||= File.join(@os_name, @os_version, target_repo, @architecture)
     end
 
     # Sets and gets the name of the operating system for the platform.

--- a/lib/vanagon/platform/deb.rb
+++ b/lib/vanagon/platform/deb.rb
@@ -47,14 +47,6 @@ class Vanagon
         "#{project.name}_#{project.version}-#{project.release}#{@codename}_#{project.noarch ? 'all' : @architecture}.deb"
       end
 
-      # Get the expected output dir for the debian packages. This allows us to
-      # use some standard tools to ship internally.
-      #
-      # @return [String] relative path to where debian packages should be staged
-      def output_dir(target_repo = "")
-        File.join("deb", @codename, target_repo)
-      end
-
       # Returns the string to add a target repo to the platforms' provisioning
       #
       # @param definition [URI] A URI to a deb or list file

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -313,6 +313,10 @@ class Vanagon
         @platform.codename = name
       end
 
+      def output_dir(directory)
+        @platform.output_dir = directory
+      end
+
       # Helper to setup a apt repository on a target system
       #
       # @param definition [String] the repo setup file, must be a valid uri, fetched with curl

--- a/lib/vanagon/platform/osx.rb
+++ b/lib/vanagon/platform/osx.rb
@@ -92,14 +92,6 @@ class Vanagon
         "#{project.name}-#{project.version}-#{project.release}.#{@os_name}#{@os_version}.dmg"
       end
 
-      # Get the expected output dir for the osx packages. This allows us to
-      # use some standard tools to ship internally.
-      #
-      # @return [String] relative path to where osx packages should be staged
-      def output_dir(target_repo = "")
-        File.join("apple", @os_version, target_repo, @architecture)
-      end
-
       # Constructor. Sets up some defaults for the osx platform and calls the parent constructor
       #
       # @param name [String] name of the platform

--- a/lib/vanagon/platform/rpm.rb
+++ b/lib/vanagon/platform/rpm.rb
@@ -36,14 +36,6 @@ class Vanagon
         "#{project.name}-#{project.version}-#{project.release}.#{project.noarch ? 'noarch' : @architecture}.rpm"
       end
 
-      # Get the expected output dir for the rpm packages. This allows us to
-      # use some standard tools to ship internally.
-      #
-      # @return [String] relative path to where rpm packages should be staged
-      def output_dir(target_repo = "products")
-        File.join(@os_name, @os_version, target_repo, @architecture)
-      end
-
       def rpm_defines
         defines =  %(--define '_topdir $(tempdir)/rpmbuild' )
         # RPM doesn't allow dashes in the os_name. This was added to

--- a/lib/vanagon/platform/solaris_10.rb
+++ b/lib/vanagon/platform/solaris_10.rb
@@ -140,14 +140,6 @@ class Vanagon
         "#{project.name}-#{project.version}-#{project.release}.#{@architecture}.pkg.gz"
       end
 
-      # Get the expected output dir for the solaris 10 packages. This allows us to
-      # use some standard tools to ship internally.
-      #
-      # @return [String] relative path to where solaris 10 packages should be staged
-      def output_dir(target_repo = "")
-        File.join("solaris", @os_version, target_repo)
-      end
-
       # Because solaris has multiple terrible ways to install packages, we have
       # this method which generates a shell script to be executed on the system
       # which will install all of the build dependencies

--- a/lib/vanagon/platform/solaris_11.rb
+++ b/lib/vanagon/platform/solaris_11.rb
@@ -106,14 +106,6 @@ class Vanagon
         "#{version},5.11-#{release}"
       end
 
-      # Get the expected output dir for the solaris 11 packages. This allows us to
-      # use some standard tools to ship internally.
-      #
-      # @return [String] relative path to where solaris 11 packages should be staged
-      def output_dir(target_repo = "")
-        File.join("solaris", @os_version, target_repo)
-      end
-
       # Constructor. Sets up some defaults for the solaris 11 platform and calls the parent constructor
       #
       # @param name [String] name of the platform

--- a/lib/vanagon/platform/windows.rb
+++ b/lib/vanagon/platform/windows.rb
@@ -294,16 +294,6 @@ class Vanagon
         commands
       end
 
-      # Get the expected output dir for the windows packages. This allows us to
-      # use some standard tools to ship internally.
-      #
-      # @param target_repo [String] optional repo target for built packages defined
-      #   at the project level
-      # @return [String] relative path to where windows packages should be staged
-      def output_dir(target_repo = "")
-        File.join("windows", target_repo, @architecture)
-      end
-
       # Generate the underlying directory structure of
       # any binary files referenced in services. note that
       # this function does not generate the structure of

--- a/spec/lib/vanagon/platform/deb_spec.rb
+++ b/spec/lib/vanagon/platform/deb_spec.rb
@@ -8,8 +8,6 @@ describe "Vanagon::Platform::DEB" do
         :os_name                => "ubuntu",
         :os_version             => "10.04",
         :architecture           => "i386",
-        :output_dir             => "deb/lucid/",
-        :output_dir_with_target => "deb/lucid/thing",
         :codename               => "lucid",
       },
       {
@@ -17,43 +15,9 @@ describe "Vanagon::Platform::DEB" do
         :os_name                => "debian",
         :os_version             => "7",
         :architecture           => "amd64",
-        :output_dir             => "deb/wheezy/",
-        :output_dir_with_target => "deb/wheezy/thing",
         :codename               => "wheezy",
       },
     ]
-  end
-
-  describe "#output_dir" do
-    it "returns an output dir consistent with the packaging repo" do
-      platforms.each do |plat|
-
-        plat_block = %Q[
-        platform "#{plat[:name]}" do |plat|
-          plat.codename "#{plat[:codename]}"
-        end
-        ]
-
-        cur_plat = Vanagon::Platform::DSL.new(plat[:name])
-        cur_plat.instance_eval(plat_block)
-        expect(cur_plat._platform.output_dir).to eq(plat[:output_dir])
-      end
-    end
-
-    it "adds the target repo in the right place" do
-      platforms.each do |plat|
-
-        plat_block = %Q[
-        platform "#{plat[:name]}" do |plat|
-          plat.codename "#{plat[:codename]}"
-        end
-        ]
-
-        cur_plat = Vanagon::Platform::DSL.new(plat[:name])
-        cur_plat.instance_eval(plat_block)
-        expect(cur_plat._platform.output_dir('thing')).to eq(plat[:output_dir_with_target])
-      end
-    end
   end
 end
 

--- a/spec/lib/vanagon/platform/rpm_spec.rb
+++ b/spec/lib/vanagon/platform/rpm_spec.rb
@@ -7,8 +7,6 @@ describe "Vanagon::Platform::RPM" do
         :os_name                => "el",
         :os_version             => "5",
         :architecture           => "i386",
-        :output_dir             => "el/5/products/i386",
-        :output_dir_with_target => "el/5/thing/i386",
         :block                  => %Q[ platform "el-5-i386" do |plat| end ]
       },
       {
@@ -16,8 +14,6 @@ describe "Vanagon::Platform::RPM" do
         :os_name                => "fedora",
         :os_version             => "21",
         :architecture           => "x86_64",
-        :output_dir             => "fedora/21/products/x86_64",
-        :output_dir_with_target => "fedora/21/thing/x86_64",
         :block                  => %Q[ platform "fedora-21-x86_64" do |plat| end ]
       },
       {
@@ -25,8 +21,6 @@ describe "Vanagon::Platform::RPM" do
         :os_name                => "fedora",
         :os_version             => "21",
         :architecture           => "x86_64",
-        :output_dir             => "cisco-wrlinux/7/products/x86_64",
-        :output_dir_with_target => "cisco-wrlinux/7/thing/x86_64",
         :block                  => %Q[ platform "cisco-wrlinux-7-x86_64" do |plat| end ]
       },
     ]
@@ -38,16 +32,6 @@ describe "Vanagon::Platform::RPM" do
 
       before do
         cur_plat.instance_eval(plat[:block])
-      end
-
-      describe "#output_dir" do
-        it "returns an output dir consistent with the packaging repo" do
-          expect(cur_plat._platform.output_dir).to eq(plat[:output_dir])
-        end
-
-        it "adds the target repo in the right way" do
-          expect(cur_plat._platform.output_dir('thing')).to eq(plat[:output_dir_with_target])
-        end
       end
 
       describe '#rpm_defines' do

--- a/spec/lib/vanagon/platform/windows_spec.rb
+++ b/spec/lib/vanagon/platform/windows_spec.rb
@@ -25,8 +25,6 @@ describe "Vanagon::Platform::Windows" do
       :os_name                => "windows",
       :os_version             => "2012r2",
       :architecture           => "x64",
-      :output_dir             => "windows/x64",
-      :output_dir_with_target => "windows/thing/x64",
       :target_user            => "Administrator",
       :projname               => "test-proj",
       :block                  => %Q[ platform "windows-2012r2-x64" do |plat| plat.servicetype 'windows' end ]
@@ -50,16 +48,6 @@ HERE
 
       before do
         cur_plat.instance_eval(plat[:block])
-      end
-
-      describe "#output_dir" do
-        it "returns an output dir consistent with the packaging repo" do
-          expect(cur_plat._platform.output_dir).to eq(plat[:output_dir])
-        end
-
-        it "adds the target repo in the right way" do
-          expect(cur_plat._platform.output_dir('thing')).to eq(plat[:output_dir_with_target])
-        end
       end
 
       describe '#target_user' do

--- a/spec/lib/vanagon/platform_spec.rb
+++ b/spec/lib/vanagon/platform_spec.rb
@@ -4,22 +4,31 @@ describe "Vanagon::Platform" do
   let(:platforms) do
     [
       {
-        :name         => "debian-6-i386",
-        :os_name      => "debian",
-        :os_version   => "6",
-        :architecture => "i386",
+        :name                   => "debian-6-i386",
+        :os_name                => "debian",
+        :os_version             => "6",
+        :architecture           => "i386",
+        :output_dir             => "debian/6/i386",
+        :output_dir_with_target => "debian/6/thing/i386",
+        :block                  => %Q[ platform "debian-6-i386" do |plat| end ],
       },
       {
-        :name         => "el-5-i386",
-        :os_name      => "el",
-        :os_version   => "5",
-        :architecture => "i386",
+        :name                   => "el-5-i386",
+        :os_name                => "el",
+        :os_version             => "5",
+        :architecture           => "i386",
+        :output_dir             => "el/5/i386",
+        :output_dir_with_target => "el/5/thing/i386",
+        :block                  => %Q[ platform "el-5-i386" do |plat| end ],
       },
       {
-        :name         => "CumulusLinux-2.2-amd64",
-        :os_name      => "CumulusLinux",
-        :os_version   => "2.2",
-        :architecture => "amd64",
+        :name                   => "debian-6-i386",
+        :os_name                => "debian",
+        :os_version             => "6",
+        :architecture           => "i386",
+        :output_dir             => "updated/output",
+        :output_dir_with_target => "updated/output",
+        :block                  => %Q[ platform "debian-6-i386" do |plat| plat.output_dir "updated/output" end ],
       },
     ]
   end
@@ -38,6 +47,24 @@ describe "Vanagon::Platform" do
       platforms.each do |plat|
         cur_plat = Vanagon::Platform.new(plat[:name])
         expect(cur_plat.os_version).to eq(plat[:os_version])
+      end
+    end
+  end
+
+  describe "#output_dir" do
+    it "returns correct output dir" do
+      platforms.each do |plat|
+        cur_plat = Vanagon::Platform::DSL.new(plat[:name])
+        cur_plat.instance_eval(plat[:block])
+        expect(cur_plat._platform.output_dir).to eq(plat[:output_dir])
+      end
+    end
+
+    it "adds the target repo in the right way" do
+      platforms.each do |plat|
+        cur_plat = Vanagon::Platform::DSL.new(plat[:name])
+        cur_plat.instance_eval(plat[:block])
+        expect(cur_plat._platform.output_dir('thing')).to eq(plat[:output_dir_with_target])
       end
     end
   end


### PR DESCRIPTION
In order to facilitate better output directory control, add the ability to
specify platform.output_dir in the platform config file and override any
defaults for output.

As part of this, to make vanagon more reusable, remove all platform specific
"defaults" that were there and create one single "default" for each platform
following the following pattern:

@platform/@platform_version/(optional)@target_repo/@plaform_arch