### PR TITLE
(PA-1991) Allow inheriting settings from a local project directory

### DIFF
--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -688,5 +688,19 @@ class Vanagon
         upstream_project.cleanup
       end
     end
+
+    # Load the settings hash from a local vanagon project.
+    # This will load the specified vanagon project (with no components) and
+    # merge its settings hash with local settings, overriding any duplicates at
+    # the time of calling. No attempt will be made to check out a specific
+    # version of the local repo; Settings will be used as they are.
+    def load_local_settings(local_project_name, local_project_path)
+      local_directory = File.expand_path(local_project_path)
+      # We don't want to load any of the upstream components, so we're going to
+      # pass an array with an empty string as the component list for load_project
+      no_components = ['']
+      local_project = Vanagon::Project.load_project(local_project_name, File.join(local_directory, ["configs", "projects"]), platform, no_components)
+      @settings.merge!(local_project.settings)
+    end
   end
 end

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -322,6 +322,14 @@ class Vanagon
         @project.load_upstream_settings(upstream_project_name, upstream_git_url, upstream_git_branch)
       end
 
+      # Inherit the settings hash from a locally cloned git repository
+      #
+      # @param local_project_name [String] The vanagon project to load settings from
+      # @param local_project_path [String] The path to the local project directory to load settings from
+      def inherit_local_settings(local_project_name, local_project_path)
+        @project.load_local_settings(local_project_name, local_project_path)
+      end
+
       # Set a package override. Will call the platform-specific implementation
       # This will get set in the spec file, deb rules, etc.
       #


### PR DESCRIPTION
Adds an `inherit_local_settings` function to the DSL that allows vanagon
projects to inherit settings from a vanagon project in a separate local
directory. Accepts a vanagon project name and a path to the project
directory. Does not offer the ability to specify a git revision - the files
are used as they are found.

This is intended to support https://github.com/puppetlabs/puppet-agent/pull/1414.