### PR TITLE
(maint) update windows package name

### DIFF
--- a/lib/vanagon/platform/windows.rb
+++ b/lib/vanagon/platform/windows.rb
@@ -214,7 +214,7 @@ class Vanagon
       # @return [String] name of the windows package for this project
       def msi_package_name(project)
         # Decided to use native project version in hope msi versioning doesn't have same resrictions as nuget
-        "#{project.name}-#{project.version}.#{project.release}-#{@architecture}.msi"
+        "#{project.name}-#{project.version}-#{@architecture}.msi"
       end
 
       # Method to derive the package name for the project.


### PR DESCRIPTION
currently puppet-agent needs package names of the form: name-version-arch.msi
instead of name-version.release-arch.msi. The need for this change to happen in
vanagon is a problem, but for now this update will have to suffice.