### PR TITLE
(PA-1958) Add redhatfips as an RPM platform

### DIFF
--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -319,14 +319,14 @@ class Vanagon
     # @return [true, false] true if it is a redhat variety or uses rpm
     # under the hood, false otherwise
     def is_rpm?
-      return !!@name.match(/^(aix|cisco-wrlinux|el|eos|fedora|sles|redhat)-.*$/)
+      return !!@name.match(/^(aix|cisco-wrlinux|el|eos|fedora|sles|redhat|redhatfips)-.*$/)
     end
 
     # Utility matcher to determine is the platform is an enterprise linux variety
     #
     # @return [true, false] true if it is a enterprise linux variety, false otherwise
     def is_el?
-      return !!@name.match(/^(el|redhat)-.*$/)
+      return !!@name.match(/^(el|redhat|redhatfips)-.*$/)
     end
 
     # Utility matcher to determine is the platform is a sles variety

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -30,7 +30,7 @@ class Vanagon
         @platform = case platform_name
                     when /^aix-/
                       Vanagon::Platform::RPM::AIX.new(@name)
-                    when /^(cisco-wrlinux|el|fedora|redhat)-/
+                    when /^(cisco-wrlinux|el|fedora|redhat|redhatfips)-/
                       Vanagon::Platform::RPM.new(@name)
                     when /^sles-/
                       Vanagon::Platform::RPM::SLES.new(@name)


### PR DESCRIPTION
redhatfips is a platform based on redhat with FIPS features enabled. We
treat it as a separate platform due to its unique build requirements.