### PR TITLE
(CPR-391) Fedora packages have odd distro tag

### DIFF
--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -10,6 +10,7 @@ class Vanagon
     attr_accessor :os_name
     attr_accessor :os_version
     attr_accessor :codename # this is Debian/Ubuntu specific
+    attr_writer   :dist # most likely to be used by rpm
 
     # The name of the sort of package type that a given platform expects,
     # e.g. msi, rpm,
@@ -214,6 +215,10 @@ class Vanagon
     # @return [String] relative path to where packages should be output to
     def output_dir(target_repo = "")
       @output_dir ||= File.join(@os_name, @os_version, target_repo, @architecture)
+    end
+
+    def dist
+      @dist ||= @os_name.tr('-', '_') + @os_version
     end
 
     # Sets and gets the name of the operating system for the platform.

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -217,6 +217,11 @@ class Vanagon
       @output_dir ||= File.join(@os_name, @os_version, target_repo, @architecture)
     end
 
+    # Get the value of @dist, or derive it from the value of @os_name and @os_version.
+    # This is relatively RPM specific but '#codename' is defined in Platform, and that's
+    # just as Deb/Ubuntu specific. All of the accessors in the top-level Platform
+    # namespace should be refactored, but #dist will live here for now.
+    # @return [String] the %dist name that RPM will use to build new RPMs
     def dist
       @dist ||= @os_name.tr('-', '_') + @os_version
     end

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -132,6 +132,13 @@ class Vanagon
         @platform.cross_compiled = cxx_flag
       end
 
+      # define an explicit Dist for the platform (most likely used for RPM platforms)
+      #
+      # @param dist_string [String] the value to use for .dist when building RPMs
+      def dist(dist_string)
+        @platform.dist = dist_string
+      end
+
       # Set the path to rpmbuild for the platform
       #
       # @param rpmbuild_cmd [String] Full path to rpmbuild with arguments to be used by default

--- a/lib/vanagon/platform/rpm.rb
+++ b/lib/vanagon/platform/rpm.rb
@@ -44,7 +44,7 @@ class Vanagon
         defines =  %(--define '_topdir $(tempdir)/rpmbuild' )
         # RPM doesn't allow dashes in the os_name. This was added to
         # convert cisco-wrlinux to cisco_wrlinux
-        defines << %(--define 'dist .#{@os_name.tr('-', '_')}#{@os_version}' )
+        defines << %(--define 'dist .#{dist}')
       end
 
       def add_repository(definition) # rubocop:disable Metrics/AbcSize


### PR DESCRIPTION
This commit adjusts how `dist` is defined for rpms. We now only use `os_name`
and `os_version` to construct `dist` if it isn't otherwise specified. This will
allow us to change the fedora distro tags without disrupting the way other
distro tags are currently defined.

- [x] Implement `dist` accessors
- [x] Implement tests for new `dist` accessors
- [x] Validate old behavior is preserved