### PR TITLE
(maint) Do not create any backup files on patch

### DIFF
--- a/lib/vanagon/patch.rb
+++ b/lib/vanagon/patch.rb
@@ -32,7 +32,7 @@ class Vanagon
     end
 
     def cmd(platform)
-      "#{platform.patch} --strip=#{@strip} --fuzz=#{@fuzz} --ignore-whitespace < $(workdir)/patches/#{File.basename(@path)}"
+      "#{platform.patch} --strip=#{@strip} --fuzz=#{@fuzz} --ignore-whitespace --no-backup-if-mismatch < $(workdir)/patches/#{File.basename(@path)}"
     end
   end
 end

--- a/spec/lib/vanagon/component/rules_spec.rb
+++ b/spec/lib/vanagon/component/rules_spec.rb
@@ -75,8 +75,8 @@ describe Vanagon::Component::Rules do
       expect(rule.recipe.first).to eq(
         [
           "cd /foo/bar",
-          "/usr/bin/patch --strip=1 --fuzz=0 --ignore-whitespace < $(workdir)/patches/patch0",
-          "/usr/bin/patch --strip=2 --fuzz=1 --ignore-whitespace < $(workdir)/patches/patch1"
+          "/usr/bin/patch --strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch < $(workdir)/patches/patch0",
+          "/usr/bin/patch --strip=2 --fuzz=1 --ignore-whitespace --no-backup-if-mismatch < $(workdir)/patches/patch1"
         ].join(" && \\\n")
       )
     end
@@ -246,8 +246,8 @@ describe Vanagon::Component::Rules do
         Vanagon::Patch.new('/foo/postinstall/patch1', 4, 10, 'install', '/foo/quux'),
       ]
 
-      expect(rule.recipe[1]).to eq("cd /foo/baz && /usr/bin/patch --strip=3 --fuzz=9 --ignore-whitespace < $(workdir)/patches/patch0")
-      expect(rule.recipe[2]).to eq("cd /foo/quux && /usr/bin/patch --strip=4 --fuzz=10 --ignore-whitespace < $(workdir)/patches/patch1")
+      expect(rule.recipe[1]).to eq("cd /foo/baz && /usr/bin/patch --strip=3 --fuzz=9 --ignore-whitespace --no-backup-if-mismatch < $(workdir)/patches/patch0")
+      expect(rule.recipe[2]).to eq("cd /foo/quux && /usr/bin/patch --strip=4 --fuzz=10 --ignore-whitespace --no-backup-if-mismatch < $(workdir)/patches/patch1")
     end
 
     it_behaves_like "a rule that touches the target file"


### PR DESCRIPTION
Prior to this commit, if a patch wasn't perfectly cleanly applied, the
patch command would create a .orig file. This often would happen if
the patch was offset by some amount. This commit updates the patch
process to prevent that backup file from being created. We don't need
that, given that we're working on a throwaway system. If the patch can't
apply, it'll throw an error. If it does apply, even if there's an offset
issue, we don't need to save that backup file.