### PR TITLE
(RE-5403) Modify Vanagon to support more than md5 sum

### DIFF
--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -278,6 +278,23 @@ class Vanagon
       # @param md5 [String] md5 sum of the source for verification
       def md5sum(md5)
         @component.options[:sum] = md5
+        @component.options[:sum_type] = "md5"
+      end
+
+      # Sets the sha256 sum to verify the sum of the source
+      #
+      # @param sha256 [String] sha256 sum of the source for verification
+      def sha256sum(sha256)
+        @component.options[:sum] = sha256
+        @component.options[:sum_type] = "sha256"
+      end
+
+      # Sets the sha512 sum to verify the sum of the source
+      #
+      # @param sha512 [String] sha512 sum of the source for verification
+      def sha512sum(sha512)
+        @component.options[:sum] = sha512
+        @component.options[:sum_type] = "sha512"
       end
 
       # Sets the ref of the source for use in a git source

--- a/lib/vanagon/component/source.rb
+++ b/lib/vanagon/component/source.rb
@@ -87,7 +87,8 @@ class Vanagon
           if Vanagon::Component::Source::Http.valid_url?(parse_and_rewrite(uri))
             return Vanagon::Component::Source::Http.new parse_and_rewrite(uri),
               sum: options[:sum],
-              workdir: options[:workdir]
+              workdir: options[:workdir],
+              sum_type: options[:sum_type]
           end
 
           # Then we try local

--- a/lib/vanagon/component/source/http.rb
+++ b/lib/vanagon/component/source/http.rb
@@ -10,7 +10,7 @@ class Vanagon
         include Vanagon::Utilities
 
         # Accessors :url, :file, :extension, :workdir, :cleanup are inherited from Local
-        attr_accessor :sum
+        attr_accessor :sum, :sum_type
 
         class << self
           def valid_url?(target_url) # rubocop:disable Metrics/AbcSize
@@ -42,14 +42,19 @@ class Vanagon
         # @param url [String] url of the http source to fetch
         # @param sum [String] sum to verify the download against
         # @param workdir [String] working directory to download into
+        # @param sum_type [String] type of sum we are verifying
         # @raise [RuntimeError] an exception is raised is sum is nil
-        def initialize(url, sum:, workdir:, **options)
+        def initialize(url, sum:, workdir:, sum_type:, **options)
           unless sum
             fail "sum is required to validate the http source"
+          end
+          unless sum_type
+            fail "sum_type is required to validate the http source"
           end
           @url = url
           @sum = sum
           @workdir = workdir
+          @sum_type = sum_type
         end
 
         # Download the source from the url specified. Sets the full path to the
@@ -65,12 +70,12 @@ class Vanagon
         # Verify the downloaded file matches the provided sum
         #
         # @raise [RuntimeError] an exception is raised if the sum does not match the sum of the file
-        def verify
+        def verify # rubocop:disable Metrics/AbcSize
           puts "Verifying file: #{file} against sum: '#{sum}'"
-          actual = get_md5sum(File.join(workdir, file))
+          actual = get_sum(File.join(workdir, file), sum_type)
           return true if sum == actual
 
-          fail "Unable to verify '#{File.join(workdir, file)}': md5sum mismatch (expected '#{sum}', got '#{actual}'')"
+          fail "Unable to verify '#{File.join(workdir, file)}': #{sum_type} mismatch (expected '#{sum}', got '#{actual}')"
         end
 
         # Downloads the file from @url into the @workdir

--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -19,7 +19,7 @@ class Vanagon
     # @param file [String] file to md5sum
     # @return [String] md5sum of the given file
     def get_md5sum(file)
-      Digest::MD5.file(file).hexdigest.to_s
+      get_sum(file, 'md5')
     end
 
     # Generic file summing utility
@@ -32,6 +32,8 @@ class Vanagon
       case type.downcase
       when 'md5'
         Digest::MD5.file(file).hexdigest.to_s
+      when 'sha256'
+        Digest::SHA256.file(file).hexdigest.to_s
       when 'sha512'
         Digest::SHA512.file(file).hexdigest.to_s
       else

--- a/spec/lib/vanagon/component/source/http_spec.rb
+++ b/spec/lib/vanagon/component/source/http_spec.rb
@@ -10,21 +10,59 @@ describe "Vanagon::Component::Source::Http" do
   let (:plaintext_url) { "#{base_url}/#{plaintext_filename}" }
   let (:plaintext_dirname) { './' }
   let (:md5sum) { 'abcdssasasa' }
