### PR TITLE
(VANAGON-108) Allow for customizable mktemp

### DIFF
--- a/lib/vanagon/engine/base.rb
+++ b/lib/vanagon/engine/base.rb
@@ -63,7 +63,7 @@ class Vanagon
             dispatch("mkdir -p #{@remote_workdir_path}", true)
             @remote_workdir = @remote_workdir_path
           else
-            @remote_workdir = dispatch("mktemp -d -p /var/tmp 2>/dev/null || mktemp -d -t 'tmp'", true)
+            @remote_workdir = dispatch("#{@platform.mktemp} 2>/dev/null", true)
           end
         end
         @remote_workdir

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -43,6 +43,7 @@ class Vanagon
     attr_accessor :find
     attr_accessor :install
     attr_accessor :make
+    attr_accessor :mktemp
     attr_accessor :patch
     attr_accessor :rpmbuild # This is RedHat/EL/Fedora/SLES specific
     attr_accessor :sort
@@ -222,6 +223,7 @@ class Vanagon
       @environment = Vanagon::Environment.new
       @provisioning = []
       @install ||= "install"
+      @mktemp ||= "mktemp -d -p /var/tmp"
       @target_user ||= "root"
       @find ||= "find"
       @sort ||= "sort"

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -170,6 +170,13 @@ class Vanagon
         @platform.install = install_cmd
       end
 
+      # Set the path and options for the mktemp command
+      # @param command [String] Full path (if needed) for the mktemp command with arguments to
+      # be used by default
+      def mktemp(command)
+        @platform.mktemp = command
+      end
+
       # Set the path to patch for the platform
       #
       # @param patch_cmd [String] Full path to the patch command for the platform

--- a/lib/vanagon/platform/osx.rb
+++ b/lib/vanagon/platform/osx.rb
@@ -107,6 +107,7 @@ class Vanagon
         @hdiutil = "/usr/bin/hdiutil"
         @patch = "/usr/bin/patch"
         @num_cores = "/usr/sbin/sysctl -n hw.physicalcpu"
+        @mktemp = "mktemp -d -t 'tmp'"
         super(name)
       end
     end

--- a/lib/vanagon/platform/rpm/wrl.rb
+++ b/lib/vanagon/platform/rpm/wrl.rb
@@ -18,7 +18,7 @@ class Vanagon
         def install_build_dependencies(build_dependencies)
           commands = []
           unless build_dependencies.empty?
-            commands << "tmpdir=$(mktemp -p /var/tmp -d)"
+            commands << "tmpdir=$(#{mktemp})"
             commands << "cd ${tmpdir}"
             build_dependencies.each do |build_dependency|
               if build_dependency =~ /^http.*\.rpm$/

--- a/lib/vanagon/platform/solaris_10.rb
+++ b/lib/vanagon/platform/solaris_10.rb
@@ -156,7 +156,7 @@ class Vanagon
           if build_dependency =~ /^http.*\.gz/
             # Fetch, unpack, install...this assumes curl is present.
             package = build_dependency.sub(/^http.*\//, '')
-            http << "tmpdir=$(mktemp -p /var/tmp -d); (cd ${tmpdir} && curl -O #{build_dependency} && gunzip -c #{package} | pkgadd -d /dev/stdin -a /var/tmp/noask all)"
+            http << "tmpdir=$(#{mktemp}); (cd ${tmpdir} && curl -O #{build_dependency} && gunzip -c #{package} | pkgadd -d /dev/stdin -a /var/tmp/noask all)"
           else
             # Opencsw dependencies. At this point we assume that pkgutil is installed.
             pkgutil << build_dependency

--- a/resources/Makefile.erb
+++ b/resources/Makefile.erb
@@ -4,7 +4,7 @@ SHELL = <%=  @platform.shell %>
 export <%= var %>
 <%- end -%>
 
-tempdir := $(shell mktemp -d -p /var/tmp 2>/dev/null || mktemp -d -t 'tmp')
+tempdir := $(shell <%= @platform.mktemp %> 2>/dev/null)
 workdir := $(PWD)
 
 all: file-list-before-build <%= package_name %>

--- a/spec/lib/vanagon/platform/osx_spec.rb
+++ b/spec/lib/vanagon/platform/osx_spec.rb
@@ -1,0 +1,21 @@
+require 'vanagon/platform'
+
+describe "Vanagon::Platform::OSX" do
+  let(:block) {
+    %Q[ platform "osx-10.12-x86_64" do |plat|
+    end
+    ]
+  }
+  let(:plat) { Vanagon::Platform::DSL.new('osx-10.12-x86_64') }
+
+  before do
+    plat.instance_eval(block)
+  end
+
+  describe "osx has a different mktemp" do
+    it "uses the right mktemp options" do
+      expect(plat._platform.send(:mktemp)).to eq("mktemp -d -t 'tmp'")
+    end
+  end
+end
+


### PR DESCRIPTION
OSX doesn't support the mktemp flags we use on other platforms, so
specify the correct flags for OSX, and allow mktemp to be overwritten in
platform definitions.