### PR TITLE
(maint) avoid duplicate file errors when directory names contain spaces

### DIFF
--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -149,11 +149,11 @@ install -d %{buildroot}
 <%- end -%>
 
 # Here we turn all dirs in the file-list into %dir entries to avoid duplicate files
-for entry in `cat %{SOURCE1}`; do
+while read entry; do
   if [ -n "$entry" -a -d "$entry" -a ! -L "$entry" ]; then
     PATH=/opt/freeware/bin:$PATH sed -i "s|^\($entry\)\$|%dir \1|g" %{SOURCE1}
   fi
-done
+done < %{SOURCE1}
 
 
 %pre


### PR DESCRIPTION
Found as

```
warning: File listed twice: /opt/puppetlabs/pdk/share/cache/ruby/2.1.0/gems/mini_portile2-2.3.0/test/assets/test mini portile-1.0.0/configure
```

See these bash experiments:

```
david@davids:~/git/vanagon$ echo "a b" >> ../tmp/quux
david@davids:~/git/vanagon$ echo "c d" >> ../tmp/quux
david@davids:~/git/vanagon$ for i in `cat ../tmp/quux`; do echo $i; done
a
b
c
d
david@davids:~/git/vanagon$ for i in "`cat ../tmp/quux`"; do echo $i; done
a b c d
david@davids:~/git/vanagon$ while read i; do echo $i; done < ../tmp/quux
a b
c d
david@davids:~/git/vanagon$
```