### PR TITLE
(VANAGON-116) Retry source fetches individually

### DIFF
--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -162,12 +162,21 @@ class Vanagon
     # Collects all sources and patches into the provided workdir
     #
     # @param workdir [String] directory to stage sources into
-    def fetch_sources(workdir)
+    # @param retry_count [Integer] number of times to retry each fetch
+    # @param timeout [Integer] How long to wait (in seconds) for each
+    #   fetch before aborting
+    def fetch_sources(workdir, retry_count = 1, timeout = 7200)
       @components.each do |component|
-        component.get_source(workdir)
+        Vanagon::Utilities.retry_with_timeout(retry_count, timeout) do
+          component.get_source(workdir)
+        end
         # Fetch secondary sources
-        component.get_sources(workdir)
-        component.get_patches(workdir)
+        Vanagon::Utilities.retry_with_timeout(retry_count, timeout) do
+          component.get_sources(workdir)
+        end
+        Vanagon::Utilities.retry_with_timeout(retry_count, timeout) do
+          component.get_patches(workdir)
+        end
       end
     end
 

--- a/spec/lib/vanagon/driver_spec.rb
+++ b/spec/lib/vanagon/driver_spec.rb
@@ -3,7 +3,7 @@ require 'vanagon/project'
 require 'vanagon/platform'
 
 describe 'Vanagon::Driver' do
-  let (:project) { double(:project, :settings => {} ) }
+  let (:project) { double(:project, :settings => {}, :timeout => 9001, :retry_count => 42 ) }
 
   let (:redhat) do
     eval_platform('el-7-x86_64', <<-END)


### PR DESCRIPTION
Previously, Vanagon would retry fetching all sources as a single
block. This could confuse debugging of failed fetches, since it's
possible for a differnt source to fail in the retry than in the
original run. It also (paradoxically) increased the chances for an
overall job failure, since successful downloads were given another
change to break.

This change causes Vanagon to retry fetching each component
individually, giving each an opportunity to succeed, and making
debugging cleaner when fetches fail.

Since on most platforms build dependencies are install in a single
package manager transaction, that is still treated monolithically in
the driver.