### PR TITLE
(MAINT) Travis-CI fixups for the new Rakefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,20 @@
 language: ruby
-bundler_args: --without development
 sudo: false
 before_script:
-  - 'git config --global user.email "you@example.com"'
-  - 'git config --global user.name "Your Name"'
-script: "bundle exec $CHECK"
+  - 'git config --global user.email "travis-stub@example.com"'
+  - 'git config --global user.name "Fake Travis User"'
+script: "bundle exec ${CHECK}"
 notifications:
   email: false
 rvm:
-  - 2.1.5
-  - 2.2.0
+  - 2.1
+  - 2.2
 
 env:
-  - "CHECK='rspec spec --color --format documentation --order random --require spec_helper.rb'"
-  - "CHECK='rubocop -D'"
+  - "CHECK='rake test:spec'"
+  - "CHECK='rake rubocop'"
 
 matrix:
   exclude:
-    - rvm: 2.1.5
-      env: "CHECK='rubocop -D'"
+    - rvm: 2.1
+      env: "CHECK='rake rubocop'"

--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,9 @@ namespace :test do
 end
 
 desc 'Run RuboCop'
-RuboCop::RakeTask.new(:rubocop)
+RuboCop::RakeTask.new(:rubocop) do |task|
+  task.options << '--display-cop-names'
+end
 
 desc 'Run all spec tests and linters'
 task check: %w(test:spec rubocop)


### PR DESCRIPTION
Vanagon uses the same group for :development and :test, so there's no
benefit to running Bundler with the `--without-development` flag.

The stubbed-out Git config during `before_check` has been updated to be
slightly more informative

Travis will now run the `test:spec` task instead of calling rspec
directly.

Travis is now unpinned from specific Ruby versions, using the aliases
for the x.y releases we actually care about.

This commit also includes a quick fix for the Rakefile: making sure
that Rubocop displays the names of failing cops by default.