### PR TITLE
(VANAGON-111) enable consumption of remote checksums

### DIFF
--- a/lib/vanagon/component/source/http.rb
+++ b/lib/vanagon/component/source/http.rb
@@ -48,7 +48,7 @@ class Vanagon
         # @param workdir [String] working directory to download into
         # @param sum_type [String] type of sum we are verifying
         # @raise [RuntimeError] an exception is raised is sum is nil
-        def initialize(url, sum:, workdir:, sum_type:, **options)
+        def initialize(url, sum:, workdir:, sum_type:, **options) # rubocop:disable Metrics/AbcSize
           unless sum
             fail "sum is required to validate the http source"
           end
@@ -70,7 +70,11 @@ class Vanagon
               # the sha1 files generated during archive creation  are formatted
               # "<sha1sum> <filename>". This will also work for sources that
               # only contain the checksum.
-              @sum = file.read.split.first
+              remote_sum = file.read.split.first
+              unless remote_sum
+                fail "Downloaded checksum file seems to be empty, make sure you have the correct URL"
+              end
+              @sum = remote_sum
             end
           end
         end

--- a/lib/vanagon/component/source/http.rb
+++ b/lib/vanagon/component/source/http.rb
@@ -43,7 +43,8 @@ class Vanagon
         # Constructor for the Http source type
         #
         # @param url [String] url of the http source to fetch
-        # @param sum [String] sum to verify the download against
+        # @param sum [String] sum to verify the download against or URL to fetch
+        #                     sum from
         # @param workdir [String] working directory to download into
         # @param sum_type [String] type of sum we are verifying
         # @raise [RuntimeError] an exception is raised is sum is nil
@@ -62,6 +63,16 @@ class Vanagon
           @sum = sum
           @workdir = workdir
           @sum_type = sum_type
+
+          if Vanagon::Component::Source::Http.valid_url?(@sum)
+            sum_file = download(@sum)
+            File.open(File.join(@workdir, sum_file)) do |file|
+              # the sha1 files generated during archive creation  are formatted
+              # "<sha1sum> <filename>". This will also work for sources that
+              # only contain the checksum.
+              @sum = file.read.split.first
+            end
+          end
         end
 
         # Download the source from the url specified. Sets the full path to the

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -65,6 +65,10 @@ end" }
   let(:dummy_sha1_sum) { "fdaa03c3f506d7b71635f2c32dfd41b0cc8b904f" }
   let(:dummy_sha256_sum) { "fd9c922702eb2e2fb26376c959753f0fc167bb6bc99c79262fcff7bcc8b34be1" }
   let(:dummy_sha512_sum) { "8feda1e9896be618dd6c65120d10afafce93888df8569c598f52285083c23befd1477da5741939d4eae042f822e45ca2e45d8d4d18cf9224b7acaf71d883841e" }
+  let(:dummy_md5_url) { "http://example.com/example.tar.gz.md5" }
+  let(:dummy_sha1_url) { "http://example.com/example.tar.gz.sha1" }
+  let(:dummy_sha256_url) { "http://example.com/example.tar.gz.sha256" }
+  let(:dummy_sha512_url) { "http://example.com/example.tar.gz.sha512" }
 
   before do
     allow(platform).to receive(:install).and_return('install')
@@ -80,6 +84,13 @@ end" }
       expect(comp._component.options[:sum]).to eq(dummy_md5_sum)
       expect(comp._component.options[:sum_type]).to eq('md5')
     end
+    it "sets md5 url and type correctly" do
+      comp = Vanagon::Component::DSL.new('test-fixture', {}, {})
+      comp.md5sum(dummy_md5_url)
+
+      expect(comp._component.options[:sum]).to eq(dummy_md5_url)
+      expect(comp._component.options[:sum_type]).to eq('md5')
+    end
   end
 
   describe "#sha1sum" do
@@ -88,6 +99,13 @@ end" }
       comp.sha1sum(dummy_sha1_sum)
 
       expect(comp._component.options[:sum]).to eq(dummy_sha1_sum)
+      expect(comp._component.options[:sum_type]).to eq('sha1')
+    end
+    it "sets sha1 url and type correctly" do
+      comp = Vanagon::Component::DSL.new('test-fixture', {}, {})
+      comp.sha1sum(dummy_sha1_url)
+
+      expect(comp._component.options[:sum]).to eq(dummy_sha1_url)
       expect(comp._component.options[:sum_type]).to eq('sha1')
     end
   end
@@ -100,6 +118,13 @@ end" }
       expect(comp._component.options[:sum]).to eq(dummy_sha256_sum)
       expect(comp._component.options[:sum_type]).to eq('sha256')
     end
+    it "sets sha256 url and type correctly" do
+      comp = Vanagon::Component::DSL.new('test-fixture', {}, {})
+      comp.sha256sum(dummy_sha256_url)
+
+      expect(comp._component.options[:sum]).to eq(dummy_sha256_url)
+      expect(comp._component.options[:sum_type]).to eq('sha256')
+    end
   end
 
   describe "#sha512sum" do
@@ -108,6 +133,13 @@ end" }
       comp.sha512sum(dummy_sha512_sum)
 
       expect(comp._component.options[:sum]).to eq(dummy_sha512_sum)
+      expect(comp._component.options[:sum_type]).to eq('sha512')
+    end
+    it "sets sha512 url and type correctly" do
+      comp = Vanagon::Component::DSL.new('test-fixture', {}, {})
+      comp.sha512sum(dummy_sha512_url)
+
+      expect(comp._component.options[:sum]).to eq(dummy_sha512_url)
       expect(comp._component.options[:sum_type]).to eq('sha512')
     end
   end

--- a/spec/lib/vanagon/component/source_spec.rb
+++ b/spec/lib/vanagon/component/source_spec.rb
@@ -70,21 +70,26 @@ describe "Vanagon::Component::Source" do
 
     context "takes a HTTP/HTTPS file" do
       before do
-        allow_any_instance_of(Vanagon::Component::Source::Http)
-          .to receive(:valid_url?)
-          .and_return(true)
-
         allow(Vanagon::Component::Source::Http)
           .to receive(:valid_url?)
-          .and_return(true)
+          .with(sum)
+          .and_return(false)
       end
 
       it "returns an object of the correct type for http:// URLS" do
+        allow(Vanagon::Component::Source::Http)
+          .to receive(:valid_url?)
+          .with(http_url)
+          .and_return(true)
         expect(klass.source(http_url, sum: sum, workdir: workdir, sum_type: "md5").class)
           .to equal(Vanagon::Component::Source::Http)
       end
 
       it "returns an object of the correct type for https:// URLS" do
+        allow(Vanagon::Component::Source::Http)
+          .to receive(:valid_url?)
+          .with(https_url)
+          .and_return(true)
         expect(klass.source(https_url, sum: sum, workdir: workdir, sum_type: "md5").class)
           .to equal(Vanagon::Component::Source::Http)
       end


### PR DESCRIPTION
This adds the ability to set the `sum` for a component to the url of a
file containing the checksum rather than the actual checksum.