### PR TITLE
(VANAGON-47) Env. var. fixups

### DIFF
--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -150,6 +150,8 @@ class Vanagon
 
       puts "rendering Makefile"
       retry_task { @project.fetch_sources(@workdir) }
+      @project.make_bill_of_materials(@workdir)
+      @project.generate_packaging_artifacts(@workdir)
       @project.make_makefile(@workdir)
     end
 

--- a/lib/vanagon/environment.rb
+++ b/lib/vanagon/environment.rb
@@ -1,4 +1,5 @@
 require 'forwardable'
+require 'vanagon/extensions/string'
 
 class Vanagon
   # Environment is a validating wrapper around a delegated Hash,
@@ -134,12 +135,12 @@ class Vanagon
     alias to_string to_s
 
     def sanitize_subshells(str)
-      pattern = %r{\$\$\((.*)\)}
+      pattern = %r{\$\$\((.*?)\)}
       escaped_variables = str.scan(pattern).flatten
       return str if escaped_variables.empty?
 
       warning = [%(Value "#{str}" looks like it's escaping one or more values for subshell interpolation.)]
-      escaped_variables.each { |v| warning.push "\t$$#{v} (will be coerced to $(shell #{v})" }
+      escaped_variables.each { |v| warning.push %(\t"$$(#{v})" will be coerced to "$(shell #{v})") }
       warning.push <<-eos.undent
         All environment variables will now be resolved by Make before they're executed
         by the shell. These variables will be mangled for you for now, but you should
@@ -157,7 +158,7 @@ class Vanagon
       return str if escaped_variables.empty?
 
       warning = [%(Value "#{str}" looks like it's escaping one or more shell variable names for shell interpolation.)]
-      escaped_variables.each { |v| warning.push "\t$$#{v} (will be coerced to $(#{v})" }
+      escaped_variables.each { |v| warning.push %(\t"$$#{v}" will be coerced to "$(#{v})") }
       warning.push <<-eos.undent
         All environment variables will now be resolved by Make before they're executed
         by the shell. These variables will be mangled for you for now, but you should

--- a/lib/vanagon/environment.rb
+++ b/lib/vanagon/environment.rb
@@ -47,22 +47,21 @@ class Vanagon
       @data = {}
     end
 
-    # Associates the value given by value with the key given by key. Keys must
-    # be strings, and should conform to the Open Group's guidelines for portable
-    # shell variable names:
+    # Associates the value given by value with the key given by key. Keys will
+    # be cast to Strings, and should conform to the Open Group's guidelines for
+    # portable shell variable names:
     #     Environment variable names used by the utilities in the Shell and
     #     Utilities volume of IEEE Std 1003.1-2001 consist solely of uppercase
     #     letters, digits, and the '_' (underscore) from the characters defined
     #     in Portable Character Set and do not begin with a digit.
     #
-    # Values must be Strings or Integers, and will be stored precisely as given,
+    # Values will be cast to Strings, and will be stored precisely as given,
     # so any escaped characters, single or double quotes, or whitespace will be
     # preserved exactly as passed during assignment.
     #
     # @param key [String]
     # @param value [String, Integer]
-    # @raise [ArgumentError] if key is not a String, or if value is not a
-    #   String or an Integer
+    # @raise [ArgumentError] if key or value cannot be cast to a String
     def []=(key, value)
       @data.update({ validate_key(key) => validate_value(value) })
     end
@@ -170,16 +169,13 @@ class Vanagon
     end
     private :sanitize_variables
 
-    # Validate that a key is a String, that it does not contain invalid
+    # Cast key to a String, and validate that it does not contain invalid
     #   characters, and that it does not begin with a digit
-    # @param key [String]
+    # @param key [Object]
     # @raise [ArgumentError] if key is not a String, if key contains invalid
     #   characters, or if key begins with a digit
     def validate_key(str)
-      unless str.is_a?(String)
-        raise ArgumentError,
-              'environment variable Name must be a String'
-      end
+      str = str.to_s
 
       if str[0] =~ /\d/
         raise ArgumentError,
@@ -196,16 +192,10 @@ class Vanagon
     end
     private :validate_key
 
-    # Validate that str is a String or an Integer, and that the value
+    # Cast str to a String, and validate that the value
     # of str cannot be split into more than a single String by #shellsplit.
-    # @param value [String, Integer]
-    # @raise [ArgumentError] if key is not a String or an Integer
+    # @param value [Object]
     def validate_value(str)
-      unless str.is_a?(String) || str.is_a?(Integer)
-        raise ArgumentError,
-              'Value must be a String or an Integer'
-      end
-
       # sanitize the value, which should look for any Shell escaped
       # variable names inside of the value.
       sanitize_variables(sanitize_subshells(str.to_s))

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -393,7 +393,7 @@ class Vanagon
       files.push get_files.map(&:path)
       files.push get_configfiles.map(&:path)
       if @platform.is_windows?
-        files.flatten.map { |f| "$$(cygpath --mixed --long-name '#{f}')" }
+        files.flatten.map { |f| "$(shell cygpath --mixed --long-name '#{f}')" }
       else
         files.flatten
       end

--- a/resources/windows/nuget/project.nuspec.erb
+++ b/resources/windows/nuget/project.nuspec.erb
@@ -7,8 +7,8 @@
     <authors><%= @vendor.match(/^(.*) <.*>$/)[1] %></authors>
     <owners><%= @vendor.match(/^(.*) <.*>$/)[1] %></owners>
     <projectUrl><%= @homepage %></projectUrl>
-    <packageSourceUrl><%= "https://github.com/puppetlabs/#{project}-vanagon" %></packageSourceUrl>
-    <projectSourceUrl><%= "https://github.com/puppetlabs/#{project}" %></projectSourceUrl>
+    <packageSourceUrl><%= @homepage %></packageSourceUrl>
+    <projectSourceUrl><%= @homepage %></projectSourceUrl>
     <docsUrl><%= @homepage %></docsUrl>
     <mailingListUrl><%= @homepage %></mailingListUrl>
     <bugTrackerUrl><%= @homepage %></bugTrackerUrl>

--- a/spec/lib/vanagon/environment_spec.rb
+++ b/spec/lib/vanagon/environment_spec.rb
@@ -17,18 +17,7 @@ describe "Vanagon::Environment" do
       '2007',
     ]
 
-    @bad_values = [
-      %w(an array of strings),
-      19.81,
-      Object.new,
-      Tempfile.new('captain_planet'),
-      lambda { |x| "#{x}" }
-    ]
-
-    @good_hash = @good_names.zip(@good_values.shuffle).to_h
-    @bad_hash = @bad_names.zip(@bad_values.shuffle).to_h
-
-    @good_names_bad_values = @good_names.zip(@bad_values.shuffle).to_h
+    @good_names_good_values = @good_names.zip(@good_values.shuffle).to_h
     @bad_names_good_values = @bad_names.zip(@good_values.shuffle).to_h
   end
 
@@ -51,7 +40,7 @@ describe "Vanagon::Environment" do
 
   describe "#[]=" do
     it "accepts and assigns valid keys and values" do
-      @good_hash.each_pair do |key, value|
+      @good_names_good_values.each_pair do |key, value|
         expect { @local_env[key] = value }
             .to_not raise_error
       end
@@ -63,18 +52,11 @@ describe "Vanagon::Environment" do
             .to raise_error(ArgumentError)
       end
     end
-
-    it "raises an ArgumentError for invalid values" do
-      @good_names_bad_values.each_pair do |key, value|
-          expect { @local_env[key] = value }
-            .to raise_error(ArgumentError)
-      end
-    end
   end
 
   describe "#keys" do
     before do
-      @good_hash.each_pair do |key, value|
+      @good_names_good_values.each_pair do |key, value|
         @local_env[key] = value
       end
     end
@@ -94,7 +76,7 @@ describe "Vanagon::Environment" do
 
   describe "#values" do
     before do
-      @good_hash.each_pair do |key, value|
+      @good_names_good_values.each_pair do |key, value|
         @local_env[key] = value
       end
     end


### PR DESCRIPTION
Thanks to an ungreedy (generous?) regular expression, not every value in an environment variable was being coerced. The generous regex has been updated, but while I was in there I flushed out a couple of typos and a few places where we'd hardcoded variables for the underlying shell instead of Make.