### PR TITLE
(maint) Revert change to default output dir

### DIFF
--- a/lib/vanagon/platform/deb.rb
+++ b/lib/vanagon/platform/deb.rb
@@ -47,6 +47,14 @@ class Vanagon
         "#{project.name}_#{project.version}-#{project.release}#{@codename}_#{project.noarch ? 'all' : @architecture}.deb"
       end
 
+      # Get the expected output dir for the debian packages. This allows us to
+      # use some standard tools to ship internally.
+      #
+      # @return [String] relative path to where debian packages should be staged
+      def output_dir(target_repo = "")
+        @output_dir ||= File.join("deb", @codename, target_repo)
+      end
+
       # Returns the string to add a target repo to the platforms' provisioning
       #
       # @param definition [URI] A URI to a deb or list file

--- a/lib/vanagon/platform/rpm.rb
+++ b/lib/vanagon/platform/rpm.rb
@@ -36,6 +36,10 @@ class Vanagon
         "#{project.name}-#{project.version}-#{project.release}.#{project.noarch ? 'noarch' : @architecture}.rpm"
       end
 
+      def output_dir(target_repo = "products")
+        super
+      end
+
       def rpm_defines
         defines =  %(--define '_topdir $(tempdir)/rpmbuild' )
         # RPM doesn't allow dashes in the os_name. This was added to

--- a/spec/lib/vanagon/platform_spec.rb
+++ b/spec/lib/vanagon/platform_spec.rb
@@ -8,10 +8,13 @@ describe "Vanagon::Platform" do
         :os_name                 => "debian",
         :os_version              => "6",
         :architecture            => "i386",
-        :output_dir              => "debian/6/i386",
-        :output_dir_with_target  => "debian/6/thing/i386",
-        :output_dir_empty_string => "debian/6/i386",
-        :block                   => %Q[ platform "debian-6-i386" do |plat| end ],
+        :output_dir              => "deb/lucid/",
+        :output_dir_with_target  => "deb/lucid/thing",
+        :output_dir_empty_string => "deb/lucid/",
+        :block                   => %Q[
+          platform "debian-6-i386" do |plat|
+            plat.codename "lucid"
+          end ],
       },
       {
         :name                    => "el-5-i386",
@@ -27,11 +30,16 @@ describe "Vanagon::Platform" do
         :name                    => "debian-6-i386",
         :os_name                 => "debian",
         :os_version              => "6",
+        :codename                => "lucid",
         :architecture            => "i386",
         :output_dir              => "updated/output",
         :output_dir_with_target  => "updated/output",
         :output_dir_empty_string => "updated/output",
-        :block                   => %Q[ platform "debian-6-i386" do |plat| plat.output_dir "updated/output" end ],
+        :block                   => %Q[
+          platform "debian-6-i386" do |plat|
+            plat.codename "lucid"
+            plat.output_dir "updated/output"
+          end ],
       },
     ]
   end

--- a/spec/lib/vanagon/platform_spec.rb
+++ b/spec/lib/vanagon/platform_spec.rb
@@ -4,31 +4,34 @@ describe "Vanagon::Platform" do
   let(:platforms) do
     [
       {
-        :name                   => "debian-6-i386",
-        :os_name                => "debian",
-        :os_version             => "6",
-        :architecture           => "i386",
-        :output_dir             => "debian/6/i386",
-        :output_dir_with_target => "debian/6/thing/i386",
-        :block                  => %Q[ platform "debian-6-i386" do |plat| end ],
+        :name                    => "debian-6-i386",
+        :os_name                 => "debian",
+        :os_version              => "6",
+        :architecture            => "i386",
+        :output_dir              => "debian/6/i386",
+        :output_dir_with_target  => "debian/6/thing/i386",
+        :output_dir_empty_string => "debian/6/i386",
+        :block                   => %Q[ platform "debian-6-i386" do |plat| end ],
       },
       {
-        :name                   => "el-5-i386",
-        :os_name                => "el",
-        :os_version             => "5",
-        :architecture           => "i386",
-        :output_dir             => "el/5/i386",
-        :output_dir_with_target => "el/5/thing/i386",
-        :block                  => %Q[ platform "el-5-i386" do |plat| end ],
+        :name                    => "el-5-i386",
+        :os_name                 => "el",
+        :os_version              => "5",
+        :architecture            => "i386",
+        :output_dir              => "el/5/products/i386",
+        :output_dir_with_target  => "el/5/thing/i386",
+        :output_dir_empty_string => "el/5/i386",
+        :block                   => %Q[ platform "el-5-i386" do |plat| end ],
       },
       {
-        :name                   => "debian-6-i386",
-        :os_name                => "debian",
-        :os_version             => "6",
-        :architecture           => "i386",
-        :output_dir             => "updated/output",
-        :output_dir_with_target => "updated/output",
-        :block                  => %Q[ platform "debian-6-i386" do |plat| plat.output_dir "updated/output" end ],
+        :name                    => "debian-6-i386",
+        :os_name                 => "debian",
+        :os_version              => "6",
+        :architecture            => "i386",
+        :output_dir              => "updated/output",
+        :output_dir_with_target  => "updated/output",
+        :output_dir_empty_string => "updated/output",
+        :block                   => %Q[ platform "debian-6-i386" do |plat| plat.output_dir "updated/output" end ],
       },
     ]
   end
@@ -65,6 +68,14 @@ describe "Vanagon::Platform" do
         cur_plat = Vanagon::Platform::DSL.new(plat[:name])
         cur_plat.instance_eval(plat[:block])
         expect(cur_plat._platform.output_dir('thing')).to eq(plat[:output_dir_with_target])
+      end
+    end
+
+    it "does the right thing with empty strings" do
+      platforms.each do |plat|
+        cur_plat = Vanagon::Platform::DSL.new(plat[:name])
+        cur_plat.instance_eval(plat[:block])
+        expect(cur_plat._platform.output_dir('')).to eq(plat[:output_dir_empty_string])
       end
     end
   end


### PR DESCRIPTION
We should maintain defaults while still making it easy to overwrite the output dir.