### PR TITLE
(VANAGON-14) Use md5 as the default checksum type if not specified

### DIFF
--- a/lib/vanagon/component/source.rb
+++ b/lib/vanagon/component/source.rb
@@ -88,7 +88,8 @@ class Vanagon
             return Vanagon::Component::Source::Http.new parse_and_rewrite(uri),
               sum: options[:sum],
               workdir: options[:workdir],
-              sum_type: options[:sum_type]
+              # Default sum_type is md5 if unspecified:
+              sum_type: options[:sum_type] || "md5"
           end
 
           # Then we try local


### PR DESCRIPTION
Now that we support multiple checksum types for validating http sources,
assume md5 if sum_type isn't explicitly set.