### PR TITLE
(VANAGON-49) install_file isn't respecting owner/group/mode

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,7 +38,7 @@ Lint/ShadowingOuterLocalVariable:
 Lint/LiteralInInterpolation:
   Enabled: true
 
-Style/MultilineMethodCallIndentation:
+Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
   IndentationWidth: 2
 
@@ -57,7 +57,7 @@ Lint/AssignmentInCondition:
   Enabled: false
 
 # DISABLED - not useful
-Style/SpaceBeforeComment:
+Layout/SpaceBeforeComment:
   Enabled: false
 
 # DISABLED - not useful
@@ -136,7 +136,7 @@ Lint/UselessAssignment:
 Lint/Void:
   Enabled: false
 
-Style/AccessModifierIndentation:
+Layout/AccessModifierIndentation:
   Enabled: false
 
 Style/AccessorMethodName:
@@ -145,13 +145,13 @@ Style/AccessorMethodName:
 Style/Alias:
   Enabled: false
 
-Style/AlignArray:
+Layout/AlignArray:
   Enabled: false
 
-Style/AlignHash:
+Layout/AlignHash:
   Enabled: false
 
-Style/AlignParameters:
+Layout/AlignParameters:
   Enabled: false
 
 Metrics/BlockNesting:
@@ -169,7 +169,7 @@ Style/BracesAroundHashParameters:
 Style/CaseEquality:
   Enabled: false
 
-Style/CaseIndentation:
+Layout/CaseIndentation:
   Enabled: false
 
 Style/CharacterLiteral:
@@ -203,67 +203,67 @@ Style/WordArray:
 Style/UnneededPercentQ:
   Enabled: false
 
-Style/Tab:
+Layout/Tab:
   Enabled: false
 
-Style/SpaceBeforeSemicolon:
+Layout/SpaceBeforeSemicolon:
   Enabled: true
 
-Style/TrailingBlankLines:
+Layout/TrailingBlankLines:
   Enabled: false
 
-Style/SpaceInsideBlockBraces:
+Layout/SpaceInsideBlockBraces:
   Enabled: true
 
-Style/SpaceInsideBrackets:
+Layout/SpaceInsideBrackets:
   Enabled: true
 
-Style/SpaceInsideHashLiteralBraces:
+Layout/SpaceInsideHashLiteralBraces:
   Enabled: true
 
-Style/SpaceInsideParens:
+Layout/SpaceInsideParens:
   Enabled: true
 
-Style/LeadingCommentSpace:
+Layout/LeadingCommentSpace:
   Enabled: false
 
-Style/SpaceBeforeFirstArg:
+Layout/SpaceBeforeFirstArg:
   Enabled: true
 
-Style/SpaceAfterColon:
+Layout/SpaceAfterColon:
   Enabled: true
 
-Style/SpaceAfterComma:
+Layout/SpaceAfterComma:
   Enabled: true
 
-Style/SpaceAroundKeyword:
+Layout/SpaceAroundKeyword:
   Enabled: true
 
-Style/SpaceAfterMethodName:
+Layout/SpaceAfterMethodName:
   Enabled: true
 
-Style/SpaceAfterNot:
+Layout/SpaceAfterNot:
   Enabled: true
 
-Style/SpaceAfterSemicolon:
+Layout/SpaceAfterSemicolon:
   Enabled: true
 
-Style/SpaceAroundEqualsInParameterDefault:
+Layout/SpaceAroundEqualsInParameterDefault:
   Enabled: true
 
-Style/SpaceAroundOperators:
+Layout/SpaceAroundOperators:
   Enabled: true
 
-Style/SpaceBeforeBlockBraces:
+Layout/SpaceBeforeBlockBraces:
   Enabled: true
 
-Style/SpaceBeforeComma:
+Layout/SpaceBeforeComma:
   Enabled: true
 
 Style/CollectionMethods:
   Enabled: false
 
-Style/CommentIndentation:
+Layout/CommentIndentation:
   Enabled: false
 
 Style/ColonMethodCall:
@@ -284,7 +284,7 @@ Style/Documentation:
 Style/DefWithParentheses:
   Enabled: false
 
-Style/DotPosition:
+Layout/DotPosition:
   Enabled: false
 
 # DISABLED - used for converting to bool
@@ -294,25 +294,25 @@ Style/DoubleNegation:
 Style/EachWithObject:
   Enabled: false
 
-Style/EmptyLineBetweenDefs:
+Layout/EmptyLineBetweenDefs:
   Enabled: false
 
-Style/IndentArray:
+Layout/IndentArray:
   Enabled: false
 
