### PR TITLE
(VANAGON-69) Add the ability to specify sed for platform

### DIFF
--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -35,6 +35,7 @@ class Vanagon
     attr_accessor :make
     attr_accessor :patch
     attr_accessor :rpmbuild # This is RedHat/EL/Fedora/SLES specific
+    attr_accessor :sed
     attr_accessor :sort
     attr_accessor :tar
     attr_accessor :shasum
@@ -214,6 +215,7 @@ class Vanagon
       @install ||= "install"
       @target_user ||= "root"
       @find ||= "find"
+      @sed ||= "sed"
       @sort ||= "sort"
       @copy ||= "cp"
       @shasum ||= "sha1sum"

--- a/lib/vanagon/platform/deb.rb
+++ b/lib/vanagon/platform/deb.rb
@@ -19,7 +19,7 @@ class Vanagon
         "cat file-list >> debian/install",
         "cp -pr debian $(tempdir)/#{project.name}-#{project.version}",
         "gunzip -c #{project.name}-#{project.version}.tar.gz | '#{@tar}' -C '$(tempdir)/#{project.name}-#{project.version}' --strip-components 1 -xf -",
-        "sed -i 's/\ /?/g' $(tempdir)/#{project.name}-#{project.version}/debian/install",
+        "#{sed} -i 's/\ /?/g' $(tempdir)/#{project.name}-#{project.version}/debian/install",
         "(cd $(tempdir)/#{project.name}-#{project.version}; debuild --no-lintian #{pkg_arch_opt} -uc -us)",
         "cp $(tempdir)/#{copy_extensions} ./output/#{target_dir}"]
       end

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -129,6 +129,13 @@ class Vanagon
         @platform.find = find_cmd
       end
 
+      # Set the path to sed for the platform
+      #
+      # @param command [String] full path to the sed command for the platform
+      def sed(command)
+        @platform.sed = command
+      end
+
       # Set the path to sort for the platform
       #
       # @param sort_cmd [String] Full path to the sort command for the platform

--- a/lib/vanagon/platform/rpm/aix.rb
+++ b/lib/vanagon/platform/rpm/aix.rb
@@ -17,6 +17,7 @@ class Vanagon
           @make = "/usr/bin/gmake"
           @tar = "/opt/freeware/bin/tar"
           @patch = "/opt/freeware/bin/patch"
+          @sed = "/opt/freeware/bin/sed"
           @shasum = "/opt/freeware/bin/sha1sum"
           @num_cores = "lsdev -Cc processor |wc -l"
           @install = "/opt/freeware/bin/install"

--- a/lib/vanagon/platform/solaris_10.rb
+++ b/lib/vanagon/platform/solaris_10.rb
@@ -62,7 +62,7 @@ class Vanagon
             $$1 ~ /^d$$/ && (#{explicit_search_string}) {print "d",$$2,$$3,"0755 root sys";} \
             $$1 ~ /^s$$/ {print;} \
             $$1 ~ /^f$$/ {print "f",$$2,$$3,$$4,"root sys";} \
-            $$1 !~ /^[dfs]$$/ {print;} ' | /opt/csw/bin/gsed \
+            $$1 !~ /^[dfs]$$/ {print;} ' | #{sed} \
                -e '/^[fd] [^ ]\\+ .*[/]s\\?bin[^ ]\\+/ {s/root sys$$/root bin/}' \
                -e '/^[fd] [^ ]\\+ .*[/]lib[/][^ ]\\+/ {s/root sys$$/root bin/}' \
                -e '/^[fd] [^ ]\\+ .*[/][^ ]\\+[.]so/ {s/root sys$$/root bin/}' >> ../packaging/proto)),
@@ -185,6 +185,7 @@ class Vanagon
         @make = "/opt/csw/bin/gmake"
         @tar = "/usr/sfw/bin/gtar"
         @patch = "/usr/bin/gpatch"
+        @sed = "/opt/csw/bin/gsed"
         @shasum = "/opt/csw/bin/shasum"
         # solaris 10
         @num_cores = "/usr/bin/kstat cpu_info | awk '{print $$1}' | grep '^core_id$$' | wc -l"

--- a/resources/Makefile.erb
+++ b/resources/Makefile.erb
@@ -31,7 +31,7 @@ file-list-after-build: <%= @components.map {|comp| comp.name }.join(" ") %>
 
 file-list: file-list-before-build <%= @name %>-project
 	comm -23 file-list-after-build file-list-before-build > file-list
-	comm -23 file-list-after-build file-list-before-build | sed -e 's/\(^.*[[:space:]].*$$\)/"\1"/g' > file-list-for-rpm
+	comm -23 file-list-after-build file-list-before-build | <%= @platform.sed %> -e 's/\(^.*[[:space:]].*$$\)/"\1"/g' > file-list-for-rpm
 
 <%- if @version_file -%>
 <%= @version_file.path %>:

