### PR TITLE
(maint) Add ability to generate source artifacts for rpm/deb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ end
 group(:development, :test) do
   gem 'json'
   gem 'lock_manager', *lock_manager_location_for(ENV['LOCK_MANAGER_LOCATION'] || '>= 0')
-  gem 'packaging', '~> 0.4.0', github: 'puppetlabs/packaging', branch: 'master'
+  gem 'packaging', github: 'puppetlabs/packaging', branch: 'master'
   gem 'rake', require: false
   gem 'rspec', '~> 3.0', require: false
   gem 'rubocop', "~> 0.47", require: false

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -60,6 +60,9 @@ class Vanagon
     # Stores the local path where retrieved artifacts will be saved.
     attr_accessor :output_dir
 
+    # Stores the local path where source artifacts will be saved.
+    attr_accessor :source_output_dir
+
     # Username to use when connecting to a build target
     attr_accessor :target_user
 
@@ -237,6 +240,17 @@ class Vanagon
     # @return [String] relative path to where packages should be output to
     def output_dir(target_repo = "")
       @output_dir ||= File.join(@os_name, @os_version, target_repo, @architecture)
+    end
+
+    # Get the source dir for packages. Don't change it if it was already defined
+    # by the platform config. Defaults to output_dir unless specified otherwise
+    # (RPM specifies this)
+    #
+    # @param target_repo [String] optional repo target for built source packages
+    # defined at the project level
+    # @return [String] relative path to where source packages should be output to
+    def source_output_dir(target_repo = "")
+      @source_output_dir ||= output_dir(target_repo)
     end
 
     # Get the value of @dist, or derive it from the value of @os_name and @os_version.

--- a/lib/vanagon/platform/deb.rb
+++ b/lib/vanagon/platform/deb.rb
@@ -7,6 +7,11 @@ class Vanagon
       # @return [Array] list of commands required to build a debian package for the given project from a tarball
       def generate_package(project) # rubocop:disable Metrics/AbcSize
         target_dir = project.repo ? output_dir(project.repo) : output_dir
+        if project.source_artifacts
+          copy_extensions = '*.{deb,build,tar.gz,changes,dsc}'
+        else
+          copy_extensions = '*.deb'
+        end
         pkg_arch_opt = project.noarch ? "" : "-a#{@architecture}"
         ["mkdir -p output/#{target_dir}",
         "mkdir -p $(tempdir)/#{project.name}-#{project.version}",
@@ -16,7 +21,7 @@ class Vanagon
         "gunzip -c #{project.name}-#{project.version}.tar.gz | '#{@tar}' -C '$(tempdir)/#{project.name}-#{project.version}' --strip-components 1 -xf -",
         "sed -i 's/\ /?/g' $(tempdir)/#{project.name}-#{project.version}/debian/install",
         "(cd $(tempdir)/#{project.name}-#{project.version}; debuild --no-lintian #{pkg_arch_opt} -uc -us)",
-        "cp $(tempdir)/*.deb ./output/#{target_dir}"]
+        "cp $(tempdir)/#{copy_extensions} ./output/#{target_dir}"]
       end
 
       # Method to generate the files required to build a debian package for the project

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -348,6 +348,10 @@ class Vanagon
         @platform.output_dir = directory
       end
 
+      def source_output_dir(directory)
+        @platform.source_output_dir = directory
+      end
+
       # Helper to setup a apt repository on a target system
       #
       # @param definition [String] the repo setup file, must be a valid uri, fetched with curl

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -80,6 +80,9 @@ class Vanagon
     # them to appear in your spec/rules files!
     attr_accessor :package_overrides
 
+    # Should we include source packages?
+    attr_accessor :source_artifacts
+
     # Loads a given project from the configdir
     #
     # @param name [String] the name of the project
@@ -122,6 +125,7 @@ class Vanagon
       @provides = []
       @conflicts = []
       @package_overrides = []
+      @source_artifacts = false
     end
 
     # Magic getter to retrieve settings in the project

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -148,6 +148,15 @@ class Vanagon
         @project.release = rel
       end
 
+      # Generate source packages in addition to binary packages.
+      # Currently only implemented for rpm/deb packages.
+      #
+      # @param source_artifacts [Boolean] whether or not to output
+      #        source packages
+      def generate_source_artifacts(source_artifacts)
+        @project.source_artifacts = source_artifacts
+      end
+
       # Sets the version for the project based on a git describe of the
       # directory that holds the configs. Requires that a git tag be present
       # and reachable from the current commit in that repository.

--- a/spec/lib/vanagon/platform/rpm_spec.rb
+++ b/spec/lib/vanagon/platform/rpm_spec.rb
@@ -26,6 +26,12 @@ describe 'Vanagon::Platform::RPM' do
         end
       end
 
+      describe '#source_output_dir' do
+        it "includes 'SRPMS'" do
+          expect(subject.source_output_dir).to include('SRPMS')
+        end
+      end
+
       describe "#dist" do
         it "uses explicit values when available" do
           expect(subject.dist).to eq(derived_dist) unless platform[:dist]

