### PR TITLE
0.9.0 was underbaked. I put it back in the oven.

### DIFF
--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -278,7 +278,7 @@ class Vanagon
       end
 
       def sum(value)
-        type = __callee__.gsub(/sum$/, '')
+        type = __callee__.to_s.gsub(/sum$/, '')
         @component.options[:sum] = value
         @component.options[:sum_type] = type
       end

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -53,13 +53,62 @@ end" }
     plat._platform
   }
 
-
-
   let(:platform) { double(Vanagon::Platform) }
+
+  # These TOTALLY VALID sums are computed against a passage from
+  # "The Hitchhiker's Guide to the Galaxy", by Douglas Adams (1979).
+  # Specifically, about humans assuming they are smarter than dolphins
+  # for exactly the same reason dolphins assume they are smart than
+  # humans. This seemed appropriate after the checksum refactoring
+  # broke all checksums and we discovered that they were untested.
+  let(:dummy_md5_sum) { "08b55473b59d2b43af8b61c9512ef5c6" }
+  let(:dummy_sha1_sum) { "fdaa03c3f506d7b71635f2c32dfd41b0cc8b904f" }
+  let(:dummy_sha256_sum) { "fd9c922702eb2e2fb26376c959753f0fc167bb6bc99c79262fcff7bcc8b34be1" }
+  let(:dummy_sha512_sum) { "8feda1e9896be618dd6c65120d10afafce93888df8569c598f52285083c23befd1477da5741939d4eae042f822e45ca2e45d8d4d18cf9224b7acaf71d883841e" }
 
   before do
     allow(platform).to receive(:install).and_return('install')
     allow(platform).to receive(:copy).and_return('cp')
+  end
+
+  describe "#md5sum" do
+    it "sets a checksum value & type correctly" do
+      comp = Vanagon::Component::DSL.new('test-fixture', {}, {})
+      comp.md5sum(dummy_md5_sum)
+
+      expect(comp._component.options[:sum]).to eq(dummy_md5_sum)
+      expect(comp._component.options[:sum_type]).to eq('md5')
+    end
+  end
+
+  describe "#sha1sum" do
+    it "sets a checksum value & type correctly" do
+      comp = Vanagon::Component::DSL.new('test-fixture', {}, {})
+      comp.sha1sum(dummy_sha1_sum)
+
+      expect(comp._component.options[:sum]).to eq(dummy_sha1_sum)
+      expect(comp._component.options[:sum_type]).to eq('sha1')
+    end
+  end
+
+  describe "#sha256sum" do
+    it "sets a checksum value & type correctly" do
+      comp = Vanagon::Component::DSL.new('test-fixture', {}, {})
+      comp.sha256sum(dummy_sha256_sum)
+
+      expect(comp._component.options[:sum]).to eq(dummy_sha256_sum)
+      expect(comp._component.options[:sum_type]).to eq('sha256')
+    end
+  end
+
+  describe "#sha512sum" do
+    it "sets a checksum value & type correctly" do
+      comp = Vanagon::Component::DSL.new('test-fixture', {}, {})
+      comp.sha512sum(dummy_sha512_sum)
+
+      expect(comp._component.options[:sum]).to eq(dummy_sha512_sum)
+      expect(comp._component.options[:sum_type]).to eq('sha512')
+    end
   end
 
   describe '#load_from_json' do

--- a/spec/lib/vanagon/engine/pooler_spec.rb
+++ b/spec/lib/vanagon/engine/pooler_spec.rb
@@ -28,6 +28,7 @@ describe 'Vanagon::Engine::Pooler' do
     # actual user credentials from being loaded, or attempt to
     # validate the way that credentials are read.
     ENV['REAL_HOME'] = ENV.delete 'HOME'
+    ENV['REAL_VMPOOLER_TOKEN'] = ENV.delete 'VMPOOLER_TOKEN'
     ENV['HOME'] = Dir.mktmpdir
 
     # This should help maintain the ENV['HOME'] masquerade
@@ -38,6 +39,7 @@ describe 'Vanagon::Engine::Pooler' do
     # Altering ENV directly is a legitimate code-smell.
     # We should at least clean up after ourselves.
     ENV['HOME'] = ENV.delete 'REAL_HOME'
+    ENV['VMPOOLER_TOKEN'] = ENV.delete 'REAL_VMPOOLER_TOKEN'
   end
 
   # We don't want to run the risk of reading legitimate user

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'tmpdir'
+require 'vanagon'
 
 if ENV["COVERAGE"]
   require 'simplecov'


### PR DESCRIPTION
![img_9835](https://cloud.githubusercontent.com/assets/344926/21736673/38988d72-d427-11e6-9496-e28c34c780b0.JPG)

The new token handling spec tests didn't quite mask pre-existing values all-the-way. So that's fixed. And it turns out that I broke checksum handling because you can't call `#gsub` on a Symbol. It's got to be cast to a String first. But while I was in there, I added some tests for that functionality because it's really important and I didn't realize it was untested.
Finally, I added a quick one-line update to `spec_handler.rb`, which will allow us to run individual spec tests much easier:

```bash
$ bundle exec rspec --order random --require spec_helper.rb ./spec/lib/vanagon/component/dsl_spec.rb

Randomized with seed 29687
....................................................................

Finished in 0.0873 seconds (files took 0.20678 seconds to load)
68 examples, 0 failures

Randomized with seed 29687
$
```