### PR TITLE
(VANAGON-111) Generate a sha1 sum at build time

### DIFF
--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -37,6 +37,7 @@ class Vanagon
     attr_accessor :rpmbuild # This is RedHat/EL/Fedora/SLES specific
     attr_accessor :sort
     attr_accessor :tar
+    attr_accessor :shasum
 
     # Hold a string containing the values that a given platform
     # should use when a Makefile is run - resolves to the CFLAGS
@@ -215,6 +216,7 @@ class Vanagon
       @find ||= "find"
       @sort ||= "sort"
       @copy ||= "cp"
+      @shasum ||= "sha1sum"
 
       # Our first attempt at defining metadata about a platform
       @cross_compiled ||= false
@@ -445,6 +447,7 @@ class Vanagon
     def generate_compiled_archive(project)
       name_and_version = "#{project.name}-#{project.version}"
       name_and_version_and_platform = "#{name_and_version}.#{name}"
+      final_archive = "output/#{name_and_version_and_platform}.tar.gz"
       archive_directory = "#{project.name}-archive"
       metadata = project.build_manifest_json(true)
       metadata.gsub!(/\n/, '\n')
@@ -457,7 +460,8 @@ class Vanagon
         "gzip -9c #{name_and_version_and_platform}.tar > #{name_and_version_and_platform}.tar.gz",
         "echo -e \"#{metadata}\" > output/#{name_and_version_and_platform}.json",
         "cp bill-of-materials output/#{name_and_version_and_platform}-bill-of-materials ||:",
-        "cp #{name_and_version_and_platform}.tar.gz output"
+        "cp #{name_and_version_and_platform}.tar.gz output",
+        "#{shasum} #{final_archive} > #{final_archive}.sha1"
       ]
     end
 

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -111,6 +111,10 @@ class Vanagon
         @platform.tar = tar_cmd
       end
 
+      def shasum(sha1sum_command)
+        @platform.shasum = sha1sum_command
+      end
+
       # Set the type of package we are going to build for this platform
       #
       # @param pkg_type [String] The type of package we are going to build for this platform

--- a/lib/vanagon/platform/osx.rb
+++ b/lib/vanagon/platform/osx.rb
@@ -101,6 +101,7 @@ class Vanagon
         @name = name
         @make = "/usr/bin/make"
         @tar = "tar"
+        @shasum = "/usr/bin/shasum"
         @pkgbuild = "/usr/bin/pkgbuild"
         @productbuild = "/usr/bin/productbuild"
         @hdiutil = "/usr/bin/hdiutil"

--- a/lib/vanagon/platform/rpm/aix.rb
+++ b/lib/vanagon/platform/rpm/aix.rb
@@ -17,6 +17,7 @@ class Vanagon
           @make = "/usr/bin/gmake"
           @tar = "/opt/freeware/bin/tar"
           @patch = "/opt/freeware/bin/patch"
+          @shasum = "/opt/freeware/bin/sha1sum"
           @num_cores = "lsdev -Cc processor |wc -l"
           @install = "/opt/freeware/bin/install"
           @rpmbuild = "/usr/bin/rpm"

--- a/lib/vanagon/platform/solaris_10.rb
+++ b/lib/vanagon/platform/solaris_10.rb
@@ -185,6 +185,7 @@ class Vanagon
         @make = "/opt/csw/bin/gmake"
         @tar = "/usr/sfw/bin/gtar"
         @patch = "/usr/bin/gpatch"
+        @shasum = "/opt/csw/bin/shasum"
         # solaris 10
         @num_cores = "/usr/bin/kstat cpu_info | awk '{print $$1}' | grep '^core_id$$' | wc -l"
         super(name)


### PR DESCRIPTION
In order to validate that the archive has the contents we expect it to, we generate the sha1 sum at build time for verification at build time of the parent project.