### PR TITLE
(maint) Allow owner, group, and mode to be passed to configfiles

### DIFF
--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -230,14 +230,14 @@ class Vanagon
       # upgrade if it has been modified
       #
       # @param file [String] name of the configfile
-      def configfile(file)
+      def configfile(file, mode: nil, owner: nil, group: nil)
         # I AM SO SORRY
         @component.delete_file file
         if @component.platform.name =~ /solaris-10|osx/
           @component.install << "mv '#{file}' '#{file}.pristine'"
-          @component.add_file Vanagon::Common::Pathname.configfile("#{file}.pristine")
+          @component.add_file Vanagon::Common::Pathname.configfile("#{file}.pristine", mode: mode, owner: owner, group: group)
         else
-          @component.add_file Vanagon::Common::Pathname.configfile(file)
+          @component.add_file Vanagon::Common::Pathname.configfile(file, mode: mode, owner: owner, group: group)
         end
       end
 
@@ -245,9 +245,9 @@ class Vanagon
       #
       # @param source [String] path to the configfile to copy
       # @param target [String] path to the desired target of the configfile
-      def install_configfile(source, target)
-        install_file(source, target)
-        configfile(target)
+      def install_configfile(source, target, mode: '0644', owner: nil, group: nil)
+        install_file(source, target, mode: mode, owner: owner, group: group)
+        configfile(target, mode: mode, owner: owner, group: group)
       end
 
       # link will add a command to the install to create a symlink from source to target

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -587,7 +587,14 @@ end" }
         it 'adds the file to the configfiles list' do
           comp = Vanagon::Component::DSL.new('install-config-file-test', {}, platform)
           comp.install_configfile('thing1', 'place/to/put/thing1')
-          expect(comp._component.configfiles).to include(Vanagon::Common::Pathname.configfile('place/to/put/thing1'))
+          expect(comp._component.configfiles).to include(Vanagon::Common::Pathname.configfile('place/to/put/thing1', mode: '0644'))
+          expect(comp._component.files).not_to include(Vanagon::Common::Pathname.file('place/to/put/thing1'))
+        end
+
+        it 'sets owner, group, and mode for the configfiles' do
+          comp = Vanagon::Component::DSL.new('install-config-file-test', {}, platform)
+          comp.install_configfile('thing1', 'place/to/put/thing1', owner: 'bob', group: 'timmy', mode: '0022')
+          expect(comp._component.configfiles).to include(Vanagon::Common::Pathname.configfile('place/to/put/thing1', mode: '0022', group: 'timmy', owner: 'bob'))
           expect(comp._component.files).not_to include(Vanagon::Common::Pathname.file('place/to/put/thing1'))
         end
       end
@@ -617,7 +624,7 @@ end" }
         it 'adds the file to the configfiles list' do
           comp = Vanagon::Component::DSL.new('install-config-file-test', {}, platform)
           comp.install_configfile('thing1', 'place/to/put/thing1')
-          expect(comp._component.configfiles).to include(Vanagon::Common::Pathname.configfile('place/to/put/thing1.pristine'))
+          expect(comp._component.configfiles).to include(Vanagon::Common::Pathname.configfile('place/to/put/thing1.pristine', mode: '0644'))
           expect(comp._component.configfiles).not_to include(Vanagon::Common::Pathname.file('place/to/put/thing1'))
         end
       end


### PR DESCRIPTION
These options are already supported when creating files, but not
supported in the wrapper that creates configfiles. You want to be able
to set these options for config files.