### PR TITLE
(QENG-4456) sneak in support for scheduled hardware under a feature flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ rvm:
   - 2.2.0
 
 env:
-  - "CHECK='rspec spec --color --format documentation --order random'"
+  - "CHECK='rspec spec --color --format documentation --order random --require spec_helper.rb'"
   - "CHECK='rubocop -D'"
 
 matrix:

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -34,23 +34,31 @@ class Vanagon
     end
 
     def load_engine(engine_type, platform, target)
-      if platform.build_hosts
-        engine_type = 'hardware'
-      elsif platform.aws_ami
-        engine_type = 'ec2'
-      elsif platform.docker_image
-        engine_type = 'docker'
-      elsif target
-        engine_type = 'base'
+      if engine_type != 'always_be_scheduling'
+        if platform.build_hosts
+          engine_type = 'hardware'
+        elsif platform.aws_ami
+          engine_type = 'ec2'
+        elsif platform.docker_image
+          engine_type = 'docker'
+        elsif target
+          engine_type = 'base'
+        end
       end
       load_engine_object(engine_type, platform, target)
     end
 
     def load_engine_object(engine_type, platform, target)
       require "vanagon/engine/#{engine_type}"
-      @engine = Object::const_get("Vanagon::Engine::#{engine_type.capitalize}").new(platform, target)
+      @engine = Object::const_get("Vanagon::Engine::#{camelize(engine_type)}").new(platform, target)
     rescue
-      fail "No such engine '#{engine_type.capitalize}'"
+      fail "No such engine '#{camelize(engine_type)}'"
+    end
+
+    def camelize(string)
+      string.gsub(/(?:^|_)([a-z])?/) do |match|
+        (Regexp.last_match[1] || '').capitalize
+      end
     end
 
     def cleanup_workdir

--- a/lib/vanagon/engine/always_be_scheduling.rb
+++ b/lib/vanagon/engine/always_be_scheduling.rb
@@ -1,0 +1,92 @@
+require 'vanagon/engine/base'
+require 'json'
+
+class Vanagon
+  class Engine
+    # This engine allows build resources to be managed by the "Always be
+    # Scheduling" (ABS) scheduler (https://github.com/puppetlabs/always-be-scheduling)
+    #
+    # ABS expects to ask `build_host_info` for the needed resources for a build,
+    # and to have that return a platform name.  ABS will then acquire the
+    # desired build host resources and will later run a vanagon build, passing
+    # those resource hostnames in specifically.
+    #
+    # `build_host_info` will normally use the `hardware` engine when a hardware
+    # platform is queried. The `always_be_scheduling` engine's behavior will
+    # be invoked instead when:
+    #
+    # `build_host_info ... --engine always_be_scheduling` is specified on the
+    # command-line.
+    #
+    # Configuration:
+    #
+    # Project platform configurations can specify the platform name to be returned
+    # via the `abs_resource_name` attribute. If this is not set but `vmpooler_template`
+    # is set, then the `vmpooler_template` value will be used. Otherwise, the
+    # platform name will be returned unchanged.
+    #
+    # Example 1:
+    #
+    # platform 'ubuntu-10.04-amd64' do |plat|
+    #   plat.vmpooler_template 'ubuntu-1004-amd64'
+    # end
+    #
+    # $ build_host_info puppet-agent ubuntu-10.04-amd64
+    # {"name":"ubuntu-10.04-amd64","engine":"pooler"}
+    #
+    # $ build_host_info puppet-agent ubuntu-10.04-amd64 --engine always_be_scheduling
+    # {"name":"ubuntu-10.04-amd64","engine":"always_be_scheduling"}
+    #
+    #
+    # Example 2:
+    #
+    # platform 'aix-5.3-ppc' do |plat|
+    #   plat.build_host ['aix53-builder-1.example.com']
+    #   plat.abs_resource_name 'aix-53-ppc'
+    # end
+    #
+    # $ build_host_info puppet-agent aix-5.3-ppc
+    # {"name":"aix53-builder-1.example.com","engine":"hardware"}
+    #
+    # $ build_host_info puppet-agent aix-5.3-ppc --engine always_be_scheduling
+    # {"name":"aix-53-ppc","engine":"always_be_scheduling"}
+    #
+    #
+    # Example 3:
+    #
+    # platform 'aix-5.3-ppc' do |plat|
+    #   plat.build_host ['aix53-builder-1.example.com']
+    #   plat.vmpooler_template
+    #   plat.abs_resource_name 'aix-53-ppc'
+    # end
+    #
+    # $ build_host_info puppet-agent aix-5.3-ppc
+    # {"name":"aix53-builder-1.example.com","engine":"hardware"}
+    #
+    # $ build_host_info puppet-agent aix-5.3-ppc --engine always_be_scheduling
+    # {"name":"aix-53-ppc","engine":"always_be_scheduling"}
+    class AlwaysBeScheduling < Base
+      def initialize(platform, target)
+        super
+
+        Vanagon::Driver.logger.debug "AlwaysBeScheduling engine invoked."
+      end
+
+      # Get the engine name
+      def name
+        'always_be_scheduling'
+      end
+
+      # return the platform name as the "host" name
+      def build_host_name
+        if @platform.abs_resource_name
+          @platform.abs_resource_name
+        elsif @platform.vmpooler_template
+          @platform.vmpooler_template
+        else
+          @platform.name
+        end
+      end
+    end
+  end
+end

