### PR TITLE
Let's test Vanagon::Component (more than we do)

### DIFF
--- a/spec/lib/vanagon/component_spec.rb
+++ b/spec/lib/vanagon/component_spec.rb
@@ -2,44 +2,41 @@ require 'vanagon/component'
 
 describe "Vanagon::Component" do
   describe "#get_environment" do
-    it "prints a deprecation warning to STDERR" do
-      comp = Vanagon::Component.new('env-test', {}, {})
-      expect { comp.get_environment }
-        .to output(/deprecated/).to_stderr
+    subject { Vanagon::Component.new('env-test', {}, {}) }
+
+    it "prints a deprecation warning to STDERR" do    
+      expect { subject.get_environment }.to output(/deprecated/).to_stderr
     end
 
     it "returns a makefile compatible environment" do
-      comp = Vanagon::Component.new('env-test', {}, {})
-      comp.environment = {'PATH' => '/usr/local/bin'}
-      expect(comp.get_environment).to eq('export PATH="/usr/local/bin"')
+      subject.environment = {'PATH' => '/usr/local/bin'}
+      expect(subject.get_environment).to eq %(export PATH="/usr/local/bin")
     end
 
     it 'merges against the existing environment' do
-      comp = Vanagon::Component.new('env-test', {}, {})
-      comp.environment = {'PATH' => '/usr/bin', 'CFLAGS' => '-I /usr/local/bin'}
-      expect(comp.get_environment).to eq('export PATH="/usr/bin" CFLAGS="-I /usr/local/bin"')
+      subject.environment = {'PATH' => '/usr/bin', 'CFLAGS' => '-I /usr/local/bin'}
+      expect(subject.get_environment).to eq %(export PATH="/usr/bin" CFLAGS="-I /usr/local/bin")
     end
 
     it 'returns : for an empty environment' do
-      comp = Vanagon::Component.new('env-test', {}, {})
-      expect(comp.get_environment).to eq(': no environment variables defined')
+      expect(subject.get_environment).to eq %(: no environment variables defined)
     end
   end
 
   describe "#get_build_dir" do
-    subject(:comp) do
+    subject do
       Vanagon::Component.new('build-dir-test', {}, {}).tap do |comp|
         comp.dirname = "build-dir-test"
       end
     end
 
     it "uses the dirname when no build_dir was set" do
-      expect(comp.get_build_dir).to eq "build-dir-test"
+      expect(subject.get_build_dir).to eq "build-dir-test"
     end
 
     it "joins the dirname and the build dir when a build_dir was set" do
-      comp.build_dir = "cmake-build"
-      expect(comp.get_build_dir).to eq File.join("build-dir-test", "cmake-build")
+      subject.build_dir = "cmake-build"
+      expect(subject.get_build_dir).to eq File.join("build-dir-test", "cmake-build")
     end
   end
 end

--- a/spec/lib/vanagon/component_spec.rb
+++ b/spec/lib/vanagon/component_spec.rb
@@ -39,4 +39,26 @@ describe "Vanagon::Component" do
       expect(subject.get_build_dir).to eq File.join("build-dir-test", "cmake-build")
     end
   end
+
+  describe "#get_sources" do
+    before :each do
+      @workdir = Dir.mktmpdir
+      @file_name = 'fake_file.txt'
+      @fake_file = "file://spec/fixtures/files/#{@file_name}"
+    end
+
+    subject do
+      # Initialize a new instance of Vanagon::Component and define a
+      # new secondary source. We can now reason about this instance and
+      # test behavior for retrieving secondary sources.
+      Vanagon::Component.new('build-dir-test', {}, {}).tap do |comp|
+        comp.sources << OpenStruct.new(url: @fake_file)
+      end
+    end
+
+    it "copies secondary sources into the workdir" do
+      subject.get_sources(@workdir)
+      expect(File.exist?(File.join(@workdir, @file_name))).to be true
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,14 @@ if ENV["COVERAGE"]
     add_filter '.bundle'
     add_filter 'spec'
     add_filter 'vendor'
+
+    # Define a minimum coverage score, and fail if it's not met.
+    # This should probably be a Float, not an Integer but as
+    # long as it's not a String it's probably fine.
+    #
+    # The coverage score on 2017-02-07 for commit 770b67db was 71.85
+    # - Ryan McKern, 2017-02-07
+    minimum_coverage ENV['MINIMUM_SCORE'] || 70.00
   end
 end
 


### PR DESCRIPTION
As per PR #448, we need some test coverage in `Vanagon::Component`, specifically around `#get_sources`. So here's an initial test, which validates existing behavior (before we start changing it). Also included:

- Simplifications for the tests that already existed for `Vanagon::Component`
- A minimum score for test coverage, and the option to enforce it