### PR TITLE
DO NOT MERGE (VANAGON-30) Add ability to specify package version numbers in build_…

### DIFF
--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -113,7 +113,8 @@ class Vanagon
       # build_requires adds a requirements to the list of build time dependencies
       # that will need to be fetched from an external source before this component
       # can be built. build_requires can also be satisfied by other components in
-      # the same project.
+      # the same project. An optional version number of a desired external package
+      # can be specified by appending '=<version>' to the package name.
       #
       # @param build_requirement [String] a library or other component that is required to build the current component
       def build_requires(build_requirement)


### PR DESCRIPTION
…requires

This allows you to specify version numbers by appending "=<version>" to
the package name. This currently only works for (and is needed for) Linux
platforms with package managers which by default grab the latest version
of a package from an online repository.

I've verified this feature works by specifying older versions of pl-boost when building the target pl-yaml-cpp for the following platforms:

* (apt) debian-8-amd64
* (yum) el-7-x86_64
* (zypper) sles-12-x86_64
* (dnf) fedora-f22-x86_64

Additionally, I ran a dynamic vanagon builder job with a p-a modified to use this vanagon branch and built pl-yaml-cpp for a variety of platforms:

http://jenkins-release.delivery.puppetlabs.net/job/vanagon_generic_job/664/