--- a/lib/vanagon/engine/hardware.rb
+++ b/lib/vanagon/engine/hardware.rb
@@ -27,7 +27,7 @@ class Vanagon
         host
       end
 
-      # Iterarte over the options and find a node open to lock.
+      # Iterate over the options and find a node open to lock.
       def node_lock(hosts)
         hosts.each do |h|
           Vanagon::Driver.logger.info "Attempting  to lock #{h}."

--- a/lib/vanagon/engine/pooler.rb
+++ b/lib/vanagon/engine/pooler.rb
@@ -32,15 +32,17 @@ class Vanagon
       # This method loads the pooler token from one of two locations
       # @return [String, nil] token for use with the vmpooler
       def load_token
-        if ENV['VMPOOLER_TOKEN']
-          token = ENV['VMPOOLER_TOKEN']
-        else
-          token_file = File.expand_path("~/.vanagon-token")
-          if File.exist?(token_file)
-            token = File.open(token_file).read.chomp
-          end
+        ENV['VMPOOLER_TOKEN'] ? ENV['VMPOOLER_TOKEN'] : token_from_file
+      end
+
+      def token_from_file
+        token_file = File.expand_path("~/.vanagon-token")
+
+        if File.exist?(token_file)
+          return File.open(token_file).read.chomp
         end
-        token
+
+        nil
       end
 
       # This method is used to obtain a vm to build upon using the Puppet Labs'

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -2,13 +2,16 @@ require 'vanagon/platform/dsl'
 
 class Vanagon
   class Platform
-    attr_accessor :make, :servicedir, :defaultdir, :provisioning, :num_cores, :tar
-    attr_accessor :build_dependencies, :name, :vmpooler_template, :cflags, :ldflags, :settings
-    attr_accessor :servicetype, :patch, :architecture, :codename, :os_name, :os_version
-    attr_accessor :docker_image, :ssh_port, :rpmbuild, :install, :platform_triple
-    attr_accessor :target_user, :package_type, :find, :sort, :build_hosts, :copy, :cross_compiled
-    attr_accessor :aws_ami, :aws_user_data, :aws_shutdown_behavior, :aws_key_name, :aws_region, :aws_key
-    attr_accessor :aws_instance_type, :aws_vpc_id, :aws_subnet_id, :output_dir
+    attr_accessor :make, :servicedir, :defaultdir, :provisioning, :num_cores
+    attr_accessor :tar, :build_dependencies, :name, :vmpooler_template
+    attr_accessor :abs_resource_name, :cflags, :ldflags, :settings
+    attr_accessor :servicetype, :patch, :architecture, :codename, :os_name
+    attr_accessor :os_version, :docker_image, :ssh_port, :rpmbuild, :install
+    attr_accessor :platform_triple, :target_user, :package_type, :find, :sort
+    attr_accessor :build_hosts, :copy, :cross_compiled, :aws_ami
+    attr_accessor :aws_user_data, :aws_shutdown_behavior, :aws_key_name
+    attr_accessor :aws_region, :aws_key, :aws_instance_type, :aws_vpc_id
+    attr_accessor :aws_subnet_id, :output_dir
 
     # Platform names currently contain some information about the platform. Fields
     # within the name are delimited by the '-' character, and this regex can be used to

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -221,6 +221,13 @@ class Vanagon
         self.vmpooler_template(name)
       end
 
