### PR TITLE
(VANAGON-111) enable consumption of remote checksums

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -318,7 +318,7 @@ class Vanagon
     def get_sources(workdir) # rubocop:disable Metrics/AbcSize
       sources.each do |source|
         src = Vanagon::Component::Source.source(
-          source.url, workdir: workdir, ref: source.ref, sum: source.sum
+          source.url, workdir: workdir, ref: source.ref, sum: source.sum, sum_url: source.sum_url
         )
         src.fetch
         src.verify

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -311,6 +311,14 @@ class Vanagon
       alias_method :sha256sum, :sum
       alias_method :sha512sum, :sum
 
+      # URL of a file to get the source checksum from
+      #
+      # @param url [String] Checksum file URL
+      def sum_url(url)
+        @component.options[:sum_url] = url
+        @component.options[:sum_type] = File.extname(url).sub(/\./, '').downcase
+      end
+
       # Sets the ref of the source for use in a git source
       #
       # @param the_ref [String] ref, sha, branch or tag to checkout for a git source

--- a/lib/vanagon/component/source.rb
+++ b/lib/vanagon/component/source.rb
@@ -28,6 +28,7 @@ class Vanagon
           if Vanagon::Component::Source::Http.valid_url?(uri)
             return Vanagon::Component::Source::Http.new uri,
               sum: options[:sum],
+              sum_url: options[:sum_url],
               workdir: options[:workdir],
               # Default sum_type is md5 if unspecified:
               sum_type: options[:sum_type] || "md5"

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -65,11 +65,46 @@ end" }
   let(:dummy_sha1_sum) { "fdaa03c3f506d7b71635f2c32dfd41b0cc8b904f" }
   let(:dummy_sha256_sum) { "fd9c922702eb2e2fb26376c959753f0fc167bb6bc99c79262fcff7bcc8b34be1" }
   let(:dummy_sha512_sum) { "8feda1e9896be618dd6c65120d10afafce93888df8569c598f52285083c23befd1477da5741939d4eae042f822e45ca2e45d8d4d18cf9224b7acaf71d883841e" }
+  let(:dummy_md5_url) { "http://example.com/example.tar.gz.md5" }
+  let(:dummy_sha1_url) { "http://example.com/example.tar.gz.sha1" }
+  let(:dummy_sha256_url) { "http://example.com/example.tar.gz.sha256" }
+  let(:dummy_sha512_url) { "http://example.com/example.tar.gz.sha512" }
 
   before do
     allow(platform).to receive(:install).and_return('install')
     allow(platform).to receive(:copy).and_return('cp')
     allow(platform).to receive(:is_windows?).and_return(false)
+  end
+
+  describe "#sum_url" do
+    it "sets md5 url and type correctly" do
+      comp = Vanagon::Component::DSL.new('test-fixture', {}, {})
+      comp.sum_url(dummy_md5_url)
+
+      expect(comp._component.options[:sum_url]).to eq(dummy_md5_url)
+      expect(comp._component.options[:sum_type]).to eq('md5')
+    end
+    it "sets sha1 url and type correctly" do
+      comp = Vanagon::Component::DSL.new('test-fixture', {}, {})
+      comp.sum_url(dummy_sha1_url)
+
+      expect(comp._component.options[:sum_url]).to eq(dummy_sha1_url)
+      expect(comp._component.options[:sum_type]).to eq('sha1')
+    end
+    it "sets sha256 url and type correctly" do
+      comp = Vanagon::Component::DSL.new('test-fixture', {}, {})
+      comp.sum_url(dummy_sha256_url)
+
+      expect(comp._component.options[:sum_url]).to eq(dummy_sha256_url)
+      expect(comp._component.options[:sum_type]).to eq('sha256')
+    end
+    it "sets sha512 url and type correctly" do
+      comp = Vanagon::Component::DSL.new('test-fixture', {}, {})
+      comp.sum_url(dummy_sha512_url)
+
+      expect(comp._component.options[:sum_url]).to eq(dummy_sha512_url)
+      expect(comp._component.options[:sum_type]).to eq('sha512')
+    end
   end
 
   describe "#md5sum" do

--- a/spec/lib/vanagon/component/source/http_spec.rb
+++ b/spec/lib/vanagon/component/source/http_spec.rb
@@ -19,6 +19,10 @@ describe "Vanagon::Component::Source::Http" do
       expect { Vanagon::Component::Source::Http.new(plaintext_url, sum: md5sum, workdir: workdir, sum_type: "md4") }
         .to raise_error(RuntimeError)
     end
+    it "fails if neither sum nor sum_url are passed" do
+      expect { Vanagon::Component::Source::Http.new(plaintext_url, workdir: workdir, sum_type: "md5") }
+        .to raise_error(RuntimeError)
+    end
   end
 
   describe "#dirname" do


### PR DESCRIPTION
This adds the ability to set the sum_url for a component instead of
setting the sum directly.