### PR TITLE
(maint) Fixes for custom bill-of-materials paths

### DIFF
--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -525,7 +525,13 @@ class Vanagon
     #
     # @return [Array] all the files and directories that should be included in the tarball
     def get_tarball_files
-      files = ['file-list', 'bill-of-materials']
+      files = ['bill-of-materials']
+
+      if bill_of_materials
+        files = ["#{bill_of_materials.path}/bill-of-materials"]
+      end
+
+      files.push 'file-list'
       files.push get_files.map(&:path)
       files.push get_configfiles.map(&:path)
       if @platform.is_windows?


### PR DESCRIPTION
When using a custom project bill-of-materials path for precompiled archives, the bill-of-materials file was not correctly removed from the compiled archive, and thus conflicts with projects using the archive with the same custom bill-of-materials path.

The files added to the tarball should include the path to the bill-of-materials, not just the default bill-of-materials location.