### PR TITLE
(maint) Add ability to install service as a link

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,6 +29,6 @@ YARD::Rake::YardocTask.new do |t|
 end
 
 desc 'Run all spec tests and linters'
-task check: %w(test:spec rubocop)
+task check: %w[test:spec rubocop]
 
 task default: :check

--- a/bin/build
+++ b/bin/build
@@ -2,7 +2,7 @@
 load File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "vanagon.rb"))
 
 optparse = Vanagon::OptParse.new("#{File.basename(__FILE__)} <project-name> <platform-name> [<target>] [options]",
-                                 %i(workdir configdir engine preserve verbose skipcheck only_build remote-workdir))
+                                 %i[workdir configdir engine preserve verbose skipcheck only_build remote-workdir])
 options = optparse.parse! ARGV
 
 project = ARGV[0]

--- a/bin/build_host_info
+++ b/bin/build_host_info
@@ -3,7 +3,7 @@ require 'json'
 
 load File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "vanagon.rb"))
 
-optparse = Vanagon::OptParse.new("#{File.basename(__FILE__)} <project-name> <platform-name> [options]", %i(workdir configdir engine))
+optparse = Vanagon::OptParse.new("#{File.basename(__FILE__)} <project-name> <platform-name> [options]", %i[workdir configdir engine])
 options = optparse.parse! ARGV
 
 project = ARGV[0]

--- a/bin/devkit
+++ b/bin/devkit
@@ -2,7 +2,7 @@
 load File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "vanagon.rb"))
 
 optparse = Vanagon::OptParse.new("#{File.basename(__FILE__)} <project-name> <platform-name> [<component-name>...] [options]",
-                                 %i(workdir configdir target engine))
+                                 %i[workdir configdir target engine])
 options = optparse.parse! ARGV
 
 project = ARGV[0]

--- a/bin/inspect
+++ b/bin/inspect
@@ -6,7 +6,7 @@ require 'vanagon/extensions/hashable'
 
 load File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "vanagon.rb"))
 
-optparse = Vanagon::OptParse.new("#{File.basename(__FILE__)} <project-name> <platform-name> [options]", %i(workdir configdir engine))
+optparse = Vanagon::OptParse.new("#{File.basename(__FILE__)} <project-name> <platform-name> [options]", %i[workdir configdir engine])
 options = optparse.parse! ARGV
 
 project = ARGV[0]

--- a/bin/render
+++ b/bin/render
@@ -3,7 +3,7 @@ load File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "vanagon.rb
 
 optparse = Vanagon::OptParse.new(
   "#{File.basename(__FILE__)} <project-name> <platform-name> [options]",
-  %i(workdir configdir engine)
+  %i[workdir configdir engine]
 )
 options = optparse.parse! ARGV
 

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -165,7 +165,8 @@ class Vanagon
       # @param default_file [String] path to the default file relative to the source
       # @param service_name [String] name of the service
       # @param service_type [String] type of the service (network, application, system, etc)
-      def install_service(service_file, default_file = nil, service_name = @component.name, service_type: nil) # rubocop:disable Metrics/AbcSize
+      # @param link_target [String] executable service file should be linked to
+      def install_service(service_file, default_file = nil, service_name = @component.name, service_type: nil, link_target: nil) # rubocop:disable Metrics/AbcSize
         case @component.platform.servicetype
         when "sysv"
           target_service_file = File.join(@component.platform.servicedir, service_name)
@@ -203,7 +204,12 @@ class Vanagon
         end
 
         # Install the service and default files
-        install_file(service_file, target_service_file, mode: target_mode)
+        if link_target
+          install_file(service_file, link_target, mode: target_mode)
+          link link_target, target_service_file
+        else
+          install_file(service_file, target_service_file, mode: target_mode)
+        end
 
         if default_file
           install_file(default_file, target_default_file, mode: default_mode)

--- a/lib/vanagon/component/rules.rb
+++ b/lib/vanagon/component/rules.rb
@@ -188,7 +188,7 @@ class Vanagon
           "#{platform[:make]} clean"
         )
 
