### PR TITLE
(VANAGON-56) Introducing Mirror URLs

### DIFF
--- a/examples/components/component1.rb
+++ b/examples/components/component1.rb
@@ -1,7 +1,10 @@
 component "component1" do |pkg, settings, platform|
   pkg.version "1.2.3"
   pkg.md5sum "abcd1234"
-  pkg.url "http://my-file-store.my-app.net/component1-1.2.3.tar.gz"
+  pkg.url "http://my-file-store.my-app.example.com/component1-1.2.3.tar.gz"
+  pkg.mirror "http://mirror-01.example.com/component1-1.2.3.tar.gz"
+  pkg.mirror "http://mirror-02.example.com/component1-1.2.3.tar.gz"
+  pkg.mirror "http://mirror-03.example.com/component1-1.2.3.tar.gz"
 
   pkg.build_requires "tar"
 

--- a/examples/components/component2.rb
+++ b/examples/components/component2.rb
@@ -1,6 +1,8 @@
 component "component2" do |pkg, settings, platform|
   pkg.ref "1.2.3"
-  pkg.url "git://github.com/my-app/component2.git"
+  pkg.url "git://git.example.com/my-app/component2.git"
+  pkg.mirror "https://git.example.com/my-app/component2.git"
+  pkg.mirror "git@git.example.com:my-app/component2.git"
 
   pkg.build_requires "component1"
 

--- a/examples/projects/project.rb
+++ b/examples/projects/project.rb
@@ -37,15 +37,27 @@ project "my-app" do |proj|
   # Something like https://www.openssl.org/source/openssl-1.0.0r.tar.gz gets
   # rewritten as
   # http://buildsources.delivery.puppetlabs.net/openssl-1.0.0r.tar.gz
-  proj.register_rewrite_rule 'http', 'http://buildsources.delivery.puppetlabs.net'
+  #
+  # @deprecated 2017-04-07 - Ryan McKern
+  #   This functionality has been replaced with Component Mirrors. This feature 
+  #   will be removed before Vanagon 1.0.0, but for now it will add all rewritten
+  #   URLs/URIs to the list of mirrors
+  #
+  # proj.register_rewrite_rule 'http', 'http://buildsources.delivery.puppetlabs.net'
 
   # Here we rewrite public git urls to use our internal git mirror It turns
   # urls that look like git://github.com/puppetlabs/puppet.git into
   # git://github.delivery.puppetlabs.net/puppetlabs-puppet.git
-  proj.register_rewrite_rule 'git', Proc.new { |url|
-    match = url.match(/github.com\/(.*)$/)
-    "git://github.delivery.puppetlabs.net/#{match[1].gsub('/', '-')}" if match
-  }
+  #
+  # @deprecated 2017-04-07 - Ryan McKern
+  #   This functionality has been replaced with Component Mirrors. This feature 
+  #   will be removed before Vanagon 1.0.0, but for now it will add all rewritten
+  #   URLs/URIs to the list of mirrors
+  #
+  # proj.register_rewrite_rule 'git', Proc.new { |url|
+  #   match = url.match(/github.com\/(.*)$/)
+  #   "git://github.delivery.puppetlabs.net/#{match[1].gsub('/', '-')}" if match
+  # }
 
   # directory adds a directory (and its contents) to the package that is created
   proj.directory proj.prefix

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -276,11 +276,20 @@ class Vanagon
         @component.version = ver
       end
 
-      # Sets the url for the source of this component
+      # Sets the canonical URL or URI for the upstream source of this component
       #
-      # @param the_url [String] the url to the source for this component
-      def url(the_url)
-        @component.url = the_url
+      # @param uri [String, URI] a URL or URI describing a canonical location
+      #   for a component's source code or artifact
+      def url(uri)
+        @component.url = uri.to_s
+      end
+
+      # Sets a mirror url for the source of this component
+      #
+      # @param url [String] a mirror url to use as the source for this component.
+      #   Can be called more than once to add multiple mirror URLs.
+      def mirror(url)
+        @component.mirrors << url
       end
 
       def sum(value)

