### PR TITLE
Rename `--remote_workdir` and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [0.11.0] - released on 2017-03-22
 ### Added
 - A new Platform DSL method, `shell`, has been added. This allows a user to define a custom shell or path to a specific shell for a given platform.
 - Support for specifying the owner, group, and permission mode has been added to the Component DSL.
@@ -408,7 +410,8 @@ on Debian < 8 and needs more work and testing.
 
 ## Versions <= 0.3.9 do not have a change log entry
 
-[Unreleased]: https://github.com/puppetlabs/vanagon/compare/0.10.0...HEAD
+[Unreleased]: https://github.com/puppetlabs/vanagon/compare/0.11.0...HEAD
+[0.11.0]: https://github.com/puppetlabs/vanagon/compare/0.10.0...0.11.0
 [0.10.0]: https://github.com/puppetlabs/vanagon/compare/0.9.2...0.10.0
 [0.9.3]: https://github.com/puppetlabs/vanagon/compare/0.9.2...0.9.3
 [0.9.2]: https://github.com/puppetlabs/vanagon/compare/0.9.1...0.9.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,20 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Added
+- A new Platform DSL method, `shell`, has been added. This allows a user to define a custom shell or path to a specific shell for a given platform.
+- Support for specifying the owner, group, and permission mode has been added to the Component DSL.
 
-## [0.10.1] - released on 2017-02-22
 ### Fixed
-- Fix a bug in the handling of component environment variables
+- Fixed many bugs in the handling of component environment variables. Rendering them as [target-specific variables](https://www.gnu.org/software/make/manual/html_node/Target_002dspecific.html) in a project's Makefile introduced a number of bugs in many Vanagon projects due to target-specific variables being transitive between dependent Make targets.
+
+### Changed
+- All defined Project and Platform environment variables are rendered as [Make variables](https://www.gnu.org/software/make/manual/html_node/Using-Variables.html). Specifically, as "[Simply expanded variables](https://www.gnu.org/software/make/manual/html_node/Flavors.html#Flavors)".
+- All defined Component environment variables will be rendered as Make variables. This means that escaped literals (`$$VARIABLE_NAME`) and subshells (`$$(echo "I'm a subshell")`) will now be converted to their Makefile equivalents: `$(VARIABLE_NAME)` and `$(shell echo "I'm a subshell")` and Vanagon will emit a deprecation notice for these values. The goal is to provide a single target for formatting environment variables in an effort to make behavior more deterministic.
+- The `build` command line flag, `--remote_workdir`, has been renamed to `--remote-workdir`. This flag allows users to specify a directory on the remote build target for Vanagon to stage components & metadata under when compiling.
+
+### Removed
+- We've removed initial support for metrics collection. The functionality depended on Make's usage of target-specific variables, so if they're unreliable (and they are) then the metrics functionality is also unreliable. Consider instead using [Remake](http://bashdb.sourceforge.net/remake/) if you need to profile a Vanagon build. We may provide official support for `remake --profile` in a future Vanagon release.
 
 ## [0.10.0] - released on 2017-02-21
 ### Added

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Build machines should be cleaned between builds.
 Specifies a directory on the local host where the sources should be placed and builds performed.
 Defaults to a temporary directory created with Ruby's `Dir.mktmpdir` method.
 
-##### --remote_dir
+##### -r DIR, --remote-workdir DIR
 Explicitly specify a directory on the remote target to place sources and perform
 builds. Components can then be rebuilt manually on the build host for faster iteration. Sources may not be correctly updated if this directory already exists.
 Defaults to a temporary directory created by running `mktemp -d` on the remote target.

--- a/bin/build
+++ b/bin/build
@@ -2,7 +2,7 @@
 load File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "vanagon.rb"))
 
 optparse = Vanagon::OptParse.new("#{File.basename(__FILE__)} <project-name> <platform-name> [<target>] [options]",
-                                 [:workdir, :configdir, :engine, :preserve, :verbose, :skipcheck, :only_build, :remote_workdir])
+                                 [:workdir, :configdir, :engine, :preserve, :verbose, :skipcheck, :only_build, :"remote-workdir"])
 options = optparse.parse! ARGV
 
 project = ARGV[0]

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -31,7 +31,7 @@ class Vanagon
       filter_out_components(only_build) if only_build
       loginit('vanagon_hosts.log')
 
-      @remote_workdir = options[:remote_workdir]
+      @remote_workdir = options[:"remote-workdir"]
 
       load_engine(engine, @platform, target)
     rescue LoadError => e

--- a/lib/vanagon/optparse.rb
+++ b/lib/vanagon/optparse.rb
@@ -4,7 +4,7 @@ class Vanagon
   class OptParse
     FLAGS = {
         :workdir => ['-w DIR', '--workdir DIR', "Working directory where build source should be put (defaults to a tmpdir)"],
-        :remote_workdir => ['--remote_workdir DIR', "Working directory where build source should be put on the remote host (defaults to a tmpdir)"],
+        :"remote-workdir" => ['-r DIR', '--remote-workdir DIR', "Working directory where build source should be put on the remote host (defaults to a tmpdir)"],
         :configdir => ['-c', '--configdir DIR', 'Configs dir (defaults to $pwd/configs)'],
         :target => ['-t HOST', '--target HOST', 'Configure a target machine for build and packaging (defaults to grabbing one from the pooler)'],
         :engine => ['-e ENGINE', '--engine ENGINE', "A custom engine to use (defaults to the pooler) [base, local, docker, pooler currently supported]"],

--- a/spec/lib/vanagon/component/source/git_spec.rb
+++ b/spec/lib/vanagon/component/source/git_spec.rb
@@ -5,7 +5,7 @@ describe "Vanagon::Component::Source::Git" do
   let(:url) { 'git://github.com/puppetlabs/facter' }
   let(:ref_tag) { 'refs/tags/2.2.0' }
   let(:bad_sha) { 'FEEDBEEF' }
-  let(:workdir) { ENV["TMPDIR"] || "/tmp" }
+  let(:workdir) { ENV["TMPDIR"] || '/tmp' }
 
   after(:each) { %x(rm -rf #{workdir}/facter) }
 

--- a/spec/lib/vanagon/driver_spec.rb
+++ b/spec/lib/vanagon/driver_spec.rb
@@ -30,7 +30,7 @@ describe 'Vanagon::Driver' do
   end
 
   describe 'when resolving build host info' do
-    it 'uses an expicitly specified workdir if provided' do
+    it 'uses an explicitly specified workdir if provided' do
       derived = create_driver(redhat)
       explicit = create_driver(redhat, workdir: explicit_workdir)
 
@@ -38,9 +38,9 @@ describe 'Vanagon::Driver' do
       expect(explicit.workdir).not_to eq(derived.workdir)
     end
 
-    it 'uses an expicitly specified remote workdir if provided' do
+    it 'uses an explicitly specified remote workdir if provided' do
       derived = create_driver(redhat)
-      explicit = create_driver(redhat, remote_workdir: explicit_remote_workdir)
+      explicit = create_driver(redhat, :"remote-workdir" => explicit_remote_workdir)
 
       expect(explicit.remote_workdir).to eq(explicit_remote_workdir)
       expect(explicit.remote_workdir).not_to eq(derived.remote_workdir)


### PR DESCRIPTION
This PR changes `--remote_workdir` to `--remote-workdir`, updates the appropriate tests, and fixes a couple of typos. THEN it updates the CHANGELOG for a pending 0.11.0 release.