### PR TITLE
(MAINT) Improve spec coverage for token loading

### DIFF
--- a/spec/lib/vanagon/engine/pooler_spec.rb
+++ b/spec/lib/vanagon/engine/pooler_spec.rb
@@ -21,28 +21,88 @@ describe 'Vanagon::Engine::Pooler' do
   before :each do
     # suppress `#warn` output during tests
     allow_any_instance_of(Vanagon::Platform::DSL).to receive(:warn)
+
+    # stubbing ENV doesn't actually intercept ENV because ENV
+    # is special and you aren't. So we have to mangle the value
+    # of ENV around each of these tests if we want to prevent
+    # actual user credentials from being loaded, or attempt to
+    # validate the way that credentials are read.
+    ENV['REAL_HOME'] = ENV.delete 'HOME'
+    ENV['HOME'] = Dir.mktmpdir
+
+    # This should help maintain the ENV['HOME'] masquerade
+    allow(Dir).to receive(:home).and_return(ENV['HOME'])
   end
 
+  after :each do
+    # Altering ENV directly is a legitimate code-smell.
+    # We should at least clean up after ourselves.
+    ENV['HOME'] = ENV.delete 'REAL_HOME'
+  end
+
+  # We don't want to run the risk of reading legitimate user
+  # data from a user who is unfortunate enough to be running spec
+  # tests on their local machine. This means we have to intercept
+  # and stub out a very specific environment, where:
+  #   1) an environment variable exists
+  #   2) the env. var is unset, and only a ~/.vmpooler-token file exists
+  #   3) the env. var is unset, and only a ~/.vmfloaty.yml file exists
   describe "#load_token" do
-    after(:each) { ENV['VMPOOLER_TOKEN'] = nil }
+    let(:environment_value) { 'cafebeef' }
+    let(:token_value) { 'decade' }
+    let(:pooler_token_file) { File.expand_path('~/.vanagon-token') }
+    let(:floaty_config) { File.expand_path('~/.vmfloaty.yml') }
 
-    let(:token_file) { double(File) }
-    let(:token_filename) { 'decade' }
+    it 'prefers the VMPOOLER_TOKEN environment variable to a config file' do
+      allow(ENV).to receive(:[])
+                      .with('VMPOOLER_TOKEN')
+                      .and_return(environment_value)
 
-    it 'prefers an environment variable to a file' do
-      ENV['VMPOOLER_TOKEN'] = 'cafebeef'
-      expect_any_instance_of(Vanagon::Engine::Pooler).to_not receive(:token_from_file)
-      expect(Vanagon::Engine::Pooler.new(platform).token).to_not eq('decade')
-      expect(Vanagon::Engine::Pooler.new(platform).token).to eq('cafebeef')
+      expect(Vanagon::Engine::Pooler.new(platform).token)
+        .to_not eq(token_value)
+
+      expect(Vanagon::Engine::Pooler.new(platform).token)
+        .to eq(environment_value)
     end
 
-    it 'falls back to a file if the environment variable is not set' do
-      allow_any_instance_of(Vanagon::Engine::Pooler).to receive(:token_from_file).and_return('decade')
-      expect(Vanagon::Engine::Pooler.new(platform).token).to eq('decade')
+    it %(reads a token from '~/.vanagon-token' if the environment variable is not set) do
+      allow(File).to receive(:exist?)
+                      .with(pooler_token_file)
+                      .and_return(true)
+
+      allow(File).to receive(:read)
+                      .with(pooler_token_file)
+                      .and_return(token_value)
+
+      expect(Vanagon::Engine::Pooler.new(platform).token)
+        .to eq(token_value)
     end
 
-    it 'returns nil if there is no env var or file' do
-      allow_any_instance_of(Vanagon::Engine::Pooler).to receive(:token_from_file).and_return(nil)
+    it %(reads a token from '~/.vmfloaty.yml' if '~/.vanagon-token' doesn't exist) do
+      allow(File).to receive(:exist?)
+                      .with(pooler_token_file)
+                      .and_return(false)
+
+      allow(File).to receive(:exist?)
+                      .with(floaty_config)
+                      .and_return(true)
+
+      allow(YAML).to receive(:load_file)
+                      .with(floaty_config)
+                      .and_return({'token' => token_value})
+
+      expect(Vanagon::Engine::Pooler.new(platform).token).to eq(token_value)
+    end
+
+    it %(returns 'nil' if no vmpooler token configuration exists) do
+      allow(File).to receive(:exist?)
+                      .with(pooler_token_file)
+                      .and_return(false)
+
+      allow(File).to receive(:exist?)
+                      .with(floaty_config)
+                      .and_return(false)
+
       expect(Vanagon::Engine::Pooler.new(platform).token).to be_nil
     end
   end


### PR DESCRIPTION
When token loading was refactored, the coverage was not sufficient.
Failures were silently masked due to overly aggressive stubbing out of
test resources. The coverage for the way that the pooler engine
handles environment variables, a ~/.vmpooler-token file, and a
~/.vmfloaty.yml file has been rewritten completely to exercise the
intended functionality.