--- a/lib/vanagon/component/source.rb
+++ b/lib/vanagon/component/source.rb
@@ -7,85 +7,26 @@ class Vanagon
   class Component
     class Source
       SUPPORTED_PROTOCOLS = %w[file http https git].freeze
-      @rewrite_rules = {}
 
       class << self
-        attr_reader :rewrite_rules
-
-        def register_rewrite_rule(protocol, rule)
-          if rule.is_a?(String) || rule.is_a?(Proc)
-            if SUPPORTED_PROTOCOLS.include?(protocol)
-              @rewrite_rules[protocol] = rule
-            else
-              raise Vanagon::Error, "#{protocol} is not a supported protocol for rewriting"
-            end
-          else
-            raise Vanagon::Error, "String or Proc is required as a rewrite_rule."
-          end
-        end
-
-        def rewrite(url, protocol)
-          # Vanagon did not originally distinguish between http and https
-          # when looking up rewrite rules; this is no longer true, but it
-          # means that we should try to preserve old, dumb behavior until
-          # the rewrite engine is removed.
-          return rewrite(url, "http") if protocol == "https"
-
-          rule = @rewrite_rules[protocol]
-          if rule
-            if rule.is_a?(Proc)
-              return proc_rewrite(rule, url)
-            elsif rule.is_a?(String)
-              return string_rewrite(rule, url)
-            end
-          end
-
-          return url
-        end
-
-        def proc_rewrite(rule, url)
-          if rule.arity == 1
-            rule.call(url)
-          else
-            raise Vanagon::Error, "Unable to use provided rewrite rule. Expected Proc with one argument, Proc has #{rule.arity} arguments"
-          end
-        end
-
-        def string_rewrite(rule, original_url)
-          url = original_url.to_s
-          target_match = url.match(/.*\/([^\/]*)$/)
-          if target_match
-            target = target_match[1]
-            return File.join(rule, target)
-          else
-            raise Vanagon::Error, "Unable to apply url rewrite to '#{url}', expected to find at least one '/' in the url."
-          end
-        end
-
-        def parse_and_rewrite(uri)
-          url = URI.parse(uri)
-          return url unless url.scheme
-          rewrite(url.to_s, url.scheme)
-        end
-
         # Basic factory to hand back the correct {Vanagon::Component::Source} subtype to the component
         #
         # @param url [String] URI of the source file (includes git@... style links)
         # @param options [Hash] hash of the options needed for the subtype
         # @param workdir [String] working directory to fetch the source into
         # @return [Vanagon::Component::Source] the correct subtype for the given source
-        def source(uri, **options) # rubocop:disable Metrics/AbcSize
+        def source(uri, **options)
           # First we try git
-          if Vanagon::Component::Source::Git.valid_remote?(parse_and_rewrite(uri))
-            return Vanagon::Component::Source::Git.new parse_and_rewrite(uri),
+          if Vanagon::Component::Source::Git.valid_remote?(uri)
+            return Vanagon::Component::Source::Git.new uri,
               sum: options[:sum],
               ref: options[:ref],
               workdir: options[:workdir]
           end
 
           # Then we try HTTP
-          if Vanagon::Component::Source::Http.valid_url?(parse_and_rewrite(uri))
-            return Vanagon::Component::Source::Http.new parse_and_rewrite(uri),
+          if Vanagon::Component::Source::Http.valid_url?(uri)
+            return Vanagon::Component::Source::Http.new uri,
               sum: options[:sum],
               workdir: options[:workdir],
               # Default sum_type is md5 if unspecified:

--- a/lib/vanagon/component/source/local.rb
+++ b/lib/vanagon/component/source/local.rb
@@ -39,7 +39,6 @@ class Vanagon
           end
         end
 
