### PR TITLE
(maint) Pass the file list in before the bill of materials

### DIFF
--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -524,14 +524,17 @@ class Vanagon
     # for the project
     #
     # @return [Array] all the files and directories that should be included in the tarball
-    def get_tarball_files
-      files = ['bill-of-materials']
+    def get_tarball_files # rubocop:disable Metrics/AbcSize
+      # It is very important that 'file-list' remains the first element in this
+      # array, lest the tar command be malformed and the package creation fail
+      files = ['file-list']
 
       if bill_of_materials
-        files = ["#{bill_of_materials.path}/bill-of-materials"]
+        files.push "#{bill_of_materials.path}/bill-of-materials"
+      else
+        files.push 'bill-of-materials'
       end
 
-      files.push 'file-list'
       files.push get_files.map(&:path)
       files.push get_configfiles.map(&:path)
       if @platform.is_windows?


### PR DESCRIPTION
When creating the tar, the list of files will be passed in to a tar
command that looks like `'tar' -cf - -T <files>`. If the file-list is
not the first entry of that array, the tar command will be malformed and
will not include the correct files.