### PR TITLE
(VANAGON-131) Fix yaml load paths for load_yaml_settings

### DIFF
--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -747,7 +747,11 @@ class Vanagon
                                                    sum: settings_sha1_uri,
                                                    sum_type: 'sha1')
         source.fetch
-        @settings.merge!(YAML.safe_load(File.read(File.join(working_directory, source.file)), [Symbol]))
+        yaml_path = source.file
+        if source_type == :http
+          yaml_path = File.join(working_directory, source.file)
+        end
+        @settings.merge!(YAML.safe_load(File.read(yaml_path), [Symbol]))
       end
     end
   end


### PR DESCRIPTION
Paths were incorrectly determined when inheriting yaml settings from a
local file source.

I messed this up at some point while refactoring https://github.com/puppetlabs/vanagon/pull/566 -- I've tested these changes with local and http settings URLs in puppet-agent.