### PR TITLE
(RE-10422) Make separate signing step before shipping to builds

### DIFF
--- a/bin/sign
+++ b/bin/sign
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+ENV["PROJECT_ROOT"] = Dir.pwd
+
+# Begin warning: This sign script is an internal tool.
+# This is not intended to function outside of Puppet Labs' infrastructure.
+# End of warning.
+
+if Dir["output/**/*"].select { |entry| File.file?(entry) }.empty?
+  fail "No packages to sign in the output directory. Maybe you want to build some first?"
+end
+
+require 'packaging'
+Pkg::Util::RakeUtils.load_packaging_tasks
+Pkg::Util::RakeUtils.invoke_task('pl:jenkins:sign_all', 'output')

--- a/vanagon.gemspec
+++ b/vanagon.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('packaging')
   gem.require_path = 'lib'
   gem.bindir       = 'bin'
-  gem.executables  = %w[build inspect ship render repo build_host_info]
+  gem.executables  = %w[build inspect ship render repo sign build_host_info]
 
   # Ensure the gem is built out of versioned files
   gem.files = Dir['{bin,lib,spec,resources}/**/*', 'README*', 'LICENSE*'] & %x(git ls-files -z).split("\0")


### PR DESCRIPTION
Before, we would build a package, ship it to builds, and if we wanted to sign
and ship it we did that as a collective step. Now, you can sign your package
before shipping anywhere, just run `bundle exec sign`

Before:
```
sara@sara:~/puppetlabs/pl-build-tools-vanagon/pkg$ rpm -qpi pl-rust-1.18.0-2.sles12.x86_64.rpm
Name        : pl-rust                      Relocations: (not relocatable)
Version     : 1.18.0                            Vendor: Puppet Labs
Release     : 2.sles12                      Build Date: Fri Mar 16 10:52:10 2018
Install Date: (not installed)            Build Host: u194ti5q5c11og7.delivery.puppetlabs.net
Group       : System Environment/Base       Source RPM: pl-rust-1.18.0-2.sles12.src.rpm
Size        : 331792277                        License: Apache 2.0 and MIT
Signature   : (none)
URL         : https://www.puppetlabs.com
Summary     : Puppet Labs Rust
Architecture: x86_64
Description :
Puppet Labs Rust
```

After running `bundle exec sign`
```
sara@sara:~/puppetlabs/pl-build-tools-vanagon/pkg$ rpm -qpi pl-rust-1.18.0-2.sles12.x86_64.rpm
warning: pl-rust-1.18.0-2.sles12.x86_64.rpm: NOKEY, key ID ef8d349f
Name        : pl-rust                      Relocations: (not relocatable)
Version     : 1.18.0                            Vendor: Puppet Labs
Release     : 2.sles12                      Build Date: Fri Mar 16 10:52:10 2018
Install Date: (not installed)            Build Host: u194ti5q5c11og7.delivery.puppetlabs.net
Group       : System Environment/Base       Source RPM: pl-rust-1.18.0-2.sles12.src.rpm
Size        : 331792277                        License: Apache 2.0 and MIT
Signature   : RSA/SHA512, Fri Mar 16 11:19:52 2018, Key ID 7f438280ef8d349f
URL         : https://www.puppetlabs.com
Summary     : Puppet Labs Rust
Architecture: x86_64
Description :
Puppet Labs Rust
```

Still need to test on different package types