### PR TITLE
(VANAGON-47) Vanagon 0.10.0 is embarrassingly broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,32 @@
 ![Build Status](https://travis-ci.org/puppetlabs/vanagon.svg?branch=master)
-The Vanagon Project
-===
- * What is vanagon?
- * Runtime requirements
- * Configuration and Usage
- * Overview
- * Contributing
- * License
- * Maintainers
- * Support
+# The Vanagon Project
 
-What is vanagon?
----
+<!-- MarkdownTOC -->
+
+- [What is Vanagon?](#what-is-vanagon)
+- [Runtime Requirements](#runtime-requirements)
+  - [Local Host:](#local-host)
+  - [Remote Build Target:](#remote-build-target)
+- [Configuration and Usage](#configuration-and-usage)
+  - [`build` usage](#build-usage)
+  - [`inspect` usage](#inspect-usage)
+  - [`devkit` usage](#devkit-usage)
+- [Engines](#engines)
+  - [Amazon Ec2](#amazon-ec2)
+- [Contributing](#contributing)
+- [License](#license)
+- [Overview](#overview)
+- [Maintainers](#maintainers)
+
+<!-- /MarkdownTOC -->
+
+
+## What is Vanagon?
+
 Vanagon is a tool to build a single package out of a project, which can itself
 contain one or more components. This tooling is being used to develop the
 puppet-agent package, which contains components such as openssl, ruby, and
-augeas among others. For a simple example, please see the examples directory.
+augeas among others. For a simple example, please see the project in the `examples/` directory.
 
 Vanagon builds up a Makefile and packaging files (specfile for RPM,
 control/rules/etc for DEB) and copies them to a remote host, where make can be
@@ -57,15 +68,14 @@ Also, Vanagon ships with a number of engines which may include additional option
 - An ssh server ([homepage](https://www.openssh.com/)) is required by most engines
 - The command line tool `rsync` ([homepage](https://rsync.samba.org/)) (At least rsync 2.6.x)
 
-Configuration and Usage
----
+## Configuration and Usage
+
 Vanagon won't be much use without a project to build. Beyond that, you must
 define any platforms you want to build for. Vanagon ships with some simple
 binaries to use, but the one you probably care about is named 'build'.
 
 ### `build` usage
 The build command has positional arguments and position independent flags.
-
 
 #### Arguments (position dependent)
 
@@ -79,7 +89,7 @@ The name of the target platform to build `<project_name>` against; a file named
 directory. This can also be a comma separated list of platforms such as `platform1,platform2`;
 note that there are no spaces after the comma.
 
-##### target host [optional]
+##### target host <optional>
 Target host is an optional argument to override the host selection. Instead of using
 a random VM collected from the pooler (Vanagon's default build engine), the build will
 attempt connect to the target host over SSH as the `root` user.
@@ -92,7 +102,9 @@ than platforms, the extra platforms will be ignored.
 
 Build machines should be cleaned between builds.
 
-#### Flagged arguments (can be anywhere in the command)
+#### Flagged arguments
+
+**Note:** command flags can be used anywhere in the command.
 
 ##### -w DIR, --workdir DIR
 Specifies a directory on the local host where the sources should be placed and builds performed.
@@ -118,13 +130,15 @@ Currently supported engines are:
 
 #### Flags
 
+**Note:** command flags can be used anywhere in the command.
+
 ##### -p, --preserve
 Indicates that the host used for building the project should be left intact
 after the build instead of destroyed. The host is usually destroyed after a
 successful build, or left after a failed build.
 
-##### -v, --verbose (not yet implemented)
-Increase verbosity of output.
+##### -v, --verbose
+(Reserved for future implementation) Will increase the verbosity of output, when implemented.
 
 ##### -h, --help
 Display command-line help.
@@ -202,7 +216,7 @@ Platform can also be a comma separated list of platforms such as platform1,platf
 Specifies a directory where the sources should be placed and builds performed.
 Defaults to a temporary directory created with Ruby's Dir.mktmpdir.
 
-##### -c DIR, --configdir DIR
+##### -c DIR, --configdir DIR <optional>
 Specifies where project configuration is found. Defaults to $pwd/configs.
 
 ##### -e ENGINE, --engine ENGINE
@@ -249,7 +263,7 @@ As in `build` arguments.
 ##### platform name
 As in `build` arguments.
 
-##### component names [optional]
+##### component names <optional>
 Specifies specific components that should be built. If components are not
 specified, then all components in the project will be built. If components
 are specified as arguments, then any in the project that aren't specified
@@ -278,7 +292,7 @@ Engines
 
 ### Amazon Ec2
 
-Note: If you have the `aws_ami` setup vanagon will default to the ec2 engine.
+Note: If you have the `aws_ami` setup Vanagon will default to the ec2 engine.
 
 To use the ec2 engine you should have your credentials set either via your `~/.aws/credentials` or environment variables.
 After this you can setup your `configs/platforms/<platform>.rb` to use your
@@ -324,7 +338,7 @@ If I wanted to build it for debian wheezy, I would define a platform called
 wheezy and build my project against it.
 
 For more detailed examples of the DSLs available, please see the
-[examples](https://github.com/puppetlabs/vanagon/tree/master/examples) directory and the YARD documentation for vanagon.
+[examples](https://github.com/puppetlabs/vanagon/tree/master/examples) directory and the YARD documentation for Vanagon.
 
 ## Maintainers
 See MAINTAINERS file.

--- a/README.md
+++ b/README.md
@@ -28,12 +28,34 @@ creates a master makefile for the project, and configures, builds, and installs
 all components. The result is an environment where you can work on individual
 components, then rebuild the project and test the installed artifacts.
 
-Runtime Requirements
----
-Vanagon is self-contained. A recent version of ruby (2.1 or greater) should be
-all that is required. Beyond that, ssh, rsync and git are also required on the
-host, and ssh-server and rsync is required on the target (package installation
-for the target can be customized in the platform config for the target).
+## Runtime Requirements
+
+Vanagon carries two sets of requirements: requirements for the local host where Vanagon is run, and for the remote target where compilation and packaging happens.
+
+Also, Vanagon ships with a number of engines which may include additional optional dependencies if you wish to use them. These engines are currently considered experimental, and receive less attention than the `Hardware` or `vmpooler` engines do. If you find a bug in these engines, [please open a ticket](https://tickets.puppetlabs.com/browse/PA) and let us know.
+
+### Local Host:
+
+- [Ruby](https://www.ruby-lang.org/en/) (Ruby 2.1.x is the miniumum supported version)
+- [fustigit](https://github.com/mckern/fustigit)
+- [ruby-git](https://github.com/schacon/ruby-git)
+- The command line tool `ssh` ([homepage](https://www.openssh.com/)) available on the local `${PATH}` (any modern version should suffice)
+- The command line tool `rsync` ([homepage](https://rsync.samba.org/)) available on the local `${PATH}` (At least rsync 2.6.x)
+- The command line tool `git` ([homepage](https://git-scm.com/)) available on the local `${PATH}` (Vanagon is tested against Git version 1.8.x but should work with any newer version)
+
+#### Optional requirements
+
+- [AWS SDK for Ruby](https://github.com/aws/aws-sdk-ruby), if you're using the EC2 engine
+- [Docker](https://www.docker.com/community-edition), if you're using the Docker engine
+
+### Remote Build Target:
+
+**Note:** package installation & builder configuration for the remote target can be customized in the `Platform` configuration that defines target provisioning instructions.
+
+- GNU Make ([homepage](https://www.gnu.org/software/make/)) (Vanagon specifically targets the feature set provided by [GNU Make 3.81](http://git.savannah.gnu.org/cgit/make.git/tree/NEWS?h=3.81&id=776d8b7bc2ff83f8ebf5d357ec89e3bbe6d83962) but newer versions are known to work -- older versions are specifically known to **not** work!)
+- Bash ([homepage](https://www.gnu.org/software/bash/)) is required by the Makefiles that Vanagon generates
+- An ssh server ([homepage](https://www.openssh.com/)) is required by most engines
+- The command line tool `rsync` ([homepage](https://rsync.samba.org/)) (At least rsync 2.6.x)
 
 Configuration and Usage
 ---
@@ -94,7 +116,7 @@ Currently supported engines are:
 * `hardware` - Build on a specific taget and lock it in redis
 * `ec2` - Build on a specific AWS instance.
 
-#### Flags (can be anywhere in the command)
+#### Flags
 
 ##### -p, --preserve
 Indicates that the host used for building the project should be left intact
@@ -172,7 +194,9 @@ directory.
 
 Platform can also be a comma separated list of platforms such as platform1,platform2.
 
-#### Flagged arguments (can be anywhere in the command)
+#### Flagged arguments
+
+**Note:** command flags can be used anywhere in the command.
 
 ##### -w DIR, --workdir DIR
 Specifies a directory where the sources should be placed and builds performed.
@@ -188,7 +212,9 @@ rendered -- the `inspect` command performs no compilation.
 
 Supported engines are the same as the `build` command.
 
-#### Flags (can be anywhere in the command)
+#### Flags
+
+**Note:** command flags can be used anywhere in the command.
 
 ##### -v, --verbose (not yet implemented)
 Increase verbosity of output.
@@ -229,14 +255,18 @@ specified, then all components in the project will be built. If components
 are specified as arguments, then any in the project that aren't specified
 as arguments will be retrieved from packages rather than built from source.
 
-#### Flagged arguments (can be anywhere in the command)
+#### Flagged arguments
+
+**Note:** command flags can be used anywhere in the command.
 
 Supports all flagged arguments from the `build` command.
 
 ##### -t HOST, --target HOST
 As in the `build` target host optional argument.
 
-#### Flags (can be anywhere in the command)
+#### Flags
+
+**Note:** command flags can be used anywhere in the command.
 
 ##### -h, --help
 Display command-line help.

--- a/lib/makefile.rb
+++ b/lib/makefile.rb
@@ -76,11 +76,17 @@ class Makefile
         .join('.')
     end
 
+    def profiled_target?
+      !!(target =~ /-configure|-build|-install\Z/)
+    end
+
     def tokenized_environment_variable
       "#{target}: export VANAGON_TARGET := #{tokenize_target_name}"
     end
 
     def environment_variables
+      return [] unless profiled_target?
+
       environment.map { |k, v| "#{k} := #{v}" }.map do |env|
         "#{target}: export #{env}"
       end
@@ -105,7 +111,7 @@ class Makefile
       # a corner case between metaprogrammed methods in Component::Rules,
       # and Ruby's preference for pass-by-reference.
       # Ryan McKern 2017-02-02
-      t.unshift tokenized_environment_variable
+      t.unshift tokenized_environment_variable if profiled_target?
 
       # prepend any environment variables to the existing target,
       # using the target prefix to identify them as such. they should

--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -265,10 +265,10 @@ class Vanagon
         The #get_environment method will be removed by Vanagon 1.0.0.
       eos
 
-      if @environment.empty?
+      if environment.empty?
         ": no environment variables defined"
       else
-        env = @environment.map { |key, value| %(#{key}="#{value}") }
+        env = environment.map { |key, value| %(#{key}="#{value}") }
         "export #{env.join(' ')}"
       end
     end

--- a/lib/vanagon/component/source/local.rb
+++ b/lib/vanagon/component/source/local.rb
@@ -108,7 +108,7 @@ class Vanagon
           when "xz"
             %(unxz "#{file}")
           when "zip"
-            "unzip '#{file}' || 7za x -r -tzip -o'#{File.basename(file, '.zip')}' '#{file}'"
+            "unzip -d '#{File.basename(file, '.zip')}' '#{file}' || 7za x -r -tzip -o'#{File.basename(file, '.zip')}' '#{file}'"
           else
             raise Vanagon::Error, "Don't know how to decompress #{extension} archives"
           end

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -120,14 +120,19 @@ class Vanagon
       puts "Target is #{@engine.target}"
       retry_task { install_build_dependencies }
       retry_task { @project.fetch_sources(@workdir) }
+
       @project.make_makefile(@workdir)
       @project.make_bill_of_materials(@workdir)
       @project.generate_packaging_artifacts(@workdir)
       @engine.ship_workdir(@workdir)
       @engine.dispatch("(cd #{@engine.remote_workdir}; #{@platform.make})")
       @engine.retrieve_built_artifact
-      @engine.teardown unless @preserve
-      cleanup_workdir unless @preserve
+      @engine.retrieve_runtimes if @platform.profiling
+
+      unless @preserve
+        @engine.teardown
+        cleanup_workdir
+      end
     rescue => e
       puts e
       puts e.backtrace.join("\n")

--- a/lib/vanagon/engine/base.rb
+++ b/lib/vanagon/engine/base.rb
@@ -78,6 +78,16 @@ class Vanagon
         Vanagon::Utilities.rsync_from("#{@remote_workdir}/output/*", "#{@target_user}@#{@target}", "output/", @platform.ssh_port)
       end
 
+      def retrieve_runtimes
+        FileUtils.mkdir_p "runtimes"
+        Vanagon::Utilities.rsync_from(
+          "#{@remote_workdir}/runtimes/*",
+          "#{@target_user}@#{@target}",
+          "runtimes/",
+          @platform.ssh_port
+        )
+      end
+
       # Ensures that the platform defines the attributes that the engine needs to function.
       #
       # @raise [Vanagon::Error] an error is raised if a needed attribute is not defined

--- a/lib/vanagon/engine/local.rb
+++ b/lib/vanagon/engine/local.rb
@@ -44,6 +44,14 @@ class Vanagon
         FileUtils.mkdir_p("output")
         FileUtils.cp_r(Dir.glob("#{@remote_workdir}/output/*"), "output/")
       end
+
+      def retrieve_runtimes
+        FileUtils.mkdir_p "runtimes"
+        FileUtils.cp_r(
+          Dir.glob("#{@remote_workdir}/runtimes/*",
+          "runtimes/")
+        )
+      end
     end
   end
 end

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -72,6 +72,14 @@ class Vanagon
     # cross-compiled or natively compiled.
     attr_accessor :cross_compiled
 
+    # Determines if a platform should use the profiling shell.
+    attr_accessor :profiling
+
+    # Stores a string, pointing at the shell that should be used
+    # if a user needs to change the path or name of the shell that
+    # Make will run build recipes in.
+    attr_accessor :shell
+
     # A string, containing the script that will be executed on
     # the remote build target to determine how many CPU cores
     # are available on that platform. Vanagon will use that count
@@ -208,7 +216,19 @@ class Vanagon
       @find ||= "find"
       @sort ||= "sort"
       @copy ||= "cp"
+
+      # Our first attempt at defining metadata about a platform
       @cross_compiled ||= false
+      @profiling ||= false
+    end
+
+    def shell=(value)
+      @shell = value
+    end
+
+    def shell
+      return "$(PWD)/profiling_shell.sh" if profile?
+      @shell ||= "/bin/bash"
     end
 
     # This allows instance variables to be accessed using the hash lookup syntax
@@ -388,6 +408,15 @@ class Vanagon
     # @return [true, false] true if it is a cross-compiled Linux variety, false otherwise
     def is_cross_compiled_linux?
       return (is_cross_compiled? && is_linux?)
+    end
+
+    # Utility matcher to determine if the platform should attempt to collect
+    # runtime numbers from -configure, -build, and -install steps during
+    # compilation.
+    #
+    # @return [Boolean] true if a platform should use the profiling shell wrapper
+    def profile?
+      return @profiling
     end
   end
 end

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -98,6 +98,21 @@ class Vanagon
         @platform.make = make_cmd
       end
 
+      # Set the path for Make's SHELL for the platform
+      #
+      # @param shell_path [String] Full path to the shell Make should use
+      def shell(shell_path)
+        @platform.shell = shell_path
+      end
+
+      # Toggle profiling on or off for the platform
+      #
+      # @param boolean [Boolean] Should this platform try to collect runtimes
+      #   of configuring, building, and installing components
+      def profiling(boolean)
+        @platform.profiling = boolean.to_s.casecmp("true").zero?
+      end
+
       # Set the path to tar for the platform
       #
       # @param tar [String] Full path to the tar command for the platform

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -70,6 +70,10 @@ class Vanagon
         @project.settings[name] = value
       end
 
+      def settings
+        @project.settings
+      end
+
       # Sets the description of the project. Mainly for use in packaging.
       #
       # @param descr [String] description of the project

--- a/resources/Makefile.erb
+++ b/resources/Makefile.erb
@@ -9,7 +9,6 @@ workdir := $(PWD)
 
 all: file-list-before-build <%= package_name %>
 
-<%= package_name %>: export VANAGON_TARGET := create-package
 <%= package_name %>: <%= @name %>-<%= @version %>.tar.gz
 	<%= generate_package.join("\n\t") %>
 

--- a/resources/Makefile.erb
+++ b/resources/Makefile.erb
@@ -1,4 +1,4 @@
-SHELL = $(PWD)/profiling_shell.sh
+SHELL = <%=  @platform.shell %>
 
 <%- merged_environment.to_a(" := ").each do |var| -%>
 export <%= var %>

--- a/resources/metrics/profiling_shell.sh
+++ b/resources/metrics/profiling_shell.sh
@@ -1,22 +1,39 @@
 #!/bin/bash
 
-# this variant of the Profiling shell wrapper
-# uses only the Bash keyword `time`, and the generally
+# Vanagon profiling shell wrapper
+# version: 1.0.0
+# author: Ryan McKern <mckern@puppet.com>
+
+# The Vanagon Profiling shell wrapper
+# uses only the Bash keyword `time` and the generally
 # standard command `tee` to get run time. This was
 # needed because the BSD/sysv variants of `date` only
 # offer second-resolution. No milliseconds, no nano-
-# seconds.
-
-# Create copies of stdout & stderr's file descriptors
-# so that the output of the subshell that `time` runs
-# can be captured and used.
-exec 3>&1
-exec 4>&2
+# seconds. The results of `time` will be written to a
+# csv file containing a single column (times for each
+# subshell run as part of a given Make target. Each line
+# is a subshell's runtime in whole seconds with 3 decimal 
+# places of precision), named after the Make target, e.g.
+#   facter-configure.csv, facter-install.csv, etc.
+#
+# Of note is that we are intentionally avoiding using
+# `set -o pipefail` or `set -e` as these can cause
+# numerous false-positive failures depending on the
+# level of care and complexity in a given Make recipe.
 
 # Write some log files, that can be post-processed
-# relatively easily.
-__stdout="${VANAGON_TARGET}.stdout.log"
-__stderr="${VANAGON_TARGET}.stderr.log"
+# relatively easily. While you're at it, store runtimes in batches.
+if [[ -n ${VANAGON_TARGET} ]]; then
+  __batchfile="${VANAGON_TARGET}.csv"
+  __stdout="${VANAGON_TARGET}.stdout.log"
+  __stderr="${VANAGON_TARGET}.stderr.log"
+else
+  # Alternatively, if there's no defined Target, just
+  # dump that stuff in the bitbucket
+  __batchfile="/dev/null"
+  __stdout="/dev/null"
+  __stderr="/dev/null"
+fi
 
 # Define a default time format (seconds and milliseconds),
 # and then use some insane output redirection hacks to capture
@@ -24,22 +41,27 @@ __stderr="${VANAGON_TARGET}.stderr.log"
 # output to stdout & stderr but we should figure out how to
 # supress that for quieter Vanagon builds.
 TIMEFORMAT='%3R'
-__seconds="$( {
-  time bash -o pipefail "${@}" > >(tee -ai "${__stdout}" >&3) 2> >(tee -ai "${__stderr}" >&4 )
-} 2>&1)"
+{ __seconds="$( {
+    time bash "${@}" > >(tee -ai "${__stdout}" >&3) 2> >(tee -ai "${__stderr}" >&4
+  ); } 2>&1 )";
+} 3>&1 4>&2
 
-# If any part of the pipeline failed, then
-# this status should correspond to whatever
-# failing status the pipeline returned. We
-# want to check & preserve that.
-if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
-  exit "${PIPESTATUS[0]}"
-fi
+# PIPESTATUS can be reset prety easily, so the value of this specific pipeline
+# should be preserved to enable correct post-processing.
+__status=("${PIPESTATUS[@]}")
 
-# Finally, if everything completed successfully,
-# finesse the numbers and fire them off to our
-# statsd interface.
-if [[ "${VANAGON_TARGET}" ]] && [[ "${VANAGON_STATSD_HOST}" ]] && [[ "${VANAGON_STATSD_PORT}" ]]; then
-  __elapsed="$(echo "scale=0;${__seconds}*1000/1" | bc -l)"
-  echo -n "vanagon.${VANAGON_PROJECT}.${VANAGON_PLATFORM}.${VANAGON_TARGET}:${__elapsed}|ms" > "/dev/udp/${VANAGON_STATSD_HOST}/${VANAGON_STATSD_PORT}"
-fi
+# allow a failure in the command pipeline to halt execution,
+# the same way Make would if the pipeline was being executed
+# directly in Bash without this wrapper. This will halt the job
+# without sending metrics for this job upstream.
+for value in "${__status[@]}"; do
+  if [[ ${value} -ne 0 ]]; then
+    exit "${value}"
+  fi
+done
+
+# Batch the runtime for this task
+echo "${__seconds}" >> "${__batchfile}"
+
+# Explicitly exit with success
+exit

--- a/resources/metrics/profiling_shell.sh
+++ b/resources/metrics/profiling_shell.sh
@@ -24,9 +24,10 @@
 # Write some log files, that can be post-processed
 # relatively easily. While you're at it, store runtimes in batches.
 if [[ -n ${VANAGON_TARGET} ]]; then
-  __batchfile="${VANAGON_TARGET}.csv"
-  __stdout="${VANAGON_TARGET}.stdout.log"
-  __stderr="${VANAGON_TARGET}.stderr.log"
+  __batchfile="runtimes/${VANAGON_TARGET}.csv"
+  __stdout="logs/${VANAGON_TARGET}.stdout.log"
+  __stderr="logs/${VANAGON_TARGET}.stderr.log"
+  mkdir "logs" "runtimes"
 else
   # Alternatively, if there's no defined Target, just
   # dump that stuff in the bitbucket

--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -48,15 +48,22 @@ Autoreq: 0
 <%- get_requires.each do |requires| -%>
 Requires:  <%= requires %>
 <%- end -%>
+
 # All rpm packages built by vanagon have the pre-/post-install script
 # boilerplates (defined below). These require `mkdir` and `touch` but previously
 # did not specify a dependency on these.
 # In the future, we will supress pre/post scripts completely if there's nothing
 # specified by the project or the components.
+<%- if @platform.is_aix? -%>
+Requires: /bin/mkdir
+Requires: /bin/touch
+<%- else -%>
 Requires(pre): /bin/mkdir
 Requires(pre): /bin/touch
 Requires(post): /bin/mkdir
 Requires(post): /bin/touch
+<%- end -%>
+
 <%- if has_services? -%>
   <%- if @platform.servicetype == "systemd" -%>
     <%- if @platform.is_sles? -%>

--- a/spec/lib/makefile_spec.rb
+++ b/spec/lib/makefile_spec.rb
@@ -5,7 +5,7 @@ describe Makefile::Rule do
     subject { described_class.new("empty") }
 
     it "creates an empty rule" do
-      expect(subject.format).to eq "empty: export VANAGON_TARGET := empty\nempty:\n"
+      expect(subject.format).to eq "empty:\n"
     end
   end
 
@@ -13,7 +13,7 @@ describe Makefile::Rule do
     subject { described_class.new("simple", recipe: ["touch simple"]) }
 
     it "creates the rule with the recipe" do
-      expect(subject.format).to eq "simple: export VANAGON_TARGET := simple\nsimple:\n\ttouch simple\n"
+      expect(subject.format).to eq "simple:\n\ttouch simple\n"
     end
   end
 
@@ -21,7 +21,7 @@ describe Makefile::Rule do
     subject { described_class.new("depends", dependencies: ["mydeps"]) }
 
     it "creates the rule with the recipe" do
-      expect(subject.format).to eq "depends: export VANAGON_TARGET := depends\ndepends: mydeps\n"
+      expect(subject.format).to eq "depends: mydeps\n"
     end
   end
 
@@ -29,7 +29,7 @@ describe Makefile::Rule do
     subject { described_class.new("deluxe", recipe: ["touch deluxe"], dependencies: ["mydeps"]) }
 
     it "creates the rule with the recipe" do
-      expect(subject.format).to eq "deluxe: export VANAGON_TARGET := deluxe\ndeluxe: mydeps\n\ttouch deluxe\n"
+      expect(subject.format).to eq "deluxe: mydeps\n\ttouch deluxe\n"
     end
   end
 
@@ -44,7 +44,23 @@ describe Makefile::Rule do
     end
 
     it "inserts tabs after each newline in the recipe" do
-      expect(subject.format).to eq "multiline: export VANAGON_TARGET := multiline\nmultiline:\n\t[ -d build ] || mkdir -p build\n\tcd build &&\n\tcmake .. &&\n\tmake &&\n\tmake install\n"
+      expect(subject.format).to eq "multiline:\n\t[ -d build ] || mkdir -p build\n\tcd build &&\n\tcmake .. &&\n\tmake &&\n\tmake install\n"
+    end
+  end
+
+  describe "any rule besides a -configure, -build, or -install rule" do
+    subject { described_class.new("deluxe-clean", recipe: ["touch deluxe"], dependencies: ["mydeps"]) }
+
+    it "does not has a VANAGON_TARGET env. var. exported" do
+      expect(subject.format).not_to match(/VANAGON_TARGET/)
+    end
+  end
+
+  describe "a -configure, -build, or -install rule" do
+    subject { described_class.new("deluxe-configure", recipe: ["touch deluxe"], dependencies: ["mydeps"]) }
+
+    it "has a VANAGON_TARGET env. var. exported" do
+      expect(subject.format).to match(/VANAGON_TARGET/)
     end
   end
 end

--- a/spec/lib/vanagon/environment_spec.rb
+++ b/spec/lib/vanagon/environment_spec.rb
@@ -4,14 +4,19 @@ describe "Vanagon::Environment" do
   before :all do
     @good_names = %w(name _name NAME _NAME NAME123 _123NAME)
     @bad_names = ['no-name', '!name', '.name', '123name_', 1, '-name']
+
+    # All environment variables will be cast to Strings, regardless
+    # of whether or not they were Integers or Strings on the way in.
+
     @good_values =[
       'valuable',
       'most\ valuable',
       'extremely-valuable',
       'VALUE_BEYOND_MEASURE',
-      2004,
-      2007,
+      '2004',
+      '2007',
     ]
+
     @bad_values = [
       %w(an array of strings),
       19.81,


### PR DESCRIPTION
- [X]  Windows builds of Puppet Agent (P-A) will no longer work at all because the new `profiling_shell.sh` doesn't run correctly on Windows.
- [X]  The interface for parsing the old implementation of `Component` environment variables is broken because `Arrays` don't have indices like `Hashes` do (fixed in previous PR).

There are refinements needed to metric retrieval now that they're being batched to single-field CSV files on the remote build target -- they will be in a follow-up PR.