### PR TITLE
(MAINT) Add Simplecov support to Rakefile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,8 @@ group(:development, :test) do
   gem 'json'
   gem 'lock_manager', *lock_manager_location_for(ENV['LOCK_MANAGER_LOCATION'] || '>= 0')
   gem 'packaging', '~> 0.4.0', github: 'puppetlabs/packaging', branch: 'master'
-  gem 'rake'
+  gem 'simplecov', require: false
+  gem 'rake', require: false
   gem 'rspec', '~> 3.0', require: false
   gem 'rubocop', "~> 0.41.2", require: false
   gem 'yard', require: false

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ desc 'Test Vanagon'
 namespace :test do
   require 'rspec/core/rake_task'
   RSpec::Core::RakeTask.new do |task|
-    task.rspec_opts = %w(--format documentation --color --require spec_helper)
+    task.rspec_opts = %(--format documentation --color --require spec_helper)
   end
 
   desc 'Test Vanagon and calculate test coverage'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,12 @@
+if ENV["COVERAGE"]
+  require 'simplecov'
+  SimpleCov.start do
+    add_filter '.bundle'
+    add_filter 'spec'
+    add_filter 'vendor'
+  end
+end
+
 RSpec.configure do |c|
   c.before do
     allow_any_instance_of(Vanagon::Component::Source::Git).to receive(:puts)


### PR DESCRIPTION
[Simplecov](https://github.com/colszowka/simplecov) allows us to start building rough metrics for how much code in Vanagon is actually tested. It's not bulletproof, but any measurement is probably better than no measurement.