### PR TITLE
(VANAGON-57) inform on STDERR, not STDOUT

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -11,7 +11,7 @@ targets = ARGV[2]
 
 if project.nil? or platforms.nil?
   warn "project and platform are both required arguments."
-  puts optparse
+  $stderr.puts optparse
   exit 1
 end
 

--- a/bin/build_host_info
+++ b/bin/build_host_info
@@ -11,11 +11,11 @@ platforms = ARGV[1]
 
 if project.nil? or platforms.nil?
   warn "project and platform are both required arguments."
-  puts optparse
+  $stderr.puts optparse
   exit 1
 end
 
 platforms.split(',').each do |platform|
   driver = Vanagon::Driver.new(platform, project, options)
-  puts JSON.generate(driver.build_host_info)
+  $stdout.puts JSON.generate(driver.build_host_info)
 end

--- a/bin/devkit
+++ b/bin/devkit
@@ -11,7 +11,7 @@ components = ARGV.drop(2)
 
 if project.nil? or platform.nil?
   warn "project and platform are both required arguments."
-  puts optparse
+  $stderr.puts optparse
   exit 1
 end
 

--- a/bin/inspect
+++ b/bin/inspect
@@ -14,12 +14,12 @@ platforms = ARGV[1]
 
 unless project or platforms
   warn "project and platform are both required arguments."
-  puts optparse
+  $stderr.puts optparse
   exit 1
 end
 
 platforms.split(',').each do |platform|
   driver = Vanagon::Driver.new(platform, project, options)
   components = driver.project.components.map(&:to_hash)
-  puts JSON.pretty_generate(components)
+  $stdout.puts JSON.pretty_generate(components)
 end

--- a/bin/render
+++ b/bin/render
@@ -13,7 +13,7 @@ targets = ARGV[2]
 
 if project.nil? or platforms.nil?
   warn "project and platform are both required arguments."
-  puts optparse
+  $stderr.puts optparse
   exit 1
 end
 

--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -119,9 +119,9 @@ class Vanagon
       dsl.instance_eval(code, __FILE__, __LINE__)
       dsl._component
     rescue => e
-      puts "Error loading project '#{name}' using '#{compfile}':"
-      puts e
-      puts e.backtrace.join("\n")
+      $stderr.puts "Error loading project '#{name}' using '#{compfile}':"
+      $stderr.puts e
+      $stderr.puts e.backtrace.join("\n")
       raise e
     end
 

--- a/lib/vanagon/component/source/git.rb
+++ b/lib/vanagon/component/source/git.rb
@@ -71,7 +71,7 @@ class Vanagon
         # There is no md5 to manually verify here, so this is a noop.
         def verify
           # nothing to do here, so just tell users that and return
-          puts "Nothing to verify for '#{dirname}' (using Git reference '#{ref}')"
+          $stderr.puts "Nothing to verify for '#{dirname}' (using Git reference '#{ref}')"
         end
 
         # The dirname to reference when building from the repo
@@ -117,8 +117,8 @@ class Vanagon
         # Clone a remote repo, make noise about it, and fail entirely
         # if we're unable to retrieve the remote repo
         def clone!
-          puts "Cloning Git repo '#{url}'"
-          puts "Successfully cloned '#{dirname}'" if clone
+          $stderr.puts "Cloning Git repo '#{url}'"
+          $stderr.puts "Successfully cloned '#{dirname}'" if clone
         rescue Git::GitExecuteError
           raise Vanagon::InvalidRepo, "Unable to clone from '#{url}'"
         end
@@ -127,7 +127,7 @@ class Vanagon
         # Checkout desired ref/sha, make noise about it, and fail
         # entirely if we're unable to checkout that given ref/sha
         def checkout!
-          puts "Checking out '#{ref}'' from Git repo '#{dirname}'"
+          $stderr.puts "Checking out '#{ref}'' from Git repo '#{dirname}'"
           clone.checkout(ref)
         rescue ::Git::GitExecuteError
           raise Vanagon::CheckoutFailed, "unable to checkout #{ref} from '#{url}'"
@@ -137,7 +137,7 @@ class Vanagon
         # Attempt to update submodules, and do not panic
         # if there are no submodules to initialize
         def update_submodules
-          puts "Attempting to update submodules for repo '#{dirname}'"
+          $stderr.puts "Attempting to update submodules for repo '#{dirname}'"
           clone.update_submodules(init: true)
         end
         private :update_submodules

--- a/lib/vanagon/component/source/http.rb
+++ b/lib/vanagon/component/source/http.rb
@@ -78,7 +78,7 @@ class Vanagon
         #
         # @raise [RuntimeError] an exception is raised if the sum does not match the sum of the file
         def verify # rubocop:disable Metrics/AbcSize
-          puts "Verifying file: #{file} against sum: '#{sum}'"
+          $stderr.puts "Verifying file: #{file} against sum: '#{sum}'"
           actual = get_sum(File.join(workdir, file), sum_type)
           return true if sum == actual
 
@@ -92,7 +92,7 @@ class Vanagon
           uri = URI.parse(target_url.to_s)
           target_file ||= File.basename(uri.path)
 