--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -17,12 +17,12 @@
 <%- end -%>
 
 # Turn off the brp-python-bytecompile script
-%global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
+%global __os_install_post %(echo '%{__os_install_post}' | <%= @platform.sed %> -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
 <% if @platform.is_cross_compiled_linux? -%>
 # Disable brp-strip-static-archive, which on EL platforms causes
 # cross-compiled static libs to end up with "no machine" as their
 # architure, breaking builds:
-%global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-strip-static-archive[[:space:]].*$!!g')
+%global __os_install_post %(echo '%{__os_install_post}' | <%= @platform.sed %> -e 's!/usr/lib[^[:space:]]*/brp-strip-static-archive[[:space:]].*$!!g')
 <% end -%>
 
 <% @package_overrides.each do |var| %>
@@ -136,7 +136,7 @@ install -d %{buildroot}
   # automatically does this implicitly, but RPMv5 is more strict and you
   # need to list the dirs for them to be packaged properly.
   <%- get_directories.map {|d| "%{buildroot}#{d.path}"}.each do |dir| -%>
-    find <%= dir %> -type d | sed -e "s#%{buildroot}##" | sed -e 's/\(^.*\s.*$\)/"\1"/g' >> dir-list-rpm
+    find <%= dir %> -type d | <%= @platform.sed %> -e "s#%{buildroot}##" | <%= @platform.sed %> -e 's/\(^.*\s.*$\)/"\1"/g' >> dir-list-rpm
   <%- end -%>
   cat dir-list-rpm | sort | uniq >> %{SOURCE1}
 <%- end -%>
@@ -145,13 +145,13 @@ install -d %{buildroot}
 # %files section separately because rpm3 on aix errors on duplicate files in
 # the package.
 <%- (get_directories + get_files + get_configfiles).map do |filething| -%>
-  PATH=/opt/freeware/bin:$PATH sed -i 's|^<%= filething.path.include?(" ") ? %Q["#{filething.path}"] : filething.path %>$||g' %{SOURCE1}
+  PATH=/opt/freeware/bin:$PATH <%= @platform.sed %> -i 's|^<%= filething.path.include?(" ") ? %Q["#{filething.path}"] : filething.path %>$||g' %{SOURCE1}
 <%- end -%>
 
 # Here we turn all dirs in the file-list into %dir entries to avoid duplicate files
 while read entry; do
   if [ -n "$entry" -a -d "$entry" -a ! -L "$entry" ]; then
-    PATH=/opt/freeware/bin:$PATH sed -i "s|^\($entry\)\$|%dir \1|g" %{SOURCE1}
+    PATH=/opt/freeware/bin:$PATH <%= @platform.sed %> -i "s|^\($entry\)\$|%dir \1|g" %{SOURCE1}
   fi
 done < %{SOURCE1}
 

--- a/spec/lib/vanagon/platform/rpm/aix_spec.rb
+++ b/spec/lib/vanagon/platform/rpm/aix_spec.rb
@@ -20,7 +20,7 @@ describe "Vanagon::Platform::RPM::AIX" do
 
   describe "aix puts commands in weird places" do
     it "uses /opt/freeware/bin everwhere" do
-      ['tar', 'patch', 'install'].each do |cmd|
+      ['tar', 'patch', 'install', 'sed'].each do |cmd|
         expect(plat._platform.send(cmd.to_sym)).to eq(File.join('/opt/freeware/bin', cmd))
       end
     end

--- a/spec/lib/vanagon/platform/solaris_10_spec.rb
+++ b/spec/lib/vanagon/platform/solaris_10_spec.rb
@@ -1,0 +1,29 @@
+require 'vanagon/platform'
+
+describe "Vanagon::Platform::Solaris10" do
+  let(:block) {
+    %Q[ platform "solaris-10-i386" do |plat|
+    end
+    ]
+  }
+  let(:plat) { Vanagon::Platform::DSL.new('solaris-10-i386') }
+
+  before do
+    plat.instance_eval(block)
+  end
+
+  describe "solaris10 has weird paths for gnu commands" do
+    it "has some in /opt/csw/bin" do
+      ['make', 'sed'].each do |cmd|
+        expect(plat._platform.send(cmd.to_sym)).to eq(File.join('/opt/csw/bin', "g#{cmd}"))
+      end
+    end
+    it "uses /usr/sfw/bin/gtar" do
+      expect(plat._platform.send(:tar)).to eq('/usr/sfw/bin/gtar')
+    end
+    it "uses /usr/bin/gpatch" do
+      expect(plat._platform.send(:patch)).to eq('/usr/bin/gpatch')
+    end
+  end
+end
+


### PR DESCRIPTION
We use some functionality only present in GNU sed. Previously the paths
were just hard-coded in relevant places, but this adds the ability to
specify the location for GNU sed for a platform.