-
         # Constructor for the File source type
         #
         # @param path [String] path of the local file to copy

--- a/lib/vanagon/component/source/rewrite.rb
+++ b/lib/vanagon/component/source/rewrite.rb
@@ -1,0 +1,85 @@
+require 'vanagon/component/source'
+
+class Vanagon
+  class Component
+    class Source
+      # This class has been extracted from Vanagon::Component::Source for the
+      # sake of isolation and in service of its pending removal. Rewrite rules
+      # should be considered deprecated. The removal will be carried out before
+      # Vanagon 1.0.0 is released.
+      class Rewrite
+        @rewrite_rules = {}
+
+        class << self
+          attr_reader :rewrite_rules
+
+          # @deprecated Please use the component DSL method #mirror(<URI>)
+          #   instead. This method will be removed before Vanagon 1.0.0.
+          def register_rewrite_rule(protocol, rule)
+            warn <<-HERE.undent
+              rewrite rule support is deprecated and will be removed before Vanagon 1.0.0.
+              Rewritten URLs will be automatically converted into mirror URLs for now but
+              please use the component DSL method '#mirror url' to define new mirror URL
+              sources for a given component.
+            HERE
+            if rule.is_a?(String) || rule.is_a?(Proc)
+              if Vanagon::Component::Source::SUPPORTED_PROTOCOLS.include?(protocol)
+                @rewrite_rules[protocol] = rule
+              else
+                raise Vanagon::Error, "#{protocol} is not a supported protocol for rewriting"
+              end
+            else
+              raise Vanagon::Error, "String or Proc is required as a rewrite_rule."
+            end
+          end
+
+          def rewrite(url, protocol)
+            # Vanagon did not originally distinguish between http and https
+            # when looking up rewrite rules; this is no longer true, but it
+            # means that we should try to preserve old, dumb behavior until
+            # the rewrite engine is removed.
+            return rewrite(url, "http") if protocol == "https"
+
+            rule = @rewrite_rules[protocol]
+            if rule
+              if rule.is_a?(Proc)
+                return proc_rewrite(rule, url)
+              elsif rule.is_a?(String)
+                return string_rewrite(rule, url)
+              end
+            end
+
+            return url
+          end
+
+          def proc_rewrite(rule, url)
+            if rule.arity == 1
+              rule.call(url)
+            else
+              raise Vanagon::Error, "Unable to use provided rewrite rule. Expected Proc with one argument, Proc has #{rule.arity} arguments"
+            end
+          end
+
+          def string_rewrite(rule, original_url)
+            url = original_url.to_s
+            target_match = url.match(/.*\/([^\/]*)$/)
+            if target_match
+              target = target_match[1]
+              return File.join(rule, target)
+            else
+              raise Vanagon::Error, "Unable to apply url rewrite to '#{url}', expected to find at least one '/' in the url."
+            end
+          end
+
+          # @deprecated Please use the component DSL method #mirror(<URI>)
+          #   instead. This method will be removed before Vanagon 1.0.0.
+          def parse_and_rewrite(uri)
+            url = URI.parse(uri)
+            return url unless url.scheme
+            rewrite(url.to_s, url.scheme)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -252,7 +252,7 @@ class Vanagon
       # @param protocol [String] a supported component source type (Http, Git, ...)
       # @param rule [String, Proc] a rule used to rewrite component source urls
       def register_rewrite_rule(protocol, rule)
-        Vanagon::Component::Source.register_rewrite_rule(protocol, rule)
+        Vanagon::Component::Source::Rewrite.register_rewrite_rule(protocol, rule)
       end
 
       # Toggle to apply additional cleanup during the build for space constrained systems