-          puts "Downloading file '#{target_file}' from url '#{target_url}'"
+          $stderr.puts "Downloading file '#{target_file}' from url '#{target_url}'"
 
           Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
             http.request(Net::HTTP::Get.new(uri, headers)) do |response|

--- a/lib/vanagon/component/source/local.rb
+++ b/lib/vanagon/component/source/local.rb
@@ -58,7 +58,7 @@ class Vanagon
         #
         # @raise [RuntimeError, Vanagon::Error] an exception is raised if the URI scheme cannot be handled
         def copy
-          puts "Copying file '#{url.basename}' to workdir"
+          $stderr.puts "Copying file '#{url.basename}' to workdir"
 
           FileUtils.cp_r(url, file)
         end

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -43,8 +43,8 @@ class Vanagon
       # flatten all the results in to one array and set project.components to that.
       @project.components = only_build.flat_map { |comp| @project.filter_component(comp) }.uniq
       if @verbose
-        puts "Only building:"
-        @project.components.each { |comp| puts comp.name }
+        $stderr.puts "Only building:"
+        @project.components.each { |comp| $stderr.puts comp.name }
       end
     end
 
@@ -117,7 +117,7 @@ class Vanagon
 
       @engine.startup(@workdir)
 
-      puts "Target is #{@engine.target}"
+      $stderr.puts "Target is #{@engine.target}"
       retry_task { install_build_dependencies }
       retry_task { @project.fetch_sources(@workdir) }
 
@@ -133,8 +133,8 @@ class Vanagon
         cleanup_workdir
       end
     rescue => e
-      puts e
-      puts e.backtrace.join("\n")
+      $stderr.puts e
+      $stderr.puts e.backtrace.join("\n")
       raise e
     ensure
       if ["hardware", "ec2"].include?(@engine.name)
@@ -148,7 +148,7 @@ class Vanagon
         raise Vanagon::Error, "Project requires a version set, all is lost."
       end
 
-      puts "rendering Makefile"
+      $stderr.puts "rendering Makefile"
       retry_task { @project.fetch_sources(@workdir) }
       @project.make_bill_of_materials(@workdir)
       @project.generate_packaging_artifacts(@workdir)
@@ -159,7 +159,7 @@ class Vanagon
       @workdir = workdir ? FileUtils.mkdir_p(workdir).first : Dir.mktmpdir
       @engine.startup(@workdir)
 
-      puts "Devkit on #{@engine.target}"
+      $stderr.puts "Devkit on #{@engine.target}"
 
       install_build_dependencies
       @project.fetch_sources(@workdir)
@@ -169,8 +169,8 @@ class Vanagon
       @engine.ship_workdir(@workdir)
       @engine.dispatch("(cd #{@engine.remote_workdir}; #{@platform.make} #{@project.name}-project)")
     rescue => e
-      puts e
-      puts e.backtrace.join("\n")
+      $stderr.puts e
+      $stderr.puts e.backtrace.join("\n")
       raise e
     end
 

--- a/lib/vanagon/engine/ec2.rb
+++ b/lib/vanagon/engine/ec2.rb
@@ -57,17 +57,17 @@ class Vanagon
       end
 
       def select_target
-        puts "Instance created id: #{instance.id}"
-        puts "Created instance waiting for status ok"
+        $stderr.puts "Instance created id: #{instance.id}"
+        $stderr.puts "Created instance waiting for status ok"
         @ec2.wait_until(:instance_status_ok, instance_ids: [instance.id])
-        puts "Instance running"
+        $stderr.puts "Instance running"
         @target = instance.private_ip_address
       rescue ::Aws::Waiters::Errors::WaiterFailed => error
         fail "Failed to wait for ec2 instance to start got error #{error}"
       end
 
       def teardown
-        puts "Destroying instance on AWS id: #{instance.id}"
+        $stderr.puts "Destroying instance on AWS id: #{instance.id}"
         instances.batch_terminate!
       end
     end

--- a/lib/vanagon/engine/hardware.rb
+++ b/lib/vanagon/engine/hardware.rb
@@ -23,7 +23,7 @@ class Vanagon
         Vanagon::Driver.logger.info "Polling for a lock on #{host}."
         @lockman.polling_lock(host, VANAGON_LOCK_USER, "Vanagon automated lock")
         Vanagon::Driver.logger.info "Lock acquired on #{host}."
-        puts "Lock acquired on #{host} for #{VANAGON_LOCK_USER}."
+        $stderr.puts "Lock acquired on #{host} for #{VANAGON_LOCK_USER}."
         host
       end
 
@@ -33,7 +33,7 @@ class Vanagon
           Vanagon::Driver.logger.info "Attempting  to lock #{h}."
           if @lockman.lock(h, VANAGON_LOCK_USER, "Vanagon automated lock")
             Vanagon::Driver.logger.info "Lock acquired on #{h}."
-            puts "Lock acquired on #{h} for #{VANAGON_LOCK_USER}."
+            $stderr.puts "Lock acquired on #{h} for #{VANAGON_LOCK_USER}."
             return h
           end
         end
