### PR TITLE
(maint) Fully qualify Git::GitExecuteError

### DIFF
--- a/lib/vanagon/component/source/git.rb
+++ b/lib/vanagon/component/source/git.rb
@@ -119,7 +119,7 @@ class Vanagon
         def clone!
           $stderr.puts "Cloning Git repo '#{url}'"
           $stderr.puts "Successfully cloned '#{dirname}'" if clone
-        rescue Git::GitExecuteError
+        rescue ::Git::GitExecuteError
           raise Vanagon::InvalidRepo, "Unable to clone from '#{url}'"
         end
         private :clone!


### PR DESCRIPTION
Since Git::GitExecuteError is referenced within a class named Git, we
need to fully qualify it, otherwise, we get:

    error uninitialized constant Vanagon::Component::Source::Git::GitExecuteError