--- a/spec/lib/vanagon/component/source/rewrite_spec.rb
+++ b/spec/lib/vanagon/component/source/rewrite_spec.rb
@@ -1,0 +1,55 @@
+require 'vanagon/component/source'
+
+describe "Vanagon::Component::Source::Rewrite" do
+  let(:klass) { Vanagon::Component::Source::Rewrite }
+  before(:each) { klass.rewrite_rules.clear }
+
+  describe ".parse_and_rewrite" do
+    let(:simple_rule) { Proc.new {|url| url.gsub('a', 'e') } }
+    let(:complex_rule) do
+      Proc.new do |url|
+        match = url.match(/github.com\/(.*)$/)
+        "git://github.delivery.puppetlabs.net/#{match[1].gsub('/', '-')}" if match
+      end
+    end
+
+    it 'replaces the first section of a url with a string if string is given' do
+      klass.register_rewrite_rule('http', 'http://buildsources.delivery.puppetlabs.net')
+
+      expect(klass.rewrite('http://things.and.stuff/foo.tar.gz', 'http'))
+        .to eq('http://buildsources.delivery.puppetlabs.net/foo.tar.gz')
+    end
+
+    it 'applies the rule to the url if a proc is given as the rule' do
+      klass.register_rewrite_rule('http', simple_rule)
+
+      expect(klass.rewrite('http://things.and.stuff/foo.tar.gz', 'http'))
+        .to eq('http://things.end.stuff/foo.ter.gz')
+    end
+
+    it 'applies the rule to the url if a proc is given as the rule' do
+      klass.register_rewrite_rule('git', complex_rule)
+
+      expect(klass.rewrite('git://github.com/puppetlabs/facter', 'git'))
+        .to eq('git://github.delivery.puppetlabs.net/puppetlabs-facter')
+    end
+  end
+
+  describe ".register_rewrite_rule" do
+    it 'only accepts Proc and String as rule types' do
+      expect { klass.register_rewrite_rule('http', 5) }
+        .to raise_error(Vanagon::Error)
+    end
+
+    it 'rejects invalid protocols' do
+      expect { klass.register_rewrite_rule('gopher', 'abcd') }
+        .to raise_error Vanagon::Error
+    end
+
+    before { klass.register_rewrite_rule('http', 'http://buildsources.delivery.puppetlabs.net') }
+    it 'registers the rule for the given protocol' do
+      expect(klass.rewrite_rules)
+        .to eq({'http' => 'http://buildsources.delivery.puppetlabs.net'})
+    end
+  end
+end

--- a/spec/lib/vanagon/component/source_spec.rb
+++ b/spec/lib/vanagon/component/source_spec.rb
@@ -2,7 +2,6 @@ require 'vanagon/component/source'
 
 describe "Vanagon::Component::Source" do
   let(:klass) { Vanagon::Component::Source }
-  before(:each) { klass.rewrite_rules.clear }
 
   describe ".source" do
     let(:unrecognized_uri) { "abcd://things" }
@@ -24,10 +23,8 @@ describe "Vanagon::Component::Source" do
     let(:workdir) { Dir.mktmpdir }
 
     let(:original_git_url) { "git://things.and.stuff/foo-bar.git" }
-    let(:rewritten_git_url) { "git://things.end.stuff/foo-ber.git" }
 
     let(:original_http_url) { "http://things.and.stuff/foo.tar.gz" }
-    let(:rewritten_http_url) { "http://buildsources.delivery.puppetlabs.net/foo.tar.gz" }
 
     it "fails on unrecognized URI schemes" do
       expect { klass.source(unrecognized_uri, workdir: workdir) }
@@ -69,17 +66,6 @@ describe "Vanagon::Component::Source" do
         expect(klass.source(https_git, ref: ref, workdir: workdir).class)
           .to eq Vanagon::Component::Source::Git
       end
-
-      it "rewrites git:// URLs" do
-        proc_rule = Proc.new { |url| url.gsub('a', 'e') }
-        klass.register_rewrite_rule('git', proc_rule)
-        # Vanagon::Component::Source::Git#url returns a URI object
-        # so to check its value, we cast it to a simple string. It's
-        # hacky for sure, but seems less diagreeable than mangling the
-        # return value in the class itself.
-        expect(klass.source(original_git_url, ref: ref, workdir: workdir).url.to_s)
-        .to eq rewritten_git_url
-      end
     end
 
     context "takes a HTTP/HTTPS file" do