@@ -45,7 +45,7 @@ class Vanagon
       # complete. In this case, we'll attempt to unlock the hardware
       def teardown
         Vanagon::Driver.logger.info "Removing lock on #{@target}."
-        puts "Removing lock on #{@target}."
+        $stderr.puts "Removing lock on #{@target}."
         @lockman.unlock(@target, VANAGON_LOCK_USER)
       end
 

--- a/lib/vanagon/engine/pooler.rb
+++ b/lib/vanagon/engine/pooler.rb
@@ -56,7 +56,7 @@ class Vanagon
         absolute_path = File.expand_path(path)
         return nil unless File.exist?(absolute_path)
 
-        puts "Reading vmpooler token from: #{path}"
+        $stderr.puts "Reading vmpooler token from: #{path}"
         File.read(absolute_path).chomp
       end
       private :read_vanagon_token
@@ -70,7 +70,7 @@ class Vanagon
         absolute_path = File.expand_path(path)
         return nil unless File.exist?(absolute_path)
 
-        puts "Reading vmpooler token from: #{path}"
+        $stderr.puts "Reading vmpooler token from: #{path}"
         YAML.load_file(absolute_path)['token']
       end
       private :read_vmfloaty_token
@@ -119,7 +119,7 @@ class Vanagon
         )
         if response and response["ok"]
           Vanagon::Driver.logger.info "#{@target} has been destroyed"
-          puts "#{@target} has been destroyed"
+          $stderr.puts "#{@target} has been destroyed"
         else
           Vanagon::Driver.logger.info "#{@target} could not be destroyed"
           warn "#{@target} could not be destroyed"

--- a/lib/vanagon/optparse.rb
+++ b/lib/vanagon/optparse.rb
@@ -28,7 +28,7 @@ class Vanagon
         end
 
         opts.on('-h', '--help', 'Display help') do
-          puts opts
+          $stdout.puts opts
           exit 1
         end
       end

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -131,9 +131,9 @@ class Vanagon
       dsl.instance_eval(code, __FILE__, __LINE__)
       dsl._platform
     rescue => e
-      puts "Error loading platform '#{name}' using '#{platfile}':"
-      puts e
-      puts e.backtrace.join("\n")
+      $stderr.puts "Error loading platform '#{name}' using '#{platfile}':"
+      $stderr.puts e
+      $stderr.puts e.backtrace.join("\n")
       raise e
     end
 

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -95,9 +95,9 @@ class Vanagon
       dsl.instance_eval(code, __FILE__, __LINE__)
       dsl._project
     rescue => e
-      puts "Error loading project '#{name}' using '#{projfile}':"
-      puts e
-      puts e.backtrace.join("\n")
+      $stderr.puts "Error loading project '#{name}' using '#{projfile}':"
+      $stderr.puts e
+      $stderr.puts e.backtrace.join("\n")
       raise e
     end
 

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -228,7 +228,7 @@ class Vanagon
       #
       # @param name [String] name of component to add. must be present in configdir/components and named $name.rb currently
       def component(name)
-        puts "Loading #{name}" if @project.settings[:verbose]
+        $stderr.puts "Loading #{name}" if @project.settings[:verbose]
         if @include_components.empty? or @include_components.include?(name)
           component = Vanagon::Component.load_component(name, File.join(Vanagon::Driver.configdir, "components"), @project.settings, @project.platform)
           @project.components << component

--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -210,7 +210,7 @@ class Vanagon
     #                        output of the command if return_command_output is true
     # @raise [RuntimeError] If there is no target given or the command fails an exception is raised
     def remote_ssh_command(target, command, port = 22, return_command_output: false)
-      puts "Executing '#{command}' on '#{target}'"
+      $stderr.puts "Executing '#{command}' on '#{target}'"
       if return_command_output
         ret = %x(#{ssh_command(port)} -T #{target} '#{command.gsub("'", "'\\\\''")}').chomp
         if $CHILD_STATUS.success?
@@ -233,7 +233,7 @@ class Vanagon
     # @raise [RuntimeError] If the command fails an exception is raised
     def local_command(command, return_command_output: false)
       clean_environment do
-        puts "Executing '#{command}' locally"
+        $stderr.puts "Executing '#{command}' locally"
         if return_command_output
           ret = %x(#{command}).chomp
           if $CHILD_STATUS.success?
@@ -277,7 +277,7 @@ class Vanagon
       outfile ||= File.join(Dir.mktmpdir, File.basename(erbfile).sub(File.extname(erbfile), ""))
       output = erb_string(erbfile, opts[:binding])
       File.open(outfile, 'w') { |f| f.write output }
-      puts "Generated: #{outfile}"
+      $stderr.puts "Generated: #{outfile}"
       FileUtils.rm_rf erbfile if remove_orig
       outfile
     end


### PR DESCRIPTION
I'm not in love with this approach, but it's not drastically different
than how Vanagon handled notification/informing users of state/status
previously. The only difference is now the output is explicit, and can
be more easily/predictably filtered. I think that this is a hold-over
bandaid until we've got a better logging/notification system in place
in Vanagon but it should address the concerns in VANAGON-57.

As is, I'm not wedded to this approach and I'd love to hear any ideas anyone else has.