### PR TITLE
(maint) Add 'archive' package type for windows

### DIFF
--- a/lib/vanagon/platform/windows.rb
+++ b/lib/vanagon/platform/windows.rb
@@ -11,6 +11,10 @@ class Vanagon
           return generate_msi_package(project)
         when "nuget"
           return generate_nuget_package(project)
+        when "archive"
+          # We don't need to generate the package for archives, return an
+          # empty array
+          return []
         else
           raise Vanagon::Error, "I don't know how to build package type '#{project.platform.package_type}' for Windows. Teach me?"
         end
@@ -26,6 +30,8 @@ class Vanagon
           return msi_package_name(project)
         when "nuget"
           return nuget_package_name(project)
+        when "archive"
+          return "#{project.name}-#{project.version}-archive"
         else
           raise Vanagon::Error, "I don't know how to name package type '#{project.platform.package_type}' for Windows. Teach me?"
         end
@@ -43,6 +49,9 @@ class Vanagon
           return generate_msi_packaging_artifacts(workdir, name, binding)
         when "nuget"
           return generate_nuget_packaging_artifacts(workdir, name, binding)
+        when "archive"
+          # We don't need to generate packaging artifacts if this is an archive
+          return
         else
           raise Vanagon::Error, "I don't know how create packaging artifacts for package type '#{project.platform.package_type}' for Windows. Teach me?"
         end

--- a/spec/lib/vanagon/platform/windows_spec.rb
+++ b/spec/lib/vanagon/platform/windows_spec.rb
@@ -38,6 +38,7 @@ describe "Vanagon::Platform::Windows" do
       let (:project_block) {
         <<-HERE.undent
           project 'test-fixture' do |proj|
+            proj.version '0.0.0'
             proj.setting(:company_name, "Test Name")
             proj.setting(:company_id, "TestID")
             proj.setting(:product_id, "TestProduct")
@@ -65,6 +66,33 @@ describe "Vanagon::Platform::Windows" do
           expect(cur_plat._platform.wix_product_version("1.0.g0")).to eq("1.0.0")
         end
       end
+
+      describe '#package_type' do
+        it "skips package generation for 'archive' package types" do
+          cur_plat.instance_eval(plat[:block])
+          cur_plat.package_type 'archive'
+          proj = Vanagon::Project::DSL.new('test-fixture', cur_plat._platform, [])
+          proj.instance_eval(project_block)
+          expect(cur_plat._platform.generate_package(proj._project)).to eq([])
+        end
+
+        it "generates a package_name for 'archive' package types" do
+          cur_plat.instance_eval(plat[:block])
+          cur_plat.package_type 'archive'
+          proj = Vanagon::Project::DSL.new('test-fixture', cur_plat._platform, [])
+          proj.instance_eval(project_block)
+          expect(cur_plat._platform.package_name(proj._project)).to eq('test-fixture-0.0.0-archive')
+        end
+
+        it "skips packaging artifact generation for 'archive' package types" do
+          cur_plat.instance_eval(plat[:block])
+          cur_plat.package_type 'archive'
+          proj = Vanagon::Project::DSL.new('test-fixture', cur_plat._platform, [])
+          proj.instance_eval(project_block)
+          expect(cur_plat._platform.generate_packaging_artifacts('',proj._project.name,'',proj._project)).to eq(nil)
+        end
+      end
+
       describe '#generate_msi_packaging_artifacts' do
         before(:each) do
           # Create Workdir and temp root directory


### PR DESCRIPTION
Due to the nature of how windows builds work, several of the packaging
steps will fail without the resources/windows/wix or resources/windows/nuget
directories. This commit adds the 'archive' package type, intended for
use when you're only generating the compiled archive. This package type
lets you skip over the generate_*_package and
generate_*_packaging_artifacts methods.