### PR TITLE
(maint) Fix bill-of-materials generation

### DIFF
--- a/resources/Makefile.erb
+++ b/resources/Makefile.erb
@@ -36,7 +36,7 @@ file-list: file-list-before-build <%= @name %>-project
 <%- end -%>
 
 <%- if @bill_of_materials -%>
-<%= @bill_of_materials %>:
+<%= @bill_of_materials.path %>:
 	mkdir -p '<%= @bill_of_materials.path %>'
 	mv bill-of-materials '<%= @bill_of_materials.path %>'
 <%- end -%>


### PR DESCRIPTION
The makefile dependency for the bill-of-materials was being incorrectly specified, which meant that any project using it would have broken dependencies for `@name-project`. This commit ensures the bill_of_materials target matches the dependency listed in the `@name-project` target.