### PR TITLE
(maint) Fix for workdir with symlinks

### DIFF
--- a/lib/vanagon/component/source/git.rb
+++ b/lib/vanagon/component/source/git.rb
@@ -45,7 +45,7 @@ class Vanagon
           # Ensure that #url returns a URI object
           @url = URI.parse(url.to_s)
           @ref = opts[:ref]
-          @workdir = workdir
+          @workdir = File.realpath(workdir)
 
           # We can test for Repo existence without cloning
           raise Vanagon::InvalidRepo, "#{url} not a valid Git repo" unless valid_remote?

--- a/spec/lib/vanagon/component/source/git_spec.rb
+++ b/spec/lib/vanagon/component/source/git_spec.rb
@@ -17,6 +17,8 @@ describe "Vanagon::Component::Source::Git" do
     allow(Git)
       .to receive(:ls_remote)
             .and_return(true)
+
+    allow(File).to receive(:realpath).and_return(@workdir)
   end
 
   describe "#initialize" do
@@ -28,6 +30,13 @@ describe "Vanagon::Component::Source::Git" do
 
       expect { @klass.new(@url, ref: @ref_tag, workdir: @workdir) }
         .to raise_error(Vanagon::InvalidRepo)
+    end
+
+    it "uses the realpath of the workdir if we're in a symlinked dir" do
+      expect(File).to receive(:realpath).and_return("/tmp/bar")
+      git_source = @klass.new(@local_url, ref: @ref_tag, workdir: "/tmp/foo")
+      expect(git_source.workdir)
+        .to eq('/tmp/bar')
     end
   end
 


### PR DESCRIPTION
Fun fact: When building on OSX your tmpdir is going to end up in /var
which is actually a symlink to /private/var. If you don't chdir / set
your workdir to the realpath of your tmpdir git will fail with

fatal: Could not chdir to
'../../../../../../../../../../../private/var/folders...'

if you are using the `--git-dir` option. The ruby-git library we use
appends `--git-dir` to each git command. So, when initializing the git
objects we need to make sure we're using the `File.realpath` so we don't
trigger this weird issue when trying to update submodules.

Big thanks to @mckern for helping me track this issue down.