+  let (:sha256sum) { 'foobarbaz' }
+  let (:sha512sum) { 'teststring' }
   let (:workdir) { "/tmp" }
 
   describe "#dirname" do
     it "returns the name of the tarball, minus extension for archives" do
-      http_source = Vanagon::Component::Source::Http.new(tar_url, sum: md5sum, workdir: workdir)
+      http_source = Vanagon::Component::Source::Http.new(tar_url, sum: md5sum, workdir: workdir, sum_type: "md5")
       expect(http_source).to receive(:download).and_return(tar_filename)
       http_source.fetch
       expect(http_source.dirname).to eq(tar_dirname)
     end
 
     it "returns the current directory for non-archive files" do
-      http_source = Vanagon::Component::Source::Http.new(plaintext_url, sum: md5sum, workdir: workdir)
+      http_source = Vanagon::Component::Source::Http.new(plaintext_url, sum: md5sum, workdir: workdir, sum_type: "md5")
       expect(http_source).to receive(:download).and_return(plaintext_filename)
       http_source.fetch
       expect(http_source.dirname).to eq(plaintext_dirname)
+    end
+  end
+
+  describe "verify" do
+    it "fails with a bad sum_type" do
+      http_source = Vanagon::Component::Source::Http.new(plaintext_url, sum: md5sum, workdir: workdir, sum_type: "md4")
+      expect(http_source).to receive(:download).and_return(plaintext_filename)
+      http_source.fetch
+      expect{ http_source.verify }.to raise_error(RuntimeError)
+    end
+
+    it "calls md5 digest when it's supposed to" do
+      Digest::MD5.any_instance.stub(:file).and_return(Digest::MD5.new)
+      Digest::MD5.any_instance.stub(:hexdigest).and_return(md5sum)
+      http_source = Vanagon::Component::Source::Http.new(plaintext_url, sum: md5sum, workdir: workdir, sum_type: "md5")
+      expect(http_source).to receive(:download).and_return(plaintext_filename)
+      http_source.fetch
+      http_source.verify
+    end
+
+    it "calls sha256 digest when it's supposed to" do
+      Digest::SHA256.any_instance.stub(:file).and_return(Digest::SHA256.new)
+      Digest::SHA256.any_instance.stub(:hexdigest).and_return(sha256sum)
+      http_source = Vanagon::Component::Source::Http.new(plaintext_url, sum: sha256sum, workdir: workdir, sum_type: "sha256")
+      expect(http_source).to receive(:download).and_return(plaintext_filename)
+      http_source.fetch
+      http_source.verify
+    end
+
+    it "calls sha512 digest when it's supposed to" do
+      Digest::SHA512.any_instance.stub(:file).and_return(Digest::SHA512.new)
+      Digest::SHA512.any_instance.stub(:hexdigest).and_return(sha512sum)
+      http_source = Vanagon::Component::Source::Http.new(plaintext_url, sum: sha512sum, workdir: workdir, sum_type: "sha512")
+      expect(http_source).to receive(:download).and_return(plaintext_filename)
+      http_source.fetch
+      http_source.verify
     end
   end
 end

--- a/spec/lib/vanagon/component/source_spec.rb
+++ b/spec/lib/vanagon/component/source_spec.rb
@@ -94,12 +94,12 @@ describe "Vanagon::Component::Source" do
       end
 
       it "returns an object of the correct type for http:// URLS" do
-        expect(klass.source(http_url, sum: sum, workdir: workdir).class)
+        expect(klass.source(http_url, sum: sum, workdir: workdir, sum_type: "md5").class)
           .to equal(Vanagon::Component::Source::Http)
       end
 
       it "returns an object of the correct type for https:// URLS" do
-        expect(klass.source(https_url, sum: sum, workdir: workdir).class)
+        expect(klass.source(https_url, sum: sum, workdir: workdir, sum_type: "md5").class)
           .to equal(Vanagon::Component::Source::Http)
       end
 
@@ -108,7 +108,7 @@ describe "Vanagon::Component::Source" do
           'http://buildsources.delivery.puppetlabs.net'
       end
       it "applies rewrite rules to HTTP URLs" do
-        expect(klass.source(original_http_url, sum: sum, workdir: workdir).url)
+        expect(klass.source(original_http_url, sum: sum, workdir: workdir, sum_type: "md5").url)
           .to eq(rewritten_http_url)
       end
     end


### PR DESCRIPTION
Before, we were only verifying http sources use md5. Modified vanagon to support multiple sum types by adding a sum_type parameter. We now support sha256, sha512, and md5.