### PR TITLE
(maint) Allow passing of custom build variables

### DIFF
--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -400,5 +400,9 @@ class Vanagon
     def is_cross_compiled_linux?
       return (is_cross_compiled? && is_linux?)
     end
+
+    def package_override(project, var)
+      fail "I don't know how to set package overrides for #{name}, teach me?"
+    end
   end
 end

--- a/lib/vanagon/platform/deb.rb
+++ b/lib/vanagon/platform/deb.rb
@@ -102,6 +102,10 @@ class Vanagon
         provisioning << "apt-get -qq update"
       end
 
+      def package_override(project, var)
+        project.package_overrides << var
+      end
+
       # Constructor. Sets up some defaults for the debian platform and calls the parent constructor
       #
       # @param name [String] name of the platform

--- a/lib/vanagon/platform/rpm.rb
+++ b/lib/vanagon/platform/rpm.rb
@@ -69,6 +69,10 @@ class Vanagon
         commands
       end
 
+      def package_override(project, var)
+        project.package_overrides << var
+      end
+
       # Constructor. Sets up some defaults for the rpm platform and calls the parent constructor
       #
       # @param name [String] name of the platform

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -73,6 +73,13 @@ class Vanagon
     # project should pass to each platform
     attr_accessor :environment
 
+    # Extra vars to be set in the spec file or debian rules.
+    # Good for setting extra %define or %global things for RPM, or env
+    # variables needed in the debian rules file
+    # No extra munging will be performed, so these should be set as you want
+    # them to appear in your spec/rules files!
+    attr_accessor :package_overrides
+
     # Loads a given project from the configdir
     #
     # @param name [String] the name of the project
@@ -114,6 +121,7 @@ class Vanagon
       @replaces = []
       @provides = []
       @conflicts = []
+      @package_overrides = []
     end
 
     # Magic getter to retrieve settings in the project

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -262,8 +262,7 @@ class Vanagon
 
       def package_override(var)
         platform = @project.platform
-        fail "I don't know how to set package overrides for #{platform.name}, teach me?" unless platform.is_rpm? || platform.is_deb?
-        @project.package_overrides << var
+        platform.package_override(self._project, var)
       end
     end
   end

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -259,6 +259,12 @@ class Vanagon
       def retry_count(retry_count)
         @project.retry_count = retry_count
       end
+
+      def package_override(var)
+        platform = @project.platform
+        fail "I don't know how to set package overrides for #{platform.name}, teach me?" unless platform.is_rpm? || platform.is_deb?
+        @project.package_overrides << var
+      end
     end
   end
 end

--- a/resources/deb/rules.erb
+++ b/resources/deb/rules.erb
@@ -2,6 +2,10 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+<% @package_overrides.each do |var| %>
+<%= var %>
+<% end -%>
+
 override_dh_auto_install:
 	install -d debian/tmp
 	# Copy each directory into place

--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -25,6 +25,10 @@
 %global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-strip-static-archive[[:space:]].*$!!g')
 <% end -%>
 
+<% @package_overrides.each do |var| %>
+<%= var %>
+<% end -%>
+
 Name:           <%= @name %>
 Version:        <%= @version %>
 Release:        <%= @release %>%{?dist}


### PR DESCRIPTION
For some projects you may need to set custom variables/defines/etc in
your RPM spec file or debian rules file. This allows you to pass
arbitrary strings that will get added to those files.

TODO:
- [x]  Unit tests
- [x]  Make sure this doesn't break other builds
- [x]  ~~Add functionality for non deb/rpm platforms~~ OR make it fail if used on unsupported platforms