### PR TITLE
(MAINT) Make the url Unzip command more robust

### DIFF
--- a/lib/vanagon/component/source/local.rb
+++ b/lib/vanagon/component/source/local.rb
@@ -107,7 +107,7 @@ class Vanagon
           when "xz"
             %(unxz "#{file}")
           when "zip"
-            "unzip -d '#{File.basename(file, '.zip')}' '#{file}' || 7za x -r -tzip -o'#{File.basename(file, '.zip')}' '#{file}'"
+            "unzip -d '#{File.basename(file, '.zip')}' '#{file}' || 7za x -r -tzip -o'#{File.basename(file, '.zip')}' '#{file}' || 7z x -r -tzip -o'#{File.basename(file, '.zip')}' '#{file}'"
           else
             raise Vanagon::Error, "Don't know how to decompress #{extension} archives"
           end


### PR DESCRIPTION
7za has changed to 7z in the latest version of chocolately, so allow
both forms of the command for compatibility