-        %w(configure build install).each do |type|
+        %w[configure build install].each do |type|
           touchfile = "#{component.name}-#{type}"
           r.recipe << andand(
             "[ -e #{touchfile} ]",

--- a/lib/vanagon/component/source.rb
+++ b/lib/vanagon/component/source.rb
@@ -6,7 +6,7 @@ require 'vanagon/component/source/local'
 class Vanagon
   class Component
     class Source
-      SUPPORTED_PROTOCOLS = %w(file http https git).freeze
+      SUPPORTED_PROTOCOLS = %w[file http https git].freeze
       @rewrite_rules = {}
 
       class << self

--- a/lib/vanagon/component/source/http.rb
+++ b/lib/vanagon/component/source/http.rb
@@ -13,7 +13,7 @@ class Vanagon
         attr_accessor :sum, :sum_type
 
         # Allowed checksum algorithms to use when validating files
-        CHECKSUM_TYPES = %w(md5 sha1 sha256 sha512).freeze
+        CHECKSUM_TYPES = %w[md5 sha1 sha256 sha512].freeze
 
         class << self
           def valid_url?(target_url) # rubocop:disable Metrics/AbcSize

--- a/lib/vanagon/component/source/local.rb
+++ b/lib/vanagon/component/source/local.rb
@@ -8,17 +8,17 @@ class Vanagon
 
         # Extensions for files we intend to unpack during the build
         ARCHIVE_EXTENSIONS = {
-          "7z" => %w(.7z),
-          "bzip2" => %w(.bz2 .bz),
-          "cpio" => %w(.cpio),
-          "gzip" => %w(.gz .z),
-          "rar" => %w(.rar),
-          "tar" => %w(.tar),
-          "tbz2" => %w(.tar.bz2 .tbz2 .tbz),
-          "tgz" => %w(.tar.gz .tgz),
-          "txz" => %w(.tar.xz .txz),
-          "xz" => %w(.xz),
-          "zip" => %w(.zip),
+          "7z" => %w[.7z],
+          "bzip2" => %w[.bz2 .bz],
+          "cpio" => %w[.cpio],
+          "gzip" => %w[.gz .z],
+          "rar" => %w[.rar],
+          "tar" => %w[.tar],
+          "tbz2" => %w[.tar.bz2 .tbz2 .tbz],
+          "tgz" => %w[.tar.gz .tgz],
+          "txz" => %w[.tar.xz .txz],
+          "xz" => %w[.xz],
+          "zip" => %w[.zip],
         }.freeze
 
         class << self

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -533,6 +533,27 @@ end" }
       # The component should now have a service registered
       expect(comp._component.service.name).to eq('service-test')
     end
+
+    it 'installs the file as a link when link_target is specified' do
+      comp = Vanagon::Component::DSL.new('service-test', {}, dummy_platform_sysv)
+      comp.install_service('component-client.init', 'component-client.sysconfig', link_target: '/tmp/service-test')
+      # Look for servicedir creation and copy
+      expect(comp._component.install).to include("install -d '/etc/init.d'")
+      expect(comp._component.install).to include("cp -p 'component-client.init' '/tmp/service-test'")
+      expect(comp._component.install).to include("([[ '/etc/init.d/service-test' -ef '/tmp/service-test' ]] || ln -s '/tmp/service-test' '/etc/init.d/service-test')")
+
+      # Look for defaultdir creation and copy
+      expect(comp._component.install).to include("install -d '/etc/default'")
+      expect(comp._component.install).to include("cp -p 'component-client.sysconfig' '/etc/default/service-test'")
+
+      # Look for files and configfiles
+      expect(comp._component.configfiles).to include(Vanagon::Common::Pathname.configfile('/etc/default/service-test'))
+      expect(comp._component.files).to include(Vanagon::Common::Pathname.file('/tmp/service-test', mode: '0755'))
+      expect(comp._component.files).to include(Vanagon::Common::Pathname.file('/etc/init.d/service-test'))
+
+      # The component should now have a service registered
+      expect(comp._component.service.name).to eq('service-test')
+    end
   end
 
   describe '#install_file' do

--- a/vanagon.gemspec
+++ b/vanagon.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('lock_manager', '>= 0')
   gem.require_path = 'lib'
   gem.bindir       = 'bin'
-  gem.executables  = %w(build inspect ship render repo devkit build_host_info)
+  gem.executables  = %w[build inspect ship render repo devkit build_host_info]
 
   # Ensure the gem is built out of versioned files
   gem.files = Dir['{bin,lib,spec,resources}/**/*', 'README*', 'LICENSE*'] & %x(git ls-files -z).split("\0")


### PR DESCRIPTION
Some packaging installs service files as links to executables. This
commit adds the `link_target` keyword argument to install_service. If
`link_target` is specified the specified `service_file` will be
installed at the location in `link_target` and the target service file
will be a symlink to the `link_target`.