--- a/spec/lib/vanagon/platform_spec.rb
+++ b/spec/lib/vanagon/platform_spec.rb
@@ -4,41 +4,51 @@ describe "Vanagon::Platform" do
   let(:platforms) do
     [
       {
-        :name                    => "debian-6-i386",
-        :os_name                 => "debian",
-        :os_version              => "6",
-        :architecture            => "i386",
-        :output_dir              => "deb/lucid/",
-        :output_dir_with_target  => "deb/lucid/thing",
-        :output_dir_empty_string => "deb/lucid/",
-        :block                   => %Q[
+        :name                           => "debian-6-i386",
+        :os_name                        => "debian",
+        :os_version                     => "6",
+        :architecture                   => "i386",
+        :output_dir                     => "deb/lucid/",
+        :output_dir_with_target         => "deb/lucid/thing",
+        :output_dir_empty_string        => "deb/lucid/",
+        :source_output_dir              => "deb/lucid/",
+        :source_output_dir_with_target  => "deb/lucid/thing",
+        :source_output_dir_empty_string => "deb/lucid/",
+        :block                          => %Q[
           platform "debian-6-i386" do |plat|
             plat.codename "lucid"
           end ],
       },
       {
-        :name                    => "el-5-i386",
-        :os_name                 => "el",
-        :os_version              => "5",
-        :architecture            => "i386",
-        :output_dir              => "el/5/products/i386",
-        :output_dir_with_target  => "el/5/thing/i386",
-        :output_dir_empty_string => "el/5/i386",
-        :block                   => %Q[ platform "el-5-i386" do |plat| end ],
+        :name                           => "el-5-i386",
+        :os_name                        => "el",
+        :os_version                     => "5",
+        :architecture                   => "i386",
+        :output_dir                     => "el/5/products/i386",
+        :output_dir_with_target         => "el/5/thing/i386",
+        :output_dir_empty_string        => "el/5/i386",
+        :source_output_dir              => "el/5/products/SRPMS",
+        :source_output_dir_with_target  => "el/5/thing/SRPMS",
+        :source_output_dir_empty_string => "el/5/SRPMS",
+        :block                          => %Q[ platform "el-5-i386" do |plat| end ],
       },
       {
-        :name                    => "debian-6-i386",
-        :os_name                 => "debian",
-        :os_version              => "6",
-        :codename                => "lucid",
-        :architecture            => "i386",
-        :output_dir              => "updated/output",
-        :output_dir_with_target  => "updated/output",
-        :output_dir_empty_string => "updated/output",
-        :block                   => %Q[
+        :name                           => "debian-6-i386",
+        :os_name                        => "debian",
+        :os_version                     => "6",
+        :codename                       => "lucid",
+        :architecture                   => "i386",
+        :output_dir                     => "updated/output",
+        :output_dir_with_target         => "updated/output",
+        :output_dir_empty_string        => "updated/output",
+        :source_output_dir              => "updated/sources",
+        :source_output_dir_with_target  => "updated/sources",
+        :source_output_dir_empty_string => "updated/sources",
+        :block                          => %Q[
           platform "debian-6-i386" do |plat|
             plat.codename "lucid"
             plat.output_dir "updated/output"
+            plat.source_output_dir "updated/sources"
           end ],
       },
     ]
@@ -87,6 +97,33 @@ describe "Vanagon::Platform" do
       end
     end
   end
+
+  describe "#source_output_dir" do
+    it "returns correct source dir" do
+      platforms.each do |plat|
+        cur_plat = Vanagon::Platform::DSL.new(plat[:name])
+        cur_plat.instance_eval(plat[:block])
+        expect(cur_plat._platform.source_output_dir).to eq(plat[:source_output_dir])
+      end
+    end
+
+    it "adds the target repo in the right way" do
+      platforms.each do |plat|
+        cur_plat = Vanagon::Platform::DSL.new(plat[:name])
+        cur_plat.instance_eval(plat[:block])
+        expect(cur_plat._platform.source_output_dir('thing')).to eq(plat[:source_output_dir_with_target])
+      end
+    end
+
+    it "does the right thing with empty strings" do
+      platforms.each do |plat|
+        cur_plat = Vanagon::Platform::DSL.new(plat[:name])
+        cur_plat.instance_eval(plat[:block])
+        expect(cur_plat._platform.source_output_dir('')).to eq(plat[:source_output_dir_empty_string])
+      end
+    end
+  end
+
 
   describe "#architecture" do
     it "returns the architecture for the platform" do

--- a/spec/lib/vanagon/project/dsl_spec.rb
+++ b/spec/lib/vanagon/project/dsl_spec.rb
@@ -142,6 +142,28 @@ end" }
     end
   end
 
+  describe '#generate_source_artifacts' do
+    it 'defaults to false' do
+      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj.instance_eval(project_block)
+      expect(proj._project.source_artifacts).to eq(false)
+    end
+
+    it 'sets source_artifacts to true' do
+      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj.instance_eval(project_block)
+      proj.generate_source_artifacts true
+      expect(proj._project.source_artifacts).to eq(true)
+    end
+
+    it 'sets source_artifacts to false' do
+      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj.instance_eval(project_block)
+      proj.generate_source_artifacts false
+      expect(proj._project.source_artifacts).to eq(false)
+    end
+  end
+
   describe '#identifier' do
     it 'sets the identifier for the project' do
       proj = Vanagon::Project::DSL.new('test-fixture', {})


### PR DESCRIPTION
Sometimes it's useful to be able to generate .src.rpm and
.dsc/changes/etc. This adds the ability to do that.