### PR TITLE
(RE-5646) add_source unpacks compressed second source & added spec tests

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -231,13 +231,18 @@ class Vanagon
     # Fetches secondary sources for the component. These are just dumped into the workdir currently.
     #
     # @param workdir [String] working directory to put the source into
-    def get_sources(workdir)
+    def get_sources(workdir) # rubocop:disable Metrics/AbcSize
+      # create an empty array if @extract_with doesn't already exist
+      @extract_with = Array(@extract_with)
       sources.each do |source|
         src = Vanagon::Component::Source.source(
           source.url, workdir: workdir, ref: source.ref, sum: source.sum
         )
         src.fetch
         src.verify
+        # set src.file to only be populated with the basename instead of entire file path
+        src.file = File.basename(src.url)
+        @extract_with << src.extract(platform.tar) if src.respond_to?(:extract)
       end
     end
 

--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -29,8 +29,8 @@ class Vanagon
     # that they were cloned to. For the outlying flat files, it'll
     # end up being defined explicitly as the string './'
     attr_accessor :dirname
-    # Which specific tool or command line invocations that
-    # should be used to extract a given component's primary source?
+    # The specific tools or command line invocations that
+    # should be used to extract a given component's sources
     attr_accessor :extract_with
     # how should this component be configured?
     attr_accessor :configure

--- a/spec/lib/vanagon/component_spec.rb
+++ b/spec/lib/vanagon/component_spec.rb
@@ -63,8 +63,7 @@ describe "Vanagon::Component" do
     end  
 
     it "copies uncompressed secondary sources into the workdir" do
-      component = subject
-      component.get_sources(@workdir)
+      subject.get_sources(@workdir)
       expect(File.exist?(File.join(@workdir, @file_name))).to be true
     end  
 
@@ -83,12 +82,11 @@ describe "Vanagon::Component" do
     end
 
     it "copies compressed secondary sources into the workdir" do
-      component = subject
-      component.get_sources(@workdir)
+      subject.get_sources(@workdir)
       expect(File.exist?(File.join(@workdir, @file_name))).to be true
       # make sure that our secondary source(s) made it into the workdir
       expect(File.exist?(File.join(@workdir, "#{@fake_dir}.tar.gz"))).to be true
-      expect(component.extract_with.join(" && ")).to match "#{@fake_dir}.tar.gz"
+      expect(subject.extract_with.join(" && ")).to match "#{@fake_dir}.tar.gz"
     end
   end
 end


### PR DESCRIPTION
Before, if a second source was compressed it could not be unpacked because we assumed it was along the lines of a conf file. Now handles second sources that are archives and unpacks them appropriately. Spec tests were also added to ensure that the secondary source was added and unpacked properly.

Previous discussion of this PR can be found [here](https://github.com/puppetlabs/vanagon/pull/448)