### PR TITLE
(VANAGON-55) Fix AIX RPMs requirements

### DIFF
--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -58,10 +58,7 @@ Requires:  <%= requires %>
 # did not specify a dependency on these.
 # In the future, we will supress pre/post scripts completely if there's nothing
 # specified by the project or the components.
-<%- if @platform.is_aix? -%>
-Requires: /bin/mkdir
-Requires: /bin/touch
-<%- else -%>
+<%- unless @platform.is_aix? -%>
 Requires(pre): /bin/mkdir
 Requires(pre): /bin/touch
 Requires(post): /bin/mkdir


### PR DESCRIPTION
AIX doesn't track the entire filesystem in the RPM database, so
there's a number of core system files that are not exposed to RPM and
should not be used as a constraint for dependencies. `/bin/touch` and
`/bin/mkdir` are two of them. We should stop requiring those files as
dependencies for AIX RPMs.