### PR TITLE
(maint) Explicitly rescue LoadError while shipping to artifactory

### DIFF
--- a/bin/ship
+++ b/bin/ship
@@ -14,7 +14,7 @@ else
   Pkg::Util::RakeUtils.invoke_task('pl:jenkins:ship', 'artifacts', 'output')
   begin
     Pkg::Util::RakeUtils.invoke_task('pl:jenkins:ship_to_artifactory', 'output')
-  rescue
+  rescue LoadError
     warn <<-DOC
   Unable to ship packages to artifactory. Please make sure you are pointing to a
   recent version of packaging in your Gemfile. Please also make sure you include


### PR DESCRIPTION
A generic `rescue` statement does not catch LoadErrors which causes this
to fail loudly with a stack trace if you don't have artifactory.