### PR TITLE
(maint) Optimise looped sed call

### DIFF
--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -161,7 +161,7 @@ install -d %{buildroot}
 # Here we turn all dirs in the file-list into %dir entries to avoid duplicate files
 while read entry; do
   if [ -n "$entry" -a -d "$entry" -a ! -L "$entry" ]; then
-    PATH=/opt/freeware/bin:$PATH <%= @platform.sed %> -i "s|^\($entry\)\$|%dir \1|g" %{SOURCE1}
+    <%= @platform.sed %> -i "\|^$entry\$|s|^|%dir |" %{SOURCE1}
   fi
 done < %{SOURCE1}
 


### PR DESCRIPTION
 * Removes redundant `PATH` modification (that directory is added to `PATH` earlier in the script and exported
 * sed command changed to search for lines matching the entry before applying the substitution (much faster than attempting the substitution globally)
 * sed substitution changed to not use a match group (prefixing a line can slightly more efficiently done by replacing the start of the line with the desired prefix).

These changes resulted in an average drop of just under 6 minutes in build time for the PDK RPMs on EL7. I extracted the resulting packages and confirmed that they all contained the same files.

This could probably be optimised further in the future by replacing the loop entirely with an awk script that looped through the file list and statted each entry to build the resulting file, but that is a more invasive change.