+      # Set the name of this platform as always-be-scheduling (ABS) expects it
+      #
+      # @param name [String] name of the platform to request from always-be-scheduling
+      def abs_resource_name(name)
+        @platform.abs_resource_name = name
+      end
+
       # Set the name of the docker image to use
       #
       # @param name [String] name of the docker image to use

--- a/spec/lib/vanagon/component/source/http_spec.rb
+++ b/spec/lib/vanagon/component/source/http_spec.rb
@@ -39,8 +39,8 @@ describe "Vanagon::Component::Source::Http" do
     end
 
     it "calls md5 digest when it's supposed to" do
-      Digest::MD5.any_instance.stub(:file).and_return(Digest::MD5.new)
-      Digest::MD5.any_instance.stub(:hexdigest).and_return(md5sum)
+      allow_any_instance_of(Digest::MD5).to receive(:file).and_return(Digest::MD5.new)
+      allow_any_instance_of(Digest::MD5).to receive(:hexdigest).and_return(md5sum)
       http_source = Vanagon::Component::Source::Http.new(plaintext_url, sum: md5sum, workdir: workdir, sum_type: "md5")
       expect(http_source).to receive(:download).and_return(plaintext_filename)
       http_source.fetch
@@ -48,8 +48,8 @@ describe "Vanagon::Component::Source::Http" do
     end
 
     it "calls sha256 digest when it's supposed to" do
-      Digest::SHA256.any_instance.stub(:file).and_return(Digest::SHA256.new)
-      Digest::SHA256.any_instance.stub(:hexdigest).and_return(sha256sum)
+      allow_any_instance_of(Digest::SHA256).to receive(:file).and_return(Digest::SHA256.new)
+      allow_any_instance_of(Digest::SHA256).to receive(:hexdigest).and_return(sha256sum)
       http_source = Vanagon::Component::Source::Http.new(plaintext_url, sum: sha256sum, workdir: workdir, sum_type: "sha256")
       expect(http_source).to receive(:download).and_return(plaintext_filename)
       http_source.fetch
@@ -57,8 +57,8 @@ describe "Vanagon::Component::Source::Http" do
     end
 
     it "calls sha512 digest when it's supposed to" do
-      Digest::SHA512.any_instance.stub(:file).and_return(Digest::SHA512.new)
-      Digest::SHA512.any_instance.stub(:hexdigest).and_return(sha512sum)
+      allow_any_instance_of(Digest::SHA512).to receive(:file).and_return(Digest::SHA512.new)
+      allow_any_instance_of(Digest::SHA512).to receive(:hexdigest).and_return(sha512sum)
       http_source = Vanagon::Component::Source::Http.new(plaintext_url, sum: sha512sum, workdir: workdir, sum_type: "sha512")
       expect(http_source).to receive(:download).and_return(plaintext_filename)
       http_source.fetch

--- a/spec/lib/vanagon/driver_spec.rb
+++ b/spec/lib/vanagon/driver_spec.rb
@@ -54,6 +54,39 @@ describe 'Vanagon::Driver' do
                               'engine' => 'hardware' })
     end
 
