### PR TITLE
(VANAGON-120) Run postinstall scripts in the postinstall phase

### DIFF
--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -218,6 +218,11 @@ fi
 if [ "$1" -eq 1 ] ; then
   <%= get_postinstall_actions("install") %>
 fi
+
+# Run postinstall scripts on upgrade if defined
+if [ "$1" -eq 2 ] ; then
+  <%= get_postinstall_actions("upgrade") %>
+fi
 <%- end -%>
 <%- get_services.each do |service| -%>
   # switch based on systemd vs systemv vs smf vs aix
@@ -272,10 +277,6 @@ fi
     if  [ "$1" -eq 0 ]; then
       /usr/bin/rmssys -s <%= service.name -%> > /dev/null 2>&1 || :
       /usr/sbin/rmitab <%= service.name -%> > /dev/null 2>&1 || :
-    fi
-    # Run postinstall scripts on upgrade if defined
-    if [ "$1" -eq 1 ] ; then
-      <%= get_postinstall_actions("upgrade") %>
     fi
   <%- end -%>
 <%- end -%>


### PR DESCRIPTION
Previously, Vanagon ran postinstall scripts for upgrades in the
postuninstall phase. This meant that any postinstall scripts would
always be sourced from the /previous/ version of a package,
which makes it rather difficult to fix bugs in the script or to
change the contract between a preinstall and postinstall phase.

This runs those scripts in the expected phase of the RPM
transaction.