### PR TITLE
(FEATURE) Add `render` command

### DIFF
--- a/bin/render
+++ b/bin/render
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+load File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "vanagon.rb"))
+
+optparse = Vanagon::OptParse.new(
+  "#{File.basename(__FILE__)} <project-name> <platform-name> [options]",
+  [:workdir, :configdir, :engine]
+)
+options = optparse.parse! ARGV
+
+project = ARGV[0]
+platforms = ARGV[1]
+targets = ARGV[2]
+
+if project.nil? or platforms.nil?
+  warn "project and platform are both required arguments."
+  puts optparse
+  exit 1
+end
+
+platform_list = platforms.split(',')
+target_list = []
+
+platform_list.zip(target_list).each do |pair|
+  platform, target = pair
+  artifact = Vanagon::Driver.new(platform, project, options.merge({ :target => target }))
+  artifact.render
+end

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -13,9 +13,10 @@ class Vanagon
     attr_accessor :platform, :project, :target, :workdir, :verbose, :preserve
     attr_accessor :timeout, :retry_count
 
-    def initialize(platform, project, options = { :configdir => nil, :target => nil, :engine => nil, :components => nil, :skipcheck => false, :verbose => false, :preserve => false, :only_build => nil }) # rubocop:disable Metrics/AbcSize
+    def initialize(platform, project, options = { workdir: Dir.mktmpdir, configdir: nil, target: nil, engine: nil, components: nil, skipcheck: false, verbose: false, preserve: false, only_build: nil }) # rubocop:disable Metrics/AbcSize
       @verbose = options[:verbose]
       @preserve = options[:preserve]
+      @workdir = options[:workdir]
 
       @@configdir = options[:configdir] || File.join(Dir.pwd, "configs")
       components = options[:components] || []
@@ -111,7 +112,7 @@ class Vanagon
       if @project.version.nil? or @project.version.empty?
         raise Vanagon::Error, "Project requires a version set, all is lost."
       end
-      @workdir = Dir.mktmpdir
+
       @engine.startup(@workdir)
 
       puts "Target is #{@engine.target}"
@@ -133,6 +134,16 @@ class Vanagon
       if ["hardware", "ec2"].include?(@engine.name)
         @engine.teardown
       end
+    end
+
+    def render
+      # Simple sanity check for the project
+      if @project.version.nil? or @project.version.empty?
+        raise Vanagon::Error, "Project requires a version set, all is lost."
+      end
+
+      puts "rendering Makefile"
+      @project.make_makefile(@workdir)
     end
 
     def prepare(workdir = nil) # rubocop:disable Metrics/AbcSize

--- a/vanagon.gemspec
+++ b/vanagon.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('lock_manager', '>= 0')
   gem.require_path = 'lib'
   gem.bindir       = 'bin'
-  gem.executables  = ['build', 'inspect', 'ship', 'repo', 'devkit', 'build_host_info']
+  gem.executables  = %w(build inspect ship render repo devkit build_host_info)
 
   # Ensure the gem is built out of versioned files
   gem.files = Dir['{bin,lib,spec,resources}/**/*', 'README*', 'LICENSE*'] & %x(git ls-files -z).split("\0")


### PR DESCRIPTION
`render` will generate just the Makefile for a given Vanagon project
and place it in a temporary directory, where it can be inspected
without interrupting/halting/aborting a project build. It will install
no dependencies, and do no engine/build target provisioning. This is
intended to help developers fine-tune any project changes that would
affect the Makefile before a project is built.