+    it 'returns the first build_host using the hardware engine when not using an engine, and not specifying an engine in the platform configuration' do
+      platform = eval_platform('aix-7.1-ppc', <<-END)
+        platform 'aix-7.1-ppc' do |plat|
+          plat.build_host ["pe-aix-71-01", "pe-aix-71-02"]
+        end
+      END
+
+      info = create_driver(platform).build_host_info
+
+      expect(info).to match({ 'name'   => 'pe-aix-71-01',
+                              'engine' => 'hardware' })
+    end
+
+    it 'returns the platform and the always_be_scheduling engine when using the always_be_scheduling engine' do
+      platform = eval_platform('aix-7.1-ppc', <<-END)
+        platform 'aix-7.1-ppc' do |plat|
+          plat.build_host ["pe-aix-71-01", "pe-aix-71-02"]
+        end
+      END
+
+      info = create_driver(platform, :engine => 'always_be_scheduling').build_host_info
+
+      expect(info).to match({ 'name'   => 'aix-7.1-ppc',
+                              'engine' => 'always_be_scheduling' })
+    end
+
+    it 'returns the vmpooler_template using the always_be_scheduling engine when using the always_be_scheduling engine' do
+      info = create_driver(redhat, :engine => 'always_be_scheduling').build_host_info
+
+      expect(info).to match({ 'name'   => 'centos-7-x86_64',
+                              'engine' => 'always_be_scheduling' })
+    end
+
     it 'returns the docker_image using the docker engine' do
       platform = eval_platform('el-7-x86_64', <<-END)
         platform 'el-7-x86_64' do |plat|
@@ -85,4 +118,3 @@ describe 'Vanagon::Driver' do
     end
   end
 end
-

