### PR TITLE
Fix backtraces from exceptions thrown from config files.

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -116,9 +116,8 @@ class Vanagon
     # @raise if the instance_eval on Component fails, the exception is reraised
     def self.load_component(name, configdir, settings, platform)
       compfile = File.join(configdir, "#{name}.rb")
-      code = File.read(compfile)
       dsl = Vanagon::Component::DSL.new(name, settings, platform)
-      dsl.instance_eval(code, __FILE__, __LINE__)
+      dsl.instance_eval(File.read(compfile), compfile, 1)
       dsl._component
     rescue => e
       $stderr.puts "Error loading project '#{name}' using '#{compfile}':"

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -129,9 +129,8 @@ class Vanagon
     # @raise if the instance_eval on Platform fails, the exception is reraised
     def self.load_platform(name, configdir)
       platfile = File.join(configdir, "#{name}.rb")
-      code = File.read(platfile)
       dsl = Vanagon::Platform::DSL.new(name)
-      dsl.instance_eval(code, __FILE__, __LINE__)
+      dsl.instance_eval(File.read(platfile), platfile, 1)
       dsl._platform
     rescue => e
       $stderr.puts "Error loading platform '#{name}' using '#{platfile}':"

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -93,9 +93,8 @@ class Vanagon
     # @raise if the instance_eval on Project fails, the exception is reraised
     def self.load_project(name, configdir, platform, include_components = [])
       projfile = File.join(configdir, "#{name}.rb")
-      code = File.read(projfile)
       dsl = Vanagon::Project::DSL.new(name, platform, include_components)
-      dsl.instance_eval(code, __FILE__, __LINE__)
+      dsl.instance_eval(File.read(projfile), projfile, 1)
       dsl._project
     rescue => e
       $stderr.puts "Error loading project '#{name}' using '#{projfile}':"


### PR DESCRIPTION
The filename and lineno params to #instance_eval were not being set
correctly, so the location indicated by the backtrace as the source of
an exception is not correct. This also confuses pry if you try to debug
your config file.

Not sure where a good place to add tests for this would be but happy to do so if someone can make a suggestion.