### PR TITLE
(VANAGON-8) Add the ability to only build single components in vanagon

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -2,7 +2,7 @@
 load File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "vanagon.rb"))
 
 optparse = Vanagon::OptParse.new("#{File.basename(__FILE__)} <project-name> <platform-name> [<target>] [options]",
-                                 [:workdir, :configdir, :engine, :preserve, :verbose, :skipcheck])
+                                 [:workdir, :configdir, :engine, :preserve, :verbose, :skipcheck, :only_build])
 options = optparse.parse! ARGV
 
 project = ARGV[0]

--- a/lib/vanagon/optparse.rb
+++ b/lib/vanagon/optparse.rb
@@ -10,6 +10,7 @@ class Vanagon
         :skipcheck => ['--skipcheck', 'Skip the `check` stage when building components'],
         :preserve => ['-p', '--preserve', 'Whether to tear down the VM on success or not (defaults to false)'],
         :verbose => ['-v', '--verbose', 'Verbose output (does nothing)'],
+        :only_build => ["--only-build COMPONENT,COMPONENT,...", Array, 'Only build this array of components']
       }.freeze
 
     def initialize(banner, options = [])

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -82,6 +82,39 @@ class Vanagon
       files.flatten.uniq
     end
 
+    # Returns a filtered out set of components only including those
+    # components necessary to build a specific component. This is a
+    # recursive function that will call itself until it gets to a
+    # component with no build requirements
+    #
+    # @param name [String] name of component to add. must be present in configdir/components and named $name.rb currently
+    # @return [Array] array of Vanagon::Component including only those required to build "name", or [] if there are none
+    def filter_component(name)
+      filtered_component = get_component(name)
+      return [] if filtered_component.nil?
+      included_components = [filtered_component]
+
+      unless filtered_component.build_requires.empty?
+        filtered_component.build_requires.each do |build_requirement|
+          unless get_component(build_requirement).nil?
+            included_components += filter_component(build_requirement)
+          end
+        end
+      end
+      included_components.uniq
+    end
+
+    # Gets the component with component.name = "name" from the list
+    # of project.components
+    #
+    # @param [String] component name
+    # @return [Vanagon::Component] the component with component.name = "name"
+    def get_component(name)
+      comps = @components.select { |comp| comp.name.to_s == name.to_s }
+      raise "ERROR: two or more components with the same name: #{comps.first.name}" if comps.size > 1
+      comps.first
+    end
+
     # Collects all of the requires for both the project and its components
     #
     # @return [Array] array of runtime requirements for the project

--- a/spec/lib/vanagon/project_spec.rb
+++ b/spec/lib/vanagon/project_spec.rb
@@ -11,13 +11,15 @@ describe 'Vanagon::Project' do
     end"
   }
 
-  before do
-    allow_any_instance_of(Vanagon::Project::DSL).to receive(:puts)
-    allow(Vanagon::Driver).to receive(:configdir).and_return(configdir)
-    allow(Vanagon::Component).to receive(:load_component).with('some-component', any_args).and_return(component)
-  end
 
   describe '#get_root_directories' do
+
+    before do
+      allow_any_instance_of(Vanagon::Project::DSL).to receive(:puts)
+      allow(Vanagon::Driver).to receive(:configdir).and_return(configdir)
+      allow(Vanagon::Component).to receive(:load_component).with('some-component', any_args).and_return(component)
+    end
+
     let(:test_sets) do
       [
         {
@@ -39,6 +41,78 @@ describe 'Vanagon::Project' do
         set[:directories].each {|dir| proj.directory dir }
         expect(proj._project.get_root_directories.sort).to eq(set[:results].sort)
       end
+    end
+  end
+
+  describe "#filter_component" do
+
+    # All of the following tests should be run with one project level
+    # component that isn't included in the build_deps of another component
+    before(:each) do
+      @proj = Vanagon::Project.new('test-fixture-with-comps', {})
+      @not_included_comp = Vanagon::Component.new('test-fixture-not-included', {}, {})
+      @proj.components << @not_included_comp
+    end
+
+    it "returns nil when given a component that doesn't exist" do
+      expect(@proj.filter_component("fake")).to eq([])
+    end
+
+    it "returns only the component with no build deps" do
+      comp = Vanagon::Component.new('test-fixture1', {}, {})
+      @proj.components << comp
+      expect(@proj.filter_component(comp.name)).to eq([comp])
+    end
+
+    it "returns component and one build dep" do
+      comp1 = Vanagon::Component.new('test-fixture1', {}, {})
+      comp2 = Vanagon::Component.new('test-fixture2', {}, {})
+      comp1.build_requires << comp2.name
+      @proj.components << comp1
+      @proj.components << comp2
+      expect(@proj.filter_component(comp1.name)).to eq([comp1, comp2])
+    end
+
+    it "returns only the component with build deps that are not components of the @project" do
+      comp = Vanagon::Component.new('test-fixture1', {}, {})
+      comp.build_requires << "fake-name"
+      @proj.components << comp
+      expect(@proj.filter_component(comp.name)).to eq([comp])
+    end
+
+    it "returns the component and build deps with both @project components and external build deps" do
+      comp1 = Vanagon::Component.new('test-fixture1', {}, {})
+      comp2 = Vanagon::Component.new('test-fixture2', {}, {})
+      comp1.build_requires << comp2.name
+      comp1.build_requires << "fake-name"
+      @proj.components << comp1
+      @proj.components << comp2
+      expect(@proj.filter_component(comp1.name)).to eq([comp1, comp2])
+    end
+
+    it "returns the component and multiple build deps" do
+      comp1 = Vanagon::Component.new('test-fixture1', {}, {})
+      comp2 = Vanagon::Component.new('test-fixture2', {}, {})
+      comp3 = Vanagon::Component.new('test-fixture3', {}, {})
+      comp1.build_requires << comp2.name
+      comp1.build_requires << comp3.name
+      @proj.components << comp1
+      @proj.components << comp2
+      @proj.components << comp3
+      expect(@proj.filter_component(comp1.name)).to eq([comp1, comp2, comp3])
+    end
+
+    it "returns the component and multiple build deps with external build deps" do
+      comp1 = Vanagon::Component.new('test-fixture1', {}, {})
+      comp2 = Vanagon::Component.new('test-fixture2', {}, {})
+      comp3 = Vanagon::Component.new('test-fixture3', {}, {})
+      comp1.build_requires << comp2.name
+      comp1.build_requires << comp3.name
+      comp1.build_requires << "another-fake-name"
+      @proj.components << comp1
+      @proj.components << comp2
+      @proj.components << comp3
+      expect(@proj.filter_component(comp1.name)).to eq([comp1, comp2, comp3])
     end
   end
 end


### PR DESCRIPTION
The use case for devs is they need to only build a single component and it's
dependencies. This PR solves this by adding a filter_components function to
the project class that recursively compiles all the components build
dependencies (and the build dependencies' dependencies and so on) together in
to one array. The driver class will use that function and replace the project
objects' components array with the output of filter_components.

Vanagon is built well enough to handle the rest, all build steps and makefile
rules can remain the same.

This should be a strictly additive change, and should not affect any current
build processes.

Usage: bundle exec build <project> <platform> [--only-build <components>]
where <components> is a comma seperated list
