### PR TITLE
(maint) Simplify compiled archive generation

### DIFF
--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -456,7 +456,7 @@ class Vanagon
         "mkdir #{archive_directory}",
         "gunzip -c #{name_and_version}.tar.gz | '#{tar}' -C #{archive_directory} -xf -",
         "rm #{name_and_version}.tar.gz",
-        "#{tar} cf #{name_and_version_and_platform}.tar -C #{archive_directory}/#{name_and_version} `#{find} #{archive_directory}/#{name_and_version} -maxdepth 1 -mindepth 1 -type d | sed -e 's|#{archive_directory}/#{name_and_version}/||'`",
+        "cd #{archive_directory}/#{name_and_version}; #{tar} cf ../../#{name_and_version_and_platform}.tar `#{find} . -type d`",
         "gzip -9c #{name_and_version_and_platform}.tar > #{name_and_version_and_platform}.tar.gz",
         "echo -e \"#{metadata}\" > output/#{name_and_version_and_platform}.json",
         "cp bill-of-materials output/#{name_and_version_and_platform}-bill-of-materials ||:",

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -456,7 +456,7 @@ class Vanagon
         "mkdir #{archive_directory}",
         "gunzip -c #{name_and_version}.tar.gz | '#{tar}' -C #{archive_directory} -xf -",
         "rm #{name_and_version}.tar.gz",
-        "cd #{archive_directory}/#{name_and_version}; #{tar} cf ../../#{name_and_version_and_platform}.tar *",
+        "cd #{archive_directory}/#{name_and_version}; rm -f bill-of-materials; #{tar} cf ../../#{name_and_version_and_platform}.tar *",
         "gzip -9c #{name_and_version_and_platform}.tar > #{name_and_version_and_platform}.tar.gz",
         "echo -e \"#{metadata}\" > output/#{name_and_version_and_platform}.json",
         "cp bill-of-materials output/#{name_and_version_and_platform}-bill-of-materials ||:",

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -456,7 +456,7 @@ class Vanagon
         "mkdir #{archive_directory}",
         "gunzip -c #{name_and_version}.tar.gz | '#{tar}' -C #{archive_directory} -xf -",
         "rm #{name_and_version}.tar.gz",
-        "cd #{archive_directory}/#{name_and_version}; #{tar} cf ../../#{name_and_version_and_platform}.tar `#{find} . -type d`",
+        "cd #{archive_directory}/#{name_and_version}; #{tar} cf ../../#{name_and_version_and_platform}.tar *",
         "gzip -9c #{name_and_version_and_platform}.tar > #{name_and_version_and_platform}.tar.gz",
         "echo -e \"#{metadata}\" > output/#{name_and_version_and_platform}.json",
         "cp bill-of-materials output/#{name_and_version_and_platform}-bill-of-materials ||:",


### PR DESCRIPTION
The way we were populating the compiled archives in the past caused failures on Solaris. The version of `gtar` on Solaris 10 and 11 claims to support the `-C` flag to change directories prior to adding files, however this ends up giving errors about the directories not being found. Since each line of the makefile executes in a separate shell anyways, let's just `cd` prior to generating the tarball to simplify the commands.