### PR TITLE
(CPR-393) puppetlabs-release-pc1 RPM on centos5

### DIFF
--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -48,6 +48,15 @@ Autoreq: 0
 <%- get_requires.each do |requires| -%>
 Requires:  <%= requires %>
 <%- end -%>
+# All rpm packages built by vanagon have the pre-/post-install script
+# boilerplates (defined below). These require `mkdir` and `touch` but previously
+# did not specify a dependency on these.
+# In the future, we will supress pre/post scripts completely if there's nothing
+# specified by the project or the components.
+Requires(pre): /bin/mkdir
+Requires(pre): /bin/touch
+Requires(post): /bin/mkdir
+Requires(post): /bin/touch
 <%- if has_services? -%>
   <%- if @platform.servicetype == "systemd" -%>
     <%- if @platform.is_sles? -%>


### PR DESCRIPTION
This commit adds a dependency on `mkdir` and `touch`, as they are used in the
pre- and post-install script boilerplates, which then get used by every project.
In the future, we will supress pre/post scripts completely if there's nothing
specified by the project or the components.