### PR TITLE
(VANAGON-63) Generate additional build metadata

### DIFF
--- a/lib/vanagon.rb
+++ b/lib/vanagon.rb
@@ -1,5 +1,9 @@
+require 'time'
+
 LIBDIR = File.expand_path(File.dirname(__FILE__))
 VANAGON_ROOT = File.join(File.expand_path(File.dirname(__FILE__)), "..")
+BUILD_TIME = Time.now.iso8601
+VANAGON_VERSION = Gem.loaded_specs["vanagon"].version.to_s
 
 $:.unshift(LIBDIR) unless
   $:.include?(File.dirname(__FILE__)) || $:.include?(LIBDIR)

--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -290,6 +290,10 @@ class Vanagon
       end
     end
 
+    def get_dependency_hash
+      { name => { 'version' => version, 'ref' => options[:ref] }.delete_if { |_, v| !v } }
+    end
+
     # Fetches secondary sources for the component. These are just dumped into the workdir currently.
     #
     # @param workdir [String] working directory to put the source into

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -124,6 +124,7 @@ class Vanagon
       @project.make_makefile(@workdir)
       @project.make_bill_of_materials(@workdir)
       @project.generate_packaging_artifacts(@workdir)
+      @project.save_manifest_json
       @engine.ship_workdir(@workdir)
       @engine.dispatch("(cd #{@engine.remote_workdir}; #{@platform.make})")
       @engine.retrieve_built_artifact

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -476,5 +476,44 @@ class Vanagon
     def generate_packaging_artifacts(workdir)
       @platform.generate_packaging_artifacts(workdir, @name, binding)
     end
+
+    # Generate a json hash which lists all of the dependant components of the
+    # project.
+    #
+    # @return [Hash] where the top level keys are components and their values
+    #   are hashes with additional information on the component.
+    def generate_dependencies_info
+      @components.each_with_object({}) do |component, hsh|
+        hsh.merge!(component.get_dependency_hash)
+      end
+    end
+
+    # Generate a hash which contains relevant information regarding components
+    # of a package, what vanagon built the package, time of build, as well as
+    # version of the thing we were building.
+    #
+    # @return [Hash] of information which is useful to know about how a package
+    #   was built and what went into the package.
+    def build_manifest_json
+      manifest = {
+        "packaging_type" => {
+          "vanagon" => VANAGON_VERSION,
+        },
+        "version" => version,
+        "components" => generate_dependencies_info,
+        "build_time" => BUILD_TIME,
+      }
+    end
+
+    # Writes a json file at `ext/build_metadata.json` containing information
+    # about what went into a built artifact
+    #
+    # @return [Hash] of build information
+    def save_manifest_json
+      manifest = build_manifest_json
+      File.open(File.join('ext', 'build_metadata.json'), 'w') do |f|
+        f.write(JSON.pretty_generate(manifest))
+      end
+    end
   end
 end

--- a/spec/lib/vanagon/project_spec.rb
+++ b/spec/lib/vanagon/project_spec.rb
@@ -115,4 +115,55 @@ describe 'Vanagon::Project' do
       expect(@proj.filter_component(comp1.name)).to eq([comp1, comp2, comp3])
     end
   end
+
+  describe '#generate_dependencies_info' do
+    before(:each) do
+      @proj = Vanagon::Project.new('test-project', {})
+    end
+
+    it "returns a hash of components and their versions" do
+      comp1 = Vanagon::Component.new('test-component1', {}, {})
+      comp1.version = '1.0.0'
+      comp2 = Vanagon::Component.new('test-component2', {}, {})
+      comp2.version = '2.0.0'
+      comp2.options[:ref] = '123abcd'
+      comp3 = Vanagon::Component.new('test-component3', {}, {})
+      @proj.components << comp1
+      @proj.components << comp2
+      @proj.components << comp3
+
+      expect(@proj.generate_dependencies_info()).to eq({
+        'test-component1' => { 'version' => '1.0.0' },
+        'test-component2' => { 'version' => '2.0.0', 'ref' => '123abcd' },
+        'test-component3' => {},
+      })
+    end
+  end
+
+  describe '#build_manifest_json' do
+    before(:each) do
+      class Vanagon
+        class Project
+          BUILD_TIME = '2017-07-10T13:34:25-07:00'
+          VANAGON_VERSION = '0.0.0-rspec'
+        end
+      end
+
+      @proj = Vanagon::Project.new('test-project', {})
+    end
+
+    it 'should generate a hash with the expected build metadata' do
+      comp1 = Vanagon::Component.new('test-component1', {}, {})
+      comp1.version = '1.0.0'
+      @proj.components << comp1
+      @proj.version = '123abcde'
+
+      expect(@proj.build_manifest_json()).to eq({
+        'packaging_type' => { 'vanagon' => '0.0.0-rspec' },
+        'version' => '123abcde',
+        'components' => { 'test-component1' => { 'version' => '1.0.0' } },
+        'build_time' => '2017-07-10T13:34:25-07:00',
+      })
+    end
+  end
 end


### PR DESCRIPTION
This commit adds in the ability for vanagon to generate additional build
data for downstream package promotion consumption.