### PR TITLE
 (VANAGON-125) Move AIX postinstall scripts to 'triggerpostun'

### DIFF
--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -194,6 +194,14 @@ if [ "$1" -gt 1 ] ; then
   <%= get_preinstall_actions("upgrade") %>
 fi
 
+<%- if @platform.is_aix? -%>
+    <%- get_services.each do |service| -%>
+        # Stop service on upgrade so that it can be restarted at the end
+        if [ "$1" -gt 1 ] ; then
+            /usr/bin/stopsrc -s <%= service.name -%> > /dev/null 2>&1 || :
+        fi
+    <%- end -%>
+<%- end -%>
 
 <%- get_all_trigger_pkgs.each do |pkg| %>
 
@@ -306,7 +314,10 @@ fi
       chkconfig --del <%= service.name %> || :
     fi
   <%- elsif @platform.servicetype == "aix" -%>
-      /usr/bin/stopsrc -s <%= service.name -%> > /dev/null 2>&1 || :
+      # stop the service only on a real uninstall, not on upgrades
+      if [ "$1" -eq 0 ] ; then
+          /usr/bin/stopsrc -s <%= service.name -%> > /dev/null 2>&1 || :
+      fi
   <%- end -%>
 <%- end -%>
 

--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -226,11 +226,6 @@ fi
 if [ "$1" -eq 1 ] ; then
   <%= get_postinstall_actions("install") %>
 fi
-
-# Run postinstall scripts on upgrade if defined
-if [ "$1" -eq 2 ] ; then
-  <%= get_postinstall_actions("upgrade") %>
-fi
 <%- end -%>
 <%- get_services.each do |service| -%>
   # switch based on systemd vs systemv vs smf vs aix
@@ -254,6 +249,19 @@ fi
     fi
     /usr/sbin/mkitab "<%= service.name -%>:2:once:/usr/bin/startsrc -s <%= service.name -%>" > /dev/null 2>&1 || :
   <%- end -%>
+<%- end -%>
+
+%triggerpostun -- <%= @name %>
+<%- if @platform.is_aix? || (@platform.is_el? && @platform.os_version.to_i == 4) -%>
+  # old versions of vanagon generated an unconditional service stop in
+  # the preun. This means that postinstall actions that mess with the
+  # service need to be run AFTER that step. To do so, we can run them
+  # in the "triggerpostun" when an upgrade is happening.
+
+  # Run postinstall scripts on upgrade if defined
+  if [ "$2" -gt 0 ] ; then
+    <%= get_postinstall_actions("upgrade") %>
+  fi
 <%- end -%>
 
 


### PR DESCRIPTION
In VANAGON-120, we moved postinstall upgrade scripts from the postun
step to the post step, so that they would always come from the new
version of the package, instead of the old. Unfortunately, vanagon
historically has had an unconditional service stop in the preun for
AIX. This meant that when upgrading from older packages, the services
we restart in post would be stopped again in preun.

We need to ensure we can still run the version of the script that
comes with the new package, but do so after the old package's
aggressive preun has run. To do that, the new package registers a
triggerpostun handler for its own name. This handler will be run from
the new package near the end of the transaction - after the old
package's preun and postun scripts.