--- a/spec/lib/vanagon/engine/always_be_scheduling_spec.rb
+++ b/spec/lib/vanagon/engine/always_be_scheduling_spec.rb
@@ -1,0 +1,84 @@
+require 'vanagon/engine/always_be_scheduling'
+require 'vanagon/driver'
+require 'vanagon/platform'
+require 'logger'
+
+class Vanagon
+  class Driver
+    @@logger = Logger.new('/dev/null')
+  end
+end
+
+describe 'Vanagon::Engine::AlwaysBeScheduling' do
+  let (:platform) {
+    plat = Vanagon::Platform::DSL.new('aix-6.1-ppc')
+    plat.instance_eval("platform 'aix-6.1-ppc' do |plat|
+                      plat.build_host 'abcd'
+                    end")
+    plat._platform
+  }
+
+  let (:platform_with_vmpooler_template) {
+    plat = Vanagon::Platform::DSL.new('ubuntu-10.04-amd64 ')
+    plat.instance_eval("platform 'aix-6.1-ppc' do |plat|
+                      plat.build_host 'abcd'
+                      plat.vmpooler_template 'ubuntu-1004-amd64'
+                    end")
+    plat._platform
+  }
+
+  let (:platform_with_abs_resource_name) {
+    plat = Vanagon::Platform::DSL.new('aix-6.1-ppc')
+    plat.instance_eval("platform 'aix-6.1-ppc' do |plat|
+                      plat.build_host 'abcd'
+                      plat.abs_resource_name 'aix-61-ppc'
+                    end")
+    plat._platform
+  }
+
+  let (:platform_with_both) {
+    plat = Vanagon::Platform::DSL.new('aix-6.1-ppc')
+    plat.instance_eval("platform 'aix-6.1-ppc' do |plat|
+                      plat.build_host 'abcd'
+                      plat.vmpooler_template 'aix-six-one-ppc'
+                      plat.abs_resource_name 'aix-61-ppc'
+                    end")
+    plat._platform
+  }
+
+  describe '#validate_platform' do
+    it 'returns true if the platform has the required attributes' do
+      expect(Vanagon::Engine::AlwaysBeScheduling.new(platform, nil).validate_platform)
+        .to be(true)
+    end
+  end
+
+  describe '#build_host_name' do
+    it 'by default returns the platform name with no translation' do
+      expect(Vanagon::Engine::AlwaysBeScheduling.new(platform, nil).build_host_name)
+        .to eq("aix-6.1-ppc")
+    end
+
+    it 'returns vmpooler_template if vmpooler_template is specified' do
+      expect(Vanagon::Engine::AlwaysBeScheduling.new(platform_with_vmpooler_template, nil).build_host_name)
+        .to eq("ubuntu-1004-amd64")
+    end
+
+    it 'returns abs_resource_name if abs_resource_name is specified' do
+      expect(Vanagon::Engine::AlwaysBeScheduling.new(platform_with_abs_resource_name, nil).build_host_name)
+        .to eq("aix-61-ppc")
+    end
+
+    it 'prefers abs_resource_name to vmpooler_template if both are specified' do
+      expect(Vanagon::Engine::AlwaysBeScheduling.new(platform_with_both, nil).build_host_name)
+        .to eq("aix-61-ppc")
+    end
+  end
+
+  describe '#name' do
+    it 'returns "always_be_scheduling" engine name' do
+      expect(Vanagon::Engine::AlwaysBeScheduling.new(platform, nil).name)
+        .to eq('always_be_scheduling')
+    end
+  end
+end

--- a/spec/lib/vanagon/platform/dsl_spec.rb
+++ b/spec/lib/vanagon/platform/dsl_spec.rb
@@ -20,6 +20,11 @@ describe 'Vanagon::Platform::DSL' do
 
   let(:hex_value) { "906264d248061b0edb1a576cc9c8f6c7" }
 
+  before :each do
+    # suppress `#warn` output during tests
+    allow_any_instance_of(Vanagon::Platform::DSL).to receive(:warn)
+  end
+
   # These apt_repo, yum_repo, and zypper_repo methods are all deprecated.
   describe '#apt_repo' do
     it "grabs the file and adds .list to it" do

--- a/spec/lib/vanagon/platform/dsl_spec.rb
+++ b/spec/lib/vanagon/platform/dsl_spec.rb
@@ -111,6 +111,15 @@ describe 'Vanagon::Platform::DSL' do
     end
   end
 
+  describe '#abs_resource_name' do
+    it 'sets the instance variable on platform' do
+      plat = Vanagon::Platform::DSL.new('solaris-test-fixture')
+      plat.instance_eval(solaris_10_platform_block)
+      plat.abs_resource_name 'solaris-10-x86_64'
+      expect(plat._platform.abs_resource_name).to eq('solaris-10-x86_64')
+    end
+  end
+
   describe '#vmpooler_template' do
     it 'sets the instance variable on platform' do
       plat = Vanagon::Platform::DSL.new('solaris-test-fixture')

--- a/spec/lib/vanagon/platform/windows_spec.rb
+++ b/spec/lib/vanagon/platform/windows_spec.rb
@@ -135,7 +135,7 @@ HERE
 
         it "Copies Hierarchy of files from Product Specific Directory to output directory with ERB translation as necessary" do
           # setup source directories and run artifact generation
-          FileUtils.cp_r("#{WIXTESTFILES}/", "#{PROJ_ROOT}/resources/windows/", :verbose => true)
+          FileUtils.cp_r("#{WIXTESTFILES}/", "#{PROJ_ROOT}/resources/windows/")
           cur_plat._platform.generate_msi_packaging_artifacts(WORKDIR, plat[:projname], binding)
           # check the result
           expect(File).to exist("#{WORKDIR}/wix/file-1.wxs")
@@ -154,7 +154,7 @@ HERE
 
         it "Copies Hierarchy of files from vanagon directory to output directory with ERB translation as necessary" do
           # setup source directories and run artifact generation
-          FileUtils.cp_r("#{WIXTESTFILES}/", "#{VANAGON_ROOT}/resources/windows/", :verbose => true)
+          FileUtils.cp_r("#{WIXTESTFILES}/", "#{VANAGON_ROOT}/resources/windows/")
           cur_plat._platform.generate_msi_packaging_artifacts(WORKDIR, plat[:projname], binding)
           # check the result
           expect(File).to exist("#{WORKDIR}/wix/file-1.wxs")

--- a/spec/lib/vanagon/utilities_spec.rb
+++ b/spec/lib/vanagon/utilities_spec.rb
@@ -2,6 +2,11 @@ require 'vanagon/utilities'
 require 'tmpdir'
 
 describe "Vanagon::Utilities" do
+  before :each do
+    # suppress `#warn` output during tests
+    allow(Vanagon::Utilities).to receive(:warn)
+  end
+
   describe "#find_program_on_path" do
     let(:command) { "thingie" }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,14 @@
 RSpec.configure do |c|
   c.before do
-    allow($stdout).to receive(:puts)
-    allow($stderr).to receive(:puts)
+    allow_any_instance_of(Vanagon::Component::Source::Git).to receive(:puts)
+    allow_any_instance_of(Vanagon::Component::Source::Http).to receive(:puts)
+    allow_any_instance_of(Vanagon::Component::Source::Local).to receive(:puts)
+
+    class Vanagon
+      module Utilities
+        def puts(*args)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
![](http://i0.wp.com/liveworkwander.com/wp-content/uploads/2015/04/Magnum-P.I.-T.C.-Vanagon-Model-640x478.jpg?resize=630%2C471)

We have an internal need for supporting the management of hardware build hosts through a common centralized scheduler, specifically [always-be-scheduling](https://github.com/puppetlabs/always-be-scheduling) (ABS).

Prior to this work, vanagon would manage hardware itself: configs would list the specific hardware resources which were known for building on a given platform/target. We would allocate the hardware instance, use the `lock_manager` to control access, etc.

In a world of scheduled hardware, allocation, lock management, setup, teardown, etc., are all Someone Else's Responsibility™.  This change allows authors to opt-in to an "always_be_scheduling" engine, which leaves the host management up to a third-party scheduler for certain platforms.

Additionally, as we wish [vmpooler](https://github.com/puppetlabs/vmpooler)-based vanagon builds in the always-be-scheduling world to allow ABS to manage assignment of vmpooler resources, here we allow the `always_be_scheduling` vanagon engine to manage those resources as well.

This is feature-flagged behind a command-line switch and can be enabled like so:

``` shell
$ build_host_info puppet-agent aix-5.3-ppc
{"name":"pe-aix-53-builder.example.com","engine":"hardware"}

$ build_host_info puppet-agent aix-5.3-ppc --engine always_be_scheduling
{"name":"aix-5.3-ppc","engine":"always_be_scheduling"}
```

In project platform configuration files we introduce the `abs_resource_name` attribute. When specified, the `always_be_scheduling` engine will use that `abs_resource_name` value as the returned platform name. If this is not available, the `vmpooler_template` value will be used.  If neither is available, the platform name string will be returned unchanged.

**tasks**
- [x] Create a `scheduled` engine
- [x] Add support for an `engine` verb in the platform DSL
- [x] Add an `engine` attribute on the platform class
- [x] add a feature flag hook method to allow enabling scheduled hardware hosts
- [x] update the driver class to use a scheduled engine when the feature flag is on and the 'engine' verb is used in a build config
- [x] fix order-dependent test failures from times of yore
- [x] fix deprecations in rspec from times of yore
- [x] remove extraneous test output from times of yore
- [x] get :eyes: on this, to make sure it's remotely sane
- [x] drop `ENV` feature-flagging in favor of specifying the vanagon engine to trigger the new behavior
- [x] review naming, select appropriate names for the domain
- [x] use `always-be-scheduling` engine name instead of `scheduled`
- [x] add more documentation on the intent of the new scheduler support
- [x] translate outbound platform names to be vmpooler-style (for abs consumption)
  - 🚦 **but** have more discussion on this, as I think there are still a number of things to sort out
- [x] use `always-be-scheduling` engine for both hardware and vmpooler nodes
- [x] now we can drop the inline `.engine` support
- [x] document the `abs_resource_name` option better
- [ ] get another round of :eyes: on this 🛥 
- [ ] squash commits before merging

cc @puppetlabs/cinext @mckern @stahnma @shrug @sbeaulie @jameswagner2015 
