### PR TITLE
[DO NOT MERGE] (RE-8057) Use .PHONY on component rules

### DIFF
--- a/resources/Makefile.erb
+++ b/resources/Makefile.erb
@@ -62,4 +62,4 @@ clean: <%= @components.map {|comp| "#{comp.name}-clean" }.join(" ") %>
 
 clobber: <%= @components.map {|comp| "#{comp.name}-clobber" }.join(" ") %>
 
-.PHONY: clean clobber  <%= @components.map {|comp| "#{comp.name}-clean #{comp.name}-clobber" }.join(" ") %>
+.PHONY: clean clobber  <%= @components.map {|comp| "#{comp.name} #{comp.name}-clean #{comp.name}-clobber" }.join(" ") %>


### PR DESCRIPTION
We uncovered an issue when installing a file with the same name as one of the
make targets. This commit updates the make invocation to include component
names in the list of .PHONY targets in the makefile which fixes the issue.
