### PR TITLE
(maint) Add capability to figure out version from branch

### DIFF
--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -409,5 +409,25 @@ class Vanagon
     def package_override(project, var)
       fail "I don't know how to set package overrides for #{name}, teach me?"
     end
+
+    # Generic adder for build repositories
+    #
+    # @param *args [Array<String>] List of arguments to pass on to the platform specific method
+    # @raise [Vanagon::Error] an arror is raised if the current platform does not define add_repository
+    def add_build_repository(*args)
+      if self.respond_to?(:add_repository)
+        self.provision_with self.send(:add_repository, *args)
+      else
+        raise Vanagon::Error, "Adding a build repository not defined for #{name}"
+      end
+    end
+
+    # Set the command to turn the target machine into a builder for vanagon
+    #
+    # @param command [String] Command to enable the target machine to build packages for the platform
+    def provision_with(command)
+      provisioning << command
+      provisioning.flatten!
+    end
   end
 end

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -184,8 +184,7 @@ class Vanagon
       #
       # @param command [String] Command to enable the target machine to build packages for the platform
       def provision_with(command)
-        @platform.provisioning << command
-        @platform.provisioning.flatten!
+        @platform.provision_with(command)
       end
 
       # Set the command to install any needed build dependencies for the target machine
@@ -382,11 +381,7 @@ class Vanagon
       # @param *args [Array<String>] List of arguments to pass on to the platform specific method
       # @raise [Vanagon::Error] an arror is raised if the current platform does not define add_repository
       def add_build_repository(*args)
-        if @platform.respond_to?(:add_repository)
-          self.provision_with @platform.send(:add_repository, *args)
-        else
-          raise Vanagon::Error, "Adding a build repository not defined for #{@platform.name}"
-        end
+        @platform.add_build_repository(*args)
       end
     end
   end

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -159,6 +159,23 @@ class Vanagon
         warn "Directory '#{dirname}' cannot be versioned by git. Maybe it hasn't been tagged yet?"
       end
 
+      # Get the version string from a git branch name. This will look for a '.'
+      # delimited string of numbers of any length and return that as the version.
+      # For example, 'maint/1.7.0/fixing-some-bugs' will return '1.7.0' and '4.8.x'
+      # will return '4.8'.
+      #
+      # @return version string parsed from branch name, fails if unable to find version
+      def version_from_branch
+        branch = Git.open(File.expand_path("..", Vanagon::Driver.configdir)).current_branch
+        if branch =~ /(\d+(\.\d+)+)/
+          return $1
+        else
+          fail "Can't find a version in your branch, make sure it matches <number>.<number>, like maint/1.7.0/fixing-some-bugs"
+        end
+      rescue Git::GitExecuteError => e
+        fail "Something went wrong trying to find your git branch.\n#{e}"
+      end
+
       # Sets the vendor for the project. Used in packaging artifacts.
       #
       # @param vend [String] vendor or author of the project


### PR DESCRIPTION
This also includes some reorganizing of Platform/Platform::DSL so we can use our handy version_from_branch to add versioned repos from our project definition!

TODO:
- [x] Add YARD docs
- [x] Add spec tests
- [x] Test building the world. - http://jenkins-release.delivery.puppetlabs.net/job/vanagon_generic_job/740/