### PR TITLE
(MAINT) Update Rubocop to 0.47.x

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,7 +82,7 @@ Lint/AmbiguousRegexpLiteral:
   Enabled: false
 
 # DISABLED
-Lint/Eval:
+Security/Eval:
   Enabled: false
 # DISABLED
 Lint/BlockAlignment:
@@ -317,7 +317,7 @@ Style/EmptyLiteral:
 Metrics/LineLength:
   Enabled: false
 
-Style/MethodCallParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Enabled: true
 
 Style/MethodDefParentheses:

--- a/Gemfile
+++ b/Gemfile
@@ -24,9 +24,9 @@ group(:development, :test) do
   gem 'json'
   gem 'lock_manager', *lock_manager_location_for(ENV['LOCK_MANAGER_LOCATION'] || '>= 0')
   gem 'packaging', '~> 0.4.0', github: 'puppetlabs/packaging', branch: 'master'
-  gem 'simplecov', require: false
   gem 'rake', require: false
   gem 'rspec', '~> 3.0', require: false
-  gem 'rubocop', "~> 0.41.2", require: false
+  gem 'rubocop', "~> 0.47", require: false
+  gem 'simplecov', require: false
   gem 'yard', require: false
 end


### PR DESCRIPTION
Keeping Rubocop up to date will probably hurt less if we do it
more often.