### PR TITLE
(MAINT) Fix CHANGELOG links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -358,7 +358,11 @@ on Debian < 8 and needs more work and testing.
 
 ## Versions <= 0.3.9 do not have a change log entry
 
-[Unreleased]: https://github.com/puppetlabs/vanagon/compare/0.8.0...HEAD
+[Unreleased]: https://github.com/puppetlabs/vanagon/compare/0.9.1...HEAD
+[0.9.1]: https://github.com/puppetlabs/vanagon/compare/0.9.0...0.9.1
+[0.9.0]: https://github.com/puppetlabs/vanagon/compare/0.8.2...0.9.0
+[0.8.2]: https://github.com/puppetlabs/vanagon/compare/0.8.1...0.8.2
+[0.8.1]: https://github.com/puppetlabs/vanagon/compare/0.8.0...0.8.1
 [0.8.0]: https://github.com/puppetlabs/vanagon/compare/0.7.1...0.8.0
 [0.7.1]: https://github.com/puppetlabs/vanagon/compare/0.7.0...0.7.1
 [0.7.0]: https://github.com/puppetlabs/vanagon/compare/0.6.3...0.7.0


### PR DESCRIPTION
We haven't remembered to update the links around the version numbers
for a little while. Oops.