### PR TITLE
(maint) Add nspooler support in vanagon for checking out from nspooler

### DIFF
--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -52,6 +52,7 @@ class Vanagon
     def http_request(url, type, payload = {}.to_json, header = nil) # rubocop:disable Metrics/AbcSize
       uri = URI.parse(url)
       http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true if uri.scheme == 'https'
 
       case type.downcase
       when "get"


### PR DESCRIPTION
This commit adds the ability to pull hosts from the nspooler as well as the
vmpooler. The way this works is simple: the pooler engine now checks both the
vmpooler and nspooler for hosts, and if the response is 'ok'='false' vanagon
just moves on to try the second pooler