### PR TITLE
(VANAGON-28) Rename is_osx? helper to is_macos?

### DIFF
--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -221,11 +221,22 @@ class Vanagon
       return !!@name.match(/^cisco-wrlinux-.*$/)
     end
 
-    # Utility matcher to determine is the platform is an osx variety
+    # Utility matcher to determine if the platform is an osx variety
     #
+    # @deprecated Please use is_macos? instead
     # @return [true, false] true if it is an osx variety, false otherwise
     def is_osx?
-      return !!@name.match(/^osx-.*$/)
+      warn "is_osx? is a deprecated method, please use #is_macos? instead."
+      is_macos?
+    end
+
+    # Utility matcher to determine if the platform is a macos or osx variety
+    # is_osx is a deprecated method that calls is_macos
+    # We still match for osx currently but this will change
+    #
+    # @return [true, false] true if it is a macos or osx variety, false otherwise
+    def is_macos?
+      !!(@name =~ /^macos-.*$/ || @name =~ /^osx-.*$/)
     end
 
     # Utility matcher to determine is the platform is a solaris variety


### PR DESCRIPTION
Make method name more canonical to what the system actually is.
Added a deprecation warning if is_osx? is still used and then calls is_macos?