### PR TITLE
(VANAGON-136) Publish yaml settings during render

### DIFF
--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -144,7 +144,7 @@ class Vanagon
       @engine.ship_workdir(workdir)
       @engine.dispatch("(cd #{@engine.remote_workdir}; #{@platform.make} #{make_target})")
       @engine.retrieve_built_artifact(@project.artifacts_to_fetch, @project.no_packaging)
-      @project.publish_yaml_settings(@platform)
+      @project.publish_yaml_settings(workdir, @platform)
 
       if %i[never on-failure].include? @preserve
         @engine.teardown

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -173,6 +173,7 @@ class Vanagon
       warn "rendering Makefile"
       @project.fetch_sources(workdir, retry_count, timeout)
       @project.make_bill_of_materials(workdir)
+      @project.publish_yaml_settings(workdir, @project.platform)
       @project.generate_packaging_artifacts(workdir)
       @project.make_makefile(workdir)
     end

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -674,13 +674,14 @@ class Vanagon
     # provided (and a corresponding sha1sum file) if `yaml_settings` has been
     # set in the project definition.
     #
-    # @param [Vanagon::Platform] the platform to publish settings for
-    def publish_yaml_settings(platform)
+    # @param workdir [String] directory to write the files to
+    # @param platform [Vanagon::Platform] the platform to publish settings for
+    def publish_yaml_settings(workdir, platform)
       return unless yaml_settings
       raise(Vanagon::Error, "You must specify a project version") unless version
 
       filename = "#{name}-#{version}.#{platform.name}.settings.yaml"
-      filepath = File.join('output', filename)
+      filepath = File.join(workdir, filename)
 
       File.open(filepath, 'w') do |f|
         f.write(@settings.to_yaml)

--- a/spec/lib/vanagon/project_spec.rb
+++ b/spec/lib/vanagon/project_spec.rb
@@ -381,6 +381,7 @@ describe 'Vanagon::Project' do
   describe '#publish_yaml_settings' do
     let(:platform_name) { 'aix-7.2-ppc' }
     let(:platform) { Vanagon::Platform.new(platform_name) }
+    let(:workdir) { '/path/to/workdir' }
 
     subject(:project) do
       project = Vanagon::Project.new('test-project', platform)
@@ -390,8 +391,8 @@ describe 'Vanagon::Project' do
       project
     end
 
-    let(:yaml_output_path) { "output/test-project-version.#{platform_name}.settings.yaml" }
-    let(:sha1_output_path) { "output/test-project-version.#{platform_name}.settings.yaml.sha1" }
+    let(:yaml_output_path) { "#{workdir}/test-project-version.#{platform_name}.settings.yaml" }
+    let(:sha1_output_path) { "#{workdir}/test-project-version.#{platform_name}.settings.yaml.sha1" }
 
     let(:yaml_file) { double('yaml_file') }
     let(:sha1_file) { double('sha1_file') }
@@ -401,24 +402,24 @@ describe 'Vanagon::Project' do
       expect(File).to receive(:open).with(sha1_output_path, "w").and_yield(sha1_file)
       expect(yaml_file).to receive(:write).with({key: 'value'}.to_yaml)
       expect(sha1_file).to receive(:write)
-      expect { project.publish_yaml_settings(platform) }.not_to raise_error
+      expect { project.publish_yaml_settings(workdir, platform) }.not_to raise_error
     end
 
     it 'does not write yaml settings or a sha1sum unless told to' do
       project.yaml_settings = false
       expect(File).not_to receive(:open)
-      expect { project.publish_yaml_settings(platform) }.not_to raise_error
+      expect { project.publish_yaml_settings(workdir, platform) }.not_to raise_error
     end
 
     it "fails if the output directory doesn't exist" do
       allow_any_instance_of(File).to receive(:open).with(yaml_output_path).and_raise(Errno::ENOENT)
       allow_any_instance_of(File).to receive(:open).with(sha1_output_path).and_raise(Errno::ENOENT)
-      expect { project.publish_yaml_settings(platform) }.to raise_error(Errno::ENOENT)
+      expect { project.publish_yaml_settings(workdir, platform) }.to raise_error(Errno::ENOENT)
     end
 
     it "fails unless the project has a version" do
       project.version = nil
-      expect { project.publish_yaml_settings(platform) }.to raise_error(Vanagon::Error)
+      expect { project.publish_yaml_settings(workdir, platform) }.to raise_error(Vanagon::Error)
     end
   end
 


### PR DESCRIPTION
Writes a yaml representation of project settings to the workdir during
`render` (in addition to during `build`) when `publish_yaml_settings`
has been called in the project configuration.

We're hoping to use this to easily determine (without building everything completely) which settings have been updated for project/platform combinations in puppet-runtime PRs. This also removes the hard-coded `output` destination, which should have been how this method worked originally.