@@ -102,15 +88,6 @@ describe "Vanagon::Component::Source" do
         expect(klass.source(https_url, sum: sum, workdir: workdir, sum_type: "md5").class)
           .to equal(Vanagon::Component::Source::Http)
       end
-
-      before do
-        klass.register_rewrite_rule 'http',
-          'http://buildsources.delivery.puppetlabs.net'
-      end
-      it "applies rewrite rules to HTTP URLs" do
-        expect(klass.source(original_http_url, sum: sum, workdir: workdir, sum_type: "md5").url)
-          .to eq(rewritten_http_url)
-      end
     end
 
     context "takes a local file" do
@@ -128,55 +105,6 @@ describe "Vanagon::Component::Source" do
         expect(klass.source(file_url, sum: sum, workdir: workdir).class)
           .to eq Vanagon::Component::Source::Local
       end
-    end
-  end
-
-  describe ".rewrite" do
-    let(:simple_rule) { Proc.new {|url| url.gsub('a', 'e') } }
-    let(:complex_rule) do
-      Proc.new do |url|
-        match = url.match(/github.com\/(.*)$/)
-        "git://github.delivery.puppetlabs.net/#{match[1].gsub('/', '-')}" if match
-      end
-    end
-
-    it 'replaces the first section of a url with a string if string is given' do
-      klass.register_rewrite_rule('http', 'http://buildsources.delivery.puppetlabs.net')
-
-      expect(klass.rewrite('http://things.and.stuff/foo.tar.gz', 'http'))
-        .to eq('http://buildsources.delivery.puppetlabs.net/foo.tar.gz')
-    end
-
-    it 'applies the rule to the url if a proc is given as the rule' do
-      klass.register_rewrite_rule('http', simple_rule)
-
-      expect(klass.rewrite('http://things.and.stuff/foo.tar.gz', 'http'))
-        .to eq('http://things.end.stuff/foo.ter.gz')
-    end
-
-    it 'applies the rule to the url if a proc is given as the rule' do
-      klass.register_rewrite_rule('git', complex_rule)
-
-      expect(klass.rewrite('git://github.com/puppetlabs/facter', 'git'))
-        .to eq('git://github.delivery.puppetlabs.net/puppetlabs-facter')
-    end
-  end
-
-  describe ".register_rewrite_rule" do
-    it 'only accepts Proc and String as rule types' do
-      expect { klass.register_rewrite_rule('http', 5) }
-        .to raise_error(Vanagon::Error)
-    end
-
-    it 'rejects invalid protocols' do
-      expect { klass.register_rewrite_rule('gopher', 'abcd') }
-        .to raise_error Vanagon::Error
-    end
-
-    before { klass.register_rewrite_rule('http', 'http://buildsources.delivery.puppetlabs.net') }
-    it 'registers the rule for the given protocol' do
-      expect(klass.rewrite_rules)
-        .to eq({'http' => 'http://buildsources.delivery.puppetlabs.net'})
     end
   end
 end


### PR DESCRIPTION
The rewrite engine in Vanagon is not popular. It's made hitting
internal mirrors easier for Puppet but it's made building Puppet Agent
harder for many of our customers. I've been planning on adding Mirror
URL support for a while now... and that day is today.

Mirror URLs will deprecate rewrite rules, and provide flexibility for
multiple mirrors (if so desired). There's a new DSL method, and some
backend code, and deprecated-but-preserved backwards compatibility for
any projects that aren't likely to be able to move forward quickly.

Checklist:

- [X] Method deprecation warnings
- [X] Tests that validate that we preserved the old methods
- [X] Tests that validate the new behavior
- [x] Updated examples