### PR TITLE
Add note that build machines should be clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ the comma). If less targets are specified than platforms, the default engine
 (`pooler`) will be used for platforms without a target. If more targets are specified
 than platforms, the extra platforms will be ignored.
 
+Build machines should be cleaned between builds.
 
 #### Flagged arguments (can be anywhere in the command)
 


### PR DESCRIPTION
When building multiple subsequent builds on a build
target things can go wrong. In particular the list
of files taken before and after the installation
phase can be quite easily incorrect.

Realistically the only way to be sure to be clean is
to reinstall the build machine.