-Style/IndentHash:
+Layout/IndentHash:
   Enabled: false
 
-Style/IndentationConsistency:
+Layout/IndentationConsistency:
   Enabled: true
 
-Style/IndentationWidth:
+Layout/IndentationWidth:
   Enabled: true
 
-Style/EmptyLines:
+Layout/EmptyLines:
   Enabled: false
 
-Style/EmptyLinesAroundAccessModifier:
+Layout/EmptyLinesAroundAccessModifier:
   Enabled: false
 
 Style/EmptyLiteral:
@@ -330,7 +330,7 @@ Style/MethodDefParentheses:
 Style/LineEndConcatenation:
   Enabled: false
 
-Style/TrailingWhitespace:
+Layout/TrailingWhitespace:
   Enabled: true
 
 Style/StringLiterals:

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -69,6 +69,7 @@ end" }
   before do
     allow(platform).to receive(:install).and_return('install')
     allow(platform).to receive(:copy).and_return('cp')
+    allow(platform).to receive(:is_windows?).and_return(false)
   end
 
   describe "#md5sum" do
@@ -576,6 +577,7 @@ end" }
       comp.install_file('thing1', 'place/to/put/thing1', owner: 'bob', group: 'timmy', mode: '0022')
       expect(comp._component.install).to include("install -d 'place/to/put'")
       expect(comp._component.install).to include("cp -p 'thing1' 'place/to/put/thing1'")
+      expect(comp._component.install).to include("chmod 0022 'place/to/put/thing1'")
       expect(comp._component.files).to include(Vanagon::Common::Pathname.file('place/to/put/thing1', mode: '0022', owner: 'bob', group: 'timmy'))
     end
   end
@@ -716,32 +718,36 @@ end" }
 
   describe '#directory' do
     it 'adds a directory with the desired path to the directory collection for the component' do
-      comp = Vanagon::Component::DSL.new('directory-test', {}, {})
+      comp = Vanagon::Component::DSL.new('directory-test', {}, platform)
       comp.directory('/a/b/c')
       expect(comp._component.directories).to include(Vanagon::Common::Pathname.new('/a/b/c'))
     end
 
     it 'adds a directory with the desired mode to the directory collection for the component' do
-      comp = Vanagon::Component::DSL.new('directory-test', {}, {})
+      comp = Vanagon::Component::DSL.new('directory-test', {}, platform)
       comp.directory('/a/b/c', mode: '0755')
+      expect(comp._component.install).to include("install -d -m '0755' '/a/b/c'")
       expect(comp._component.directories.first).to eq(Vanagon::Common::Pathname.new('/a/b/c', mode: '0755'))
     end
 
     it 'adds a directory with the desired owner to the directory collection for the component' do
-      comp = Vanagon::Component::DSL.new('directory-test', {}, {})
+      comp = Vanagon::Component::DSL.new('directory-test', {}, platform)
       comp.directory('/a/b/c', owner: 'olivia')
+      expect(comp._component.install).to include("install -d '/a/b/c'")
       expect(comp._component.directories.first).to eq(Vanagon::Common::Pathname.new('/a/b/c', owner: 'olivia'))
     end
 
     it 'adds a directory with the desired group to the directory collection for the component' do
-      comp = Vanagon::Component::DSL.new('directory-test', {}, {})
+      comp = Vanagon::Component::DSL.new('directory-test', {}, platform)
       comp.directory('/a/b/c', group: 'release-engineering')
+      expect(comp._component.install).to include("install -d '/a/b/c'")
       expect(comp._component.directories.first).to eq(Vanagon::Common::Pathname.new('/a/b/c', group: 'release-engineering'))
     end
 
     it 'adds a directory with the desired attributes to the directory collection for the component' do
-      comp = Vanagon::Component::DSL.new('directory-test', {}, {})
+      comp = Vanagon::Component::DSL.new('directory-test', {}, platform)
       comp.directory('/a/b/c', mode: '0400', owner: 'olivia', group: 'release-engineering')
+      expect(comp._component.install).to include("install -d -m '0400' '/a/b/c'")
       expect(comp._component.directories.first).to eq(Vanagon::Common::Pathname.new('/a/b/c', mode: '0400', owner: 'olivia', group: 'release-engineering'))
     end
   end


### PR DESCRIPTION
Currently the owner/group/mode is set in the inidividual post-install
steps based on platform. However, some platforms do not have this
implemented. We can work around this by setting owner/group/mode when we
install files and directories on the build environment.

This seems to at least fix an issue with mode not being set for osx.
More in-depth testing should be done though.