### PR TITLE
(MAINT) Git tests shouldn't hit the network

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -2,7 +2,7 @@
 load File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "vanagon.rb"))
 
 optparse = Vanagon::OptParse.new("#{File.basename(__FILE__)} <project-name> <platform-name> [<target>] [options]",
-                                 [:workdir, :configdir, :engine, :preserve, :verbose, :skipcheck, :only_build, :"remote-workdir"])
+                                 %i(workdir configdir engine preserve verbose skipcheck only_build remote-workdir))
 options = optparse.parse! ARGV
 
 project = ARGV[0]

--- a/bin/build_host_info
+++ b/bin/build_host_info
@@ -3,7 +3,7 @@ require 'json'
 
 load File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "vanagon.rb"))
 
-optparse = Vanagon::OptParse.new("#{File.basename(__FILE__)} <project-name> <platform-name> [options]", [:workdir, :configdir, :engine])
+optparse = Vanagon::OptParse.new("#{File.basename(__FILE__)} <project-name> <platform-name> [options]", %i(workdir configdir engine))
 options = optparse.parse! ARGV
 
 project = ARGV[0]

--- a/bin/devkit
+++ b/bin/devkit
@@ -2,7 +2,7 @@
 load File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "vanagon.rb"))
 
 optparse = Vanagon::OptParse.new("#{File.basename(__FILE__)} <project-name> <platform-name> [<component-name>...] [options]",
-                                 [:workdir, :configdir, :target, :engine])
+                                 %i(workdir configdir target engine))
 options = optparse.parse! ARGV
 
 project = ARGV[0]

--- a/bin/inspect
+++ b/bin/inspect
@@ -6,7 +6,7 @@ require 'vanagon/extensions/hashable'
 
 load File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "vanagon.rb"))
 
-optparse = Vanagon::OptParse.new("#{File.basename(__FILE__)} <project-name> <platform-name> [options]", [:workdir, :configdir, :engine])
+optparse = Vanagon::OptParse.new("#{File.basename(__FILE__)} <project-name> <platform-name> [options]", %i(workdir configdir engine))
 options = optparse.parse! ARGV
 
 project = ARGV[0]

--- a/bin/render
+++ b/bin/render
@@ -3,7 +3,7 @@ load File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "vanagon.rb
 
 optparse = Vanagon::OptParse.new(
   "#{File.basename(__FILE__)} <project-name> <platform-name> [options]",
-  [:workdir, :configdir, :engine]
+  %i(workdir configdir engine)
 )
 options = optparse.parse! ARGV
 

--- a/lib/vanagon/component/source/http.rb
+++ b/lib/vanagon/component/source/http.rb
@@ -115,7 +115,6 @@ class Vanagon
           end
 
           target_file
-
         rescue Errno::ETIMEDOUT, Timeout::Error, Errno::EINVAL,
           Errno::EACCES, Errno::ECONNRESET, EOFError, Net::HTTPBadResponse,
           Net::HTTPHeaderSyntaxError, Net::ProtocolError => e

--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -78,7 +78,6 @@ class Vanagon
       response = http.request(request)
 
       JSON.parse(response.body)
-
     rescue Errno::ETIMEDOUT, Timeout::Error, Errno::EINVAL, Errno::ECONNRESET,
       EOFError, Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError,
       Net::ProtocolError => e

--- a/spec/lib/vanagon/component/source/git_spec.rb
+++ b/spec/lib/vanagon/component/source/git_spec.rb
@@ -1,32 +1,45 @@
 require 'vanagon/component/source/git'
 
 describe "Vanagon::Component::Source::Git" do
-  let(:klass) { Vanagon::Component::Source::Git }
-  let(:url) { 'git://github.com/puppetlabs/facter' }
-  let(:ref_tag) { 'refs/tags/2.2.0' }
-  let(:bad_sha) { 'FEEDBEEF' }
-  let(:workdir) { ENV["TMPDIR"] || '/tmp' }
+  # before(:all) blocks are run once before all of the examples in a group
+  before :all do
+    @klass = Vanagon::Component::Source::Git
+    # This repo will not be cloned over the network
+    @url = 'git://github.com/puppetlabs/facter.git'
+    # This path will not be created on disk
+    @local_url = "file://#{Dir.tmpdir}/puppet-agent"
+    @ref_tag = 'refs/tags/2.2.0'
+    @workdir = nil
+  end
 
-  after(:each) { %x(rm -rf #{workdir}/facter) }
+  # before(:each) blocks are run before each example
+  before :each do
+    allow(Git)
+      .to receive(:ls_remote)
+            .and_return(true)
+  end
 
   describe "#initialize" do
     it "raises error on initialization with an invalid repo" do
-      # this test has a spelling error for the git repo
-      # * this is on purpose *
-      expect { klass.new("#{url}l.git", ref: ref_tag, workdir: workdir) }
-        .to raise_error Vanagon::InvalidRepo
+      # Ensure initializing a repo fails without calling over the network
+      allow(Git)
+        .to receive(:ls_remote)
+              .and_return(false)
+
+      expect { @klass.new(@url, ref: @ref_tag, workdir: @workdir) }
+        .to raise_error(Vanagon::InvalidRepo)
     end
   end
 
   describe "#dirname" do
     it "returns the name of the repo" do
-      git_source = klass.new(url, ref: ref_tag, workdir: workdir)
+      git_source = @klass.new(@local_url, ref: @ref_tag, workdir: @workdir)
       expect(git_source.dirname)
-        .to eq('facter')
+        .to eq('puppet-agent')
     end
 
     it "returns the name of the repo and strips .git" do
-      git_source = klass.new("#{url}.git", ref: ref_tag, workdir: workdir)
+      git_source = @klass.new(@url, ref: @ref_tag, workdir: @workdir)
       expect(git_source.dirname)
         .to eq('facter')
     end
@@ -34,16 +47,9 @@ describe "Vanagon::Component::Source::Git" do
 
   describe "#ref" do
     it "returns a default value of HEAD when no explicit Git reference is provided" do
-      git_source = klass.new(url, workdir: workdir)
+      git_source = @klass.new(@url, workdir: @workdir)
       expect(git_source.ref)
         .to eq('HEAD')
-    end
-  end
-
-  describe "#fetch" do
-    it "raises an error on checkout failure with a bad SHA" do
-      expect { klass.new("#{url}", ref: bad_sha, workdir: workdir).fetch }
-        .to raise_error Vanagon::CheckoutFailed
     end
   end
 end


### PR DESCRIPTION
Since we outsource git repo handling to a 3rd party library, we don't have to test every single aspect of our wrapper. Just ensuring that it talks to the underlying Git library should be sufficient.

The benefit is that unit test run time drops from about 7 seconds to consistently less than 1 second. A win is a win, right?