### PR TITLE
(MAINT) Fix tests that fail on macOS

### DIFF
--- a/spec/lib/vanagon/component/source/http_spec.rb
+++ b/spec/lib/vanagon/component/source/http_spec.rb
@@ -12,7 +12,7 @@ describe "Vanagon::Component::Source::Http" do
   let (:md5sum) { 'abcdssasasa' }
   let (:sha256sum) { 'foobarbaz' }
   let (:sha512sum) { 'teststring' }
-  let (:workdir) { "/tmp" }
+  let (:workdir) { Dir.mktmpdir }
 
   describe "#dirname" do
     it "returns the name of the tarball, minus extension for archives" do

--- a/spec/lib/vanagon/component/source/local_spec.rb
+++ b/spec/lib/vanagon/component/source/local_spec.rb
@@ -4,7 +4,7 @@ describe "Vanagon::Component::Source::File" do
   let (:file_base) { 'file://spec/fixtures/files/fake_file_ext' }
   let (:tar_filename) { 'file://spec/fixtures/files/fake_dir.tar.gz' }
   let (:plaintext_filename) { 'file://spec/fixtures/files/fake_file.txt' }
-  let (:workdir) { "/tmp" }
+  let (:workdir) { Dir.mktmpdir }
   let (:simple_directory) { 'file://spec/fixtures/files/fake_dir/' }
   let (:nested_directory) { 'file://spec/fixtures/files/fake_nested_dir/' }
 

--- a/spec/lib/vanagon/component/source_spec.rb
+++ b/spec/lib/vanagon/component/source_spec.rb
@@ -21,7 +21,7 @@ describe "Vanagon::Component::Source" do
 
     let(:ref) { "cafebeef" }
     let(:sum) { "abcd1234" }
-    let(:workdir) { "/tmp" }
+    let(:workdir) { Dir.mktmpdir }
 
     let(:original_git_url) { "git://things.and.stuff/foo-bar.git" }
     let(:rewritten_git_url) { "git://things.end.stuff/foo-ber.git" }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require 'tmpdir'
+
 if ENV["COVERAGE"]
   require 'simplecov'
   SimpleCov.start do


### PR DESCRIPTION
Thanks to macOS' [System Integrity Protection feature](https://en.wikipedia.org/wiki/System_Integrity_Protection), assuming that writing to `/tmp` will probably let you down. Instead, we should call `mktemp -d` or using Dir.mktmpdir from within Ruby. Any tests that hardcoded `/tmp` as a value have been updated.