### PR TITLE
(MAINT) `Driver#render` is incomplete

### DIFF
--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -143,6 +143,7 @@ class Vanagon
       end
 
       puts "rendering Makefile"
+      retry_task { @project.fetch_sources(@workdir) }
       @project.make_makefile(@workdir)
     end
 


### PR DESCRIPTION
Looks like Vanagon is missing a bunch of the data that a Makefile
would need to contain (directory names, unpacking methods, etc.) until
we remote sources are retrieved. This is a short-term workaround until
the source handling is smart enough to work from its metadata.