### PR TITLE
(VANAGON-44) Add --remote_dir flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,13 @@ Build machines should be cleaned between builds.
 #### Flagged arguments (can be anywhere in the command)
 
 ##### -w DIR, --workdir DIR
-Specifies a directory where the sources should be placed and builds performed.
+Specifies a directory on the controller where the sources should be placed and builds performed.
 Defaults to a temporary directory created with Ruby's Dir.mktmpdir.
+
+##### --remote_dir
+Specify a permament directory on the build host to place sources and perform
+builds. Components can then be rebuild manually on the build host for faster iteraction. Sources may not be correctly updated if this directory already exists.
+Defaults to a temporary directory.
 
 ##### -c DIR, --configdir DIR
 Specifies where project configuration is found. Defaults to $pwd/configs.

--- a/bin/build
+++ b/bin/build
@@ -2,7 +2,7 @@
 load File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "vanagon.rb"))
 
 optparse = Vanagon::OptParse.new("#{File.basename(__FILE__)} <project-name> <platform-name> [<target>] [options]",
-                                 [:workdir, :configdir, :engine, :preserve, :verbose, :skipcheck, :only_build])
+                                 [:workdir, :configdir, :engine, :preserve, :verbose, :skipcheck, :only_build, :remote_workdir])
 options = optparse.parse! ARGV
 
 project = ARGV[0]

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -10,10 +10,10 @@ require 'logger'
 class Vanagon
   class Driver
     include Vanagon::Utilities
-    attr_accessor :platform, :project, :target, :workdir, :verbose, :preserve
+    attr_accessor :platform, :project, :target, :workdir, :remote_workdir, :verbose, :preserve
     attr_accessor :timeout, :retry_count
 
-    def initialize(platform, project, options = { :configdir => nil, :target => nil, :engine => nil, :components => nil, :skipcheck => false, :verbose => false, :preserve => false, :only_build => nil }) # rubocop:disable Metrics/AbcSize
+    def initialize(platform, project, options = { :configdir => nil, :target => nil, :engine => nil, :components => nil, :skipcheck => false, :verbose => false, :preserve => false, :only_build => nil, :remote_workdir => nil }) # rubocop:disable Metrics/AbcSize
       @verbose = options[:verbose]
       @preserve = options[:preserve]
 
@@ -29,6 +29,8 @@ class Vanagon
       @project.settings[:skipcheck] = options[:skipcheck]
       filter_out_components(only_build) if only_build
       loginit('vanagon_hosts.log')
+
+      @remote_workdir = options[:remote_workdir]
 
       load_engine(engine, @platform, target)
     rescue LoadError => e
@@ -62,7 +64,7 @@ class Vanagon
 
     def load_engine_object(engine_type, platform, target)
       require "vanagon/engine/#{engine_type}"
-      @engine = Object::const_get("Vanagon::Engine::#{camelize(engine_type)}").new(platform, target)
+      @engine = Object::const_get("Vanagon::Engine::#{camelize(engine_type)}").new(platform, target, :remote_workdir => @remote_workdir)
     rescue
       fail "No such engine '#{camelize(engine_type)}'"
     end

--- a/lib/vanagon/engine/always_be_scheduling.rb
+++ b/lib/vanagon/engine/always_be_scheduling.rb
@@ -66,7 +66,7 @@ class Vanagon
     # $ build_host_info puppet-agent aix-5.3-ppc --engine always_be_scheduling
     # {"name":"aix-53-ppc","engine":"always_be_scheduling"}
     class AlwaysBeScheduling < Base
-      def initialize(platform, target)
+      def initialize(platform, target, opts = {})
         super
 
         Vanagon::Driver.logger.debug "AlwaysBeScheduling engine invoked."

--- a/lib/vanagon/engine/base.rb
+++ b/lib/vanagon/engine/base.rb
@@ -6,11 +6,12 @@ class Vanagon
     class Base
       attr_accessor :target, :remote_workdir
 
-      def initialize(platform, target = nil)
+      def initialize(platform, target = nil, opts = {})
         @platform = platform
         @required_attributes = ["ssh_port"]
         @target = target if target
         @target_user = @platform.target_user
+        @remote_workdir_path = opts[:remote_workdir]
       end
 
       # Get the engine name
@@ -57,7 +58,15 @@ class Vanagon
       end
 
       def get_remote_workdir
-        @remote_workdir ||= dispatch("mktemp -d -p /var/tmp 2>/dev/null || mktemp -d -t 'tmp'", true)
+        unless @remote_workdir
+          if @remote_workdir_path
+            dispatch("mkdir -p #{@remote_workdir_path}", true)
+            @remote_workdir = @remote_workdir_path
+          else
+            @remote_workdir = dispatch("mktemp -d -p /var/tmp 2>/dev/null || mktemp -d -t 'tmp'", true)
+          end
+        end
+        @remote_workdir
       end
 
       def ship_workdir(workdir)

--- a/lib/vanagon/engine/docker.rb
+++ b/lib/vanagon/engine/docker.rb
@@ -5,7 +5,7 @@ class Vanagon
     class Docker < Base
       # Both the docker_image and the docker command itself are required for
       # the docker engine to work
-      def initialize(platform, target = nil)
+      def initialize(platform, target = nil, opts = {})
         super
 
         @docker_cmd = Vanagon::Utilities.find_program_on_path('docker')

--- a/lib/vanagon/engine/ec2.rb
+++ b/lib/vanagon/engine/ec2.rb
@@ -9,7 +9,7 @@ class Vanagon
       attr_accessor :ami, :key_name, :userdata, :key, :key_name, :shutdown_behavior
       attr_accessor :subnet_id, :instance_type
 
-      def initialize(platform, target = nil) # rubocop:disable Metrics/AbcSize
+      def initialize(platform, target = nil, opts = {}) # rubocop:disable Metrics/AbcSize
         super
 
         @ami = @platform.aws_ami

--- a/lib/vanagon/engine/hardware.rb
+++ b/lib/vanagon/engine/hardware.rb
@@ -49,7 +49,7 @@ class Vanagon
         @lockman.unlock(@target, VANAGON_LOCK_USER)
       end
 
-      def initialize(platform, target)
+      def initialize(platform, target, opts = {})
         super
 
         Vanagon::Driver.logger.debug "Hardware engine invoked."

--- a/lib/vanagon/engine/local.rb
+++ b/lib/vanagon/engine/local.rb
@@ -5,7 +5,7 @@ require 'vanagon/errors'
 class Vanagon
   class Engine
     class Local < Base
-      def initialize(platform, target = nil)
+      def initialize(platform, target = nil, opts = {})
         # local engine can't be used with a target
         super(platform, 'local machine')
 

--- a/lib/vanagon/engine/pooler.rb
+++ b/lib/vanagon/engine/pooler.rb
@@ -7,7 +7,7 @@ class Vanagon
       attr_reader :token
 
       # The vmpooler_template is required to use the pooler engine
-      def initialize(platform, target = nil)
+      def initialize(platform, target = nil, opts = {})
         super
 
         @pooler = "http://vmpooler.delivery.puppetlabs.net"

--- a/lib/vanagon/optparse.rb
+++ b/lib/vanagon/optparse.rb
@@ -4,6 +4,7 @@ class Vanagon
   class OptParse
     FLAGS = {
         :workdir => ['-w DIR', '--workdir DIR', "Working directory where build source should be put (defaults to a tmpdir)"],
+        :remote_workdir => ['--remote_workdir DIR', "Working directory where build source should be put on the remote host (defaults to a tmpdir)"],
         :configdir => ['-c', '--configdir DIR', 'Configs dir (defaults to $pwd/configs)'],
         :target => ['-t HOST', '--target HOST', 'Configure a target machine for build and packaging (defaults to grabbing one from the pooler)'],
         :engine => ['-e ENGINE', '--engine ENGINE', "A custom engine to use (defaults to the pooler) [base, local, docker, pooler currently supported]"],


### PR DESCRIPTION
I'd like to be able to specify the remote_workdir on the build build box so that all dependencies and make files remain in place and I can rebuild specific components quickly. For example when working on puppet-job for windows this allows me to quickly provision a build box on which I can recompile in a few seconds.

Is this a feature anyone else wants?
Is there a better way to do this?