### PR TITLE
(maint) Ensure dirname override will be honored

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -204,7 +204,7 @@ class Vanagon
         extract_with << source.extract(platform.tar) if source.respond_to? :extract
 
         @cleanup_source = source.cleanup if source.respond_to?(:cleanup)
-        @dirname = source.dirname
+        @dirname ||= source.dirname
 
         # Git based sources probably won't set the version, so we load it if it hasn't been already set
         if source.respond_to?(:version)

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -315,6 +315,29 @@ class Vanagon
         end
       end
 
+      # Set a source dir
+      #
+      # The build dir will be created when the source archive is unpacked. This
+      # should be used when the unpacked directory name does not match the
+      # source archive name.
+      #
+      # @example
+      #   pkg.url "http://the-internet.com/a-silly-name-that-unpacks-into-not-this.tar.gz"
+      #   pkg.dirname "really-cool-directory"
+      #   pkg.configure { ["cmake .."] }
+      #   pkg.build { ["make -j 3"] }
+      #   pkg.install { ["make install"] }
+      #
+      # @param path [String] The build directory to use for building the project
+      def dirname(path)
+        if Pathname.new(path).relative?
+          @component.dirname = path
+        else
+          raise Vanagon::Error, "dirname should be a relative path, but '#{path}' looks to be absolute."
+        end
+      end
+
+
       # This will add a source to the project and put it in the workdir alongside the other sources
       #
       # @param uri [String] uri of the source


### PR DESCRIPTION
We allow the user to set dirname in case they are dealing with a source
that unpacks into a directory that's different than the name of the
archive. However, we don't honor this. The code always overwrites that
user-set variable with what it thinks it should be. That's lame.

This commit fixes how that variable is treated. If the user does in fact
supply `dirname` in the component config, then that variable assignment
will be honored. Otherwise, it defaults to use the same name as the
original archive.