### PR TITLE
Revert "Merge pull request #556 from underscorgan/tickets/master/vanagon-123-deb-no-systemd"

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -175,7 +175,6 @@ class Vanagon
       @preremove_actions = []
       @postremove_actions = []
       @install_only = false
-      @service = []
     end
 
     # Adds the given file to the list of files and returns @files.

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -163,40 +163,36 @@ class Vanagon
       #
       # @param service_file [String] path to the service file relative to the source
       # @param default_file [String] path to the default file relative to the source
-      # @param options optional extra parameters
-      #        service_name [String] name of the service
-      #        service_type [String] type of the service (network, application, system, etc)
-      #        link_target [String] executable service file should be linked to
-      def install_service(service_file, default_file = nil, service_name = @component.name, **options) # rubocop:disable Metrics/AbcSize
-        init_system = options[:init_system] || @component.platform.servicetype
-        servicedir = @component.platform.get_service_dir(init_system)
-
-        case init_system
+      # @param service_name [String] name of the service
+      # @param service_type [String] type of the service (network, application, system, etc)
+      # @param link_target [String] executable service file should be linked to
+      def install_service(service_file, default_file = nil, service_name = @component.name, service_type: nil, link_target: nil) # rubocop:disable Metrics/AbcSize
+        case @component.platform.servicetype
         when "sysv"
-          target_service_file = File.join(servicedir, service_name)
+          target_service_file = File.join(@component.platform.servicedir, service_name)
           target_default_file = File.join(@component.platform.defaultdir, service_name)
           target_mode = '0755'
           default_mode = '0644'
         when "systemd"
-          target_service_file = File.join(servicedir, "#{service_name}.service")
+          target_service_file = File.join(@component.platform.servicedir, "#{service_name}.service")
           target_default_file = File.join(@component.platform.defaultdir, service_name)
           target_mode = '0644'
           default_mode = '0644'
         when "launchd"
-          target_service_file = File.join(servicedir, "#{service_name}.plist")
+          target_service_file = File.join(@component.platform.servicedir, "#{service_name}.plist")
           target_mode = '0644'
           default_mode = '0644'
         when "smf"
-          target_service_file = File.join(servicedir, options[:service_type].to_s, "#{service_name}.xml")
+          target_service_file = File.join(@component.platform.servicedir, service_type.to_s, "#{service_name}.xml")
           target_default_file = File.join(@component.platform.defaultdir, service_name)
           target_mode = '0644'
           default_mode = '0755'
         when "aix"
-          @component.service << OpenStruct.new(:name => service_name, :service_command => File.read(service_file).chomp)
+          @component.service = OpenStruct.new(:name => service_name, :service_command => File.read(service_file).chomp)
           # Return here because there is no file to install, just a string read in
           return
         when "windows"
-          @component.service << OpenStruct.new(\
+          @component.service = OpenStruct.new(\
             :bindir_id => "#{service_name.gsub(/[^A-Za-z0-9]/, '').upcase}BINDIR", \
             :service_file => service_file, \
             :component_group_id => "#{service_name.gsub(/[^A-Za-z0-9]/, '')}Component"\
@@ -204,13 +200,13 @@ class Vanagon
           # return here as we are just collecting the name of the service file to put into the harvest filter list.
           return
         else
-          fail "Don't know how to install the #{init_system}. Please teach #install_service how to do this."
+          fail "Don't know how to install the #{@component.platform.servicetype}. Please teach #install_service how to do this."
         end
 
         # Install the service and default files
-        if options[:link_target]
-          install_file(service_file, options[:link_target], mode: target_mode)
-          link options[:link_target], target_service_file
+        if link_target
+          install_file(service_file, link_target, mode: target_mode)
+          link link_target, target_service_file
         else
           install_file(service_file, target_service_file, mode: target_mode)
         end
@@ -221,7 +217,7 @@ class Vanagon
         end
 
         # Register the service for use in packaging
-        @component.service << OpenStruct.new(:name => service_name, :service_file => target_service_file, :type => options[:service_type])
+        @component.service = OpenStruct.new(:name => service_name, :service_file => target_service_file, :type => service_type)
       end
 
       # Copies a file from source to target during the install phase of the component

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -32,9 +32,6 @@ class Vanagon
     # Where does a given platform expect to find init scripts/service files?
     # e.g. /etc/init.d, /usr/lib/systemd/system
     attr_accessor :servicedir
-    # Array of OpenStructs containing the servicetype and the corresponding
-    # servicedir
-    attr_accessor :servicetypes
     # Where does a given platform's init system expect to find
     # something resembling 'defaults' files. Most likely to apply
     # to Linux systems that use SysV-ish, upstart, or systemd init systems.
@@ -242,7 +239,6 @@ class Vanagon
       # Our first attempt at defining metadata about a platform
       @cross_compiled ||= false
       @valid_operators ||= ['<', '>', '<=', '>=', '=']
-      @servicetypes = []
     end
 
     def shell # rubocop:disable Lint/DuplicateMethods
@@ -533,34 +529,6 @@ class Vanagon
 
     def validate_operator(operator_string)
       valid_operators.include?(operator_string)
-    end
-
-    # Get all configured service types (added through plat.servicetype)
-    # @return array of service types, empty array if none have been configured
-    def get_service_types
-      if @servicetypes.any?
-        @servicetypes.flat_map(&:servicetype).compact
-      elsif @servicetype
-        [@servicetype]
-      else
-        []
-      end
-    end
-
-    # Get configured service dir (added through plat.servicedir, or plat.servicetype 'foo', servicedir: 'bar')
-    # @param servicetype the service type you want the service dir for (optional)
-    # @raises VanagonError if more than one service dir is found
-    def get_service_dir(servicetype = '')
-      if @servicetypes.empty?
-        return @servicedir
-      end
-      servicedir = @servicetypes.select { |s| s.servicetype.include?(servicetype) }.flat_map(&:servicedir).compact
-
-      if servicedir.size > 1
-        raise Vanagon::Error, "You can only have one service dir for each service type. Found '#{servicedir.join(',')}' for service type #{servicetype}"
-      end
-
-      servicedir.first
     end
   end
 end

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -9,7 +9,6 @@ require 'vanagon/platform/solaris_10'
 require 'vanagon/platform/solaris_11'
 require 'vanagon/platform/windows'
 require 'securerandom'
-require 'ostruct'
 require 'uri'
 
 class Vanagon
@@ -219,11 +218,6 @@ class Vanagon
       # @param dir [String] Directory where service files live on the platform
       def servicedir(dir)
         @platform.servicedir = dir
-
-        # Add to the servicetypes array if we haven't already
-        if @platform.servicetype && @platform.servicedir && @platform.servicetypes.select { |s| s.servicetype == @platform.servicetype }.empty?
-          @platform.servicetypes << OpenStruct.new(:servicetype => @platform.servicetype, :servicedir => @platform.servicedir)
-        end
       end
 
       # Set the directory where default or sysconfig files live for the platform
@@ -236,18 +230,8 @@ class Vanagon
       # Set the servicetype for the platform so that services can be installed correctly.
       #
       # @param type [String] service type for the platform ('sysv' for example)
-      # @param servicedir [String] service dir for this platform and service type ('/etc/init.d' for example). Optional.
-      def servicetype(type, servicedir: nil) # rubocop:disable Metrics/AbcSize
-        if servicedir
-          @platform.servicetypes << OpenStruct.new(:servicetype => type, :servicedir => servicedir)
-        else
-          @platform.servicetype = type
-        end
-
-        # Add to the servicetypes array if we haven't already
-        if @platform.servicetype && @platform.servicedir && @platform.servicetypes.select { |s| s.servicetype == @platform.servicetype }.empty?
-          @platform.servicetypes << OpenStruct.new(:servicetype => @platform.servicetype, :servicedir => @platform.servicedir)
-        end
+      def servicetype(type)
+        @platform.servicetype = type
       end
 
       # Set the list of possible host to perform a build on (when not using

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -293,14 +293,10 @@ class Vanagon
     # will return nil
     #
     # @param [string] name of service to grab
-    # @return [@component.service obj] specific service, or array of services
-    #         if there's more than one
+    # @return [@component.service obj] specific service
     def get_service(name)
       components.each do |component|
         if component.name == name
-          if component.service.size == 1
-            return component.service.first
-          end
           return component.service
         end
       end

--- a/resources/deb/postinst.erb
+++ b/resources/deb/postinst.erb
@@ -2,23 +2,18 @@
 <%- get_services.each do |service| -%>
   # switch based on systemd vs systemv
   #
-  <%- if service.init_system.nil? || service.init_system.eq?('systemd') -%>
-if [ -d '/run/systemd/system' ] ; then
-  if [ -z "$2" ]; then
-    systemctl enable <%= service.name %>.service >/dev/null || :
-  else
-    systemctl try-restart <%= service.name %>.service >/dev/null || :
-  fi
+  <%- if @platform.servicetype == "systemd" -%>
+if [ -z "$2" ]; then
+  systemctl enable <%= service.name %>.service >/dev/null || :
+else
+  systemctl try-restart <%= service.name %>.service >/dev/null || :
 fi
-  <%- end -%>
-  <%- if service.init_system.nil? || service.init_system.eq?('sysv') -%>
-if [ ! -d '/run/systemd/system' ] ; then
-  if [ -x "<%= service.service_file %>" ]; then
-    update-rc.d <%= service.name %> defaults > /dev/null
+  <%- elsif @platform.servicetype == "sysv" -%>
+if [ -x "<%= service.service_file %>" ]; then
+  update-rc.d <%= service.name %> defaults > /dev/null
 
-    if [ -n "$2" ]; then
-      invoke-rc.d <%= service.name %> condrestart || true
-    fi
+  if [ -n "$2" ]; then
+    invoke-rc.d <%= service.name %> condrestart || true
   fi
 fi
   <%- end -%>
@@ -32,17 +27,17 @@ fi
 
 # Set up any specific permissions needed...
 <%- (get_directories + get_configfiles + get_files).select { |pathname| pathname.has_overrides? }.uniq.each do |file_or_directory| -%>
-  <%= "chmod '#{file_or_directory.mode}' '#{file_or_directory.path}' &>/dev/null ||:" if file_or_directory.mode %>
+  <%= "chmod '#{file_or_directory.mode}' '#{file_or_directory.path}'" if file_or_directory.mode %>
   <%- if file_or_directory.owner -%>
     if getent passwd '<%= file_or_directory.owner %>' &> /dev/null; then
-      chown '<%= file_or_directory.owner %>' '<%= file_or_directory.path %>' &>/dev/null ||:
+      chown '<%= file_or_directory.owner %>' '<%= file_or_directory.path %>'
     else
       echo "Error updating '<%= file_or_directory.path %>': user '<%= file_or_directory.owner %>' does not exist."
     fi
   <%- end -%>
   <%- if file_or_directory.group -%>
     if getent group '<%= file_or_directory.group %>' &> /dev/null; then
-      chgrp '<%= file_or_directory.group %>' '<%= file_or_directory.path %>' &>/dev/null ||:
+      chgrp '<%= file_or_directory.group %>' '<%= file_or_directory.path %>'
     else
       echo "Error updating '<%= file_or_directory.path %>': group '<%= file_or_directory.group %>' does not exist."
     fi

--- a/resources/deb/postrm.erb
+++ b/resources/deb/postrm.erb
@@ -13,11 +13,11 @@ fi
 <%- get_services.each do |service| -%>
   # switch based on systemd vs systemv
   #
-if [ -d '/run/systemd/system' ] ; then
-  systemctl daemon-reload >/dev/null 2>&1 || :
-else
-  if [ "$1" = "purge" ] ; then
-    update-rc.d <%= service.name %> remove > /dev/null
-  fi
+  <%- if @platform.servicetype == "systemd" -%>
+systemctl daemon-reload >/dev/null 2>&1 || :
+  <%- elsif @platform.servicetype == "sysv" -%>
+if [ "$1" = "purge" ] ; then
+  update-rc.d <%= service.name %> remove > /dev/null
 fi
+  <%- end -%>
 <%- end -%>

--- a/resources/deb/prerm.erb
+++ b/resources/deb/prerm.erb
@@ -13,19 +13,15 @@ fi
 <%- get_services.each do |service| -%>
   # switch based on systemd vs systemv
   #
-  <%- if service.init_system.nil? || service.init_system.eq?('systemd') -%>
-if [ -d '/run/systemd/system' ] ; then
-  if [ "$1" = remove ]; then
-    systemctl --no-reload disable <%= service.name %>.service > /dev/null 2>&1 || :
-    systemctl stop <%= service.name %>.service > /dev/null 2>&1 || :
-  fi
+  <%- if @platform.servicetype == "systemd" -%>
+if [ "$1" = remove ]; then
+  systemctl --no-reload disable <%= service.name %>.service > /dev/null 2>&1 || :
+  systemctl stop <%= service.name %>.service > /dev/null 2>&1 || :
 fi
-  <%- end -%>
-  <%- if service.init_system.nil? || service.init_system.eq?('sysv') -%>
-if [ ! -d '/run/systemd/system' ] ; then
-  if [ -x "<%= service.service_file %>" ] && [ "$1" = remove ]; then
-    invoke-rc.d <%= service.name %> stop || true
-  fi
+
+  <%- elsif @platform.servicetype == "sysv" -%>
+if [ -x "<%= service.service_file %>" ] && [ "$1" = remove ]; then
+  invoke-rc.d <%= service.name %> stop || true
 fi
   <%- end -%>
 <%- end -%>

--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -76,7 +76,7 @@ Requires(post): /bin/touch
 <%- end -%>
 
 <%- if has_services? -%>
-  <%- if @platform.get_service_types.include?("systemd") -%>
+  <%- if @platform.servicetype == "systemd" -%>
     <%- if @platform.is_sles? -%>
 BuildRequires:    systemd
 %{?systemd_requires}
@@ -86,7 +86,7 @@ Requires(post):   systemd
 Requires(preun):  systemd
 Requires(postun): systemd
     <%- end -%>
-  <%- elsif @platform.get_service_types.include?("sysv") -%>
+  <%- elsif @platform.servicetype == "sysv" -%>
     <%- if @platform.is_sles? -%>
 Requires: aaa_base
     <%- elsif @platform.is_linux? -%>
@@ -230,15 +230,15 @@ fi
 <%- get_services.each do |service| -%>
   # switch based on systemd vs systemv vs smf vs aix
   #
-  <%- if @platform.get_service_types.include?("systemd") -%>
+  <%- if @platform.servicetype == "systemd" -%>
     <%- if @platform.is_sles? -%>
       %service_add_post <%= service.name %>.service
     <%- else -%>
       %systemd_post <%= service.name %>.service
     <%- end -%>
-  <%- elsif @platform.get_service_types.include?("sysv") -%>
+  <%- elsif @platform.servicetype == "sysv" -%>
     chkconfig --add <%= service.name %> >/dev/null 2>&1 || :
-  <%- elsif @platform.get_service_types.include?("aix") -%>
+  <%- elsif @platform.servicetype == "aix" -%>
     if /usr/bin/lssrc -s <%= service.name -%> > /dev/null 2>&1; then
       /usr/bin/chssys -s <%= service.name -%> -p <%= service.service_command -%> -w 7 -S -n 15 -f 9 > /dev/null 2>&1 || :
     else
@@ -279,17 +279,17 @@ fi
 <%- get_services.each do |service| -%>
   # switch based on systemd vs systemv vs smf vs aix
   #
-  <%- if @platform.get_service_types.include?("systemd") -%>
+  <%- if @platform.servicetype == "systemd" -%>
     <%- if @platform.is_sles? -%>
       %service_del_postun <%= service.name %>.service
     <%- else -%>
       %systemd_postun_with_restart <%= service.name %>.service
     <%- end -%>
-  <%- elsif @platform.get_service_types.include?("sysv") -%>
+  <%- elsif @platform.servicetype == "sysv" -%>
     if [ "$1" -eq 1 ]; then
       /sbin/service <%= service.name %> condrestart || :
     fi
-  <%- elsif @platform.get_service_types.include?("aix") -%>
+  <%- elsif @platform.servicetype == "aix" -%>
     if  [ "$1" -eq 0 ]; then
       /usr/bin/rmssys -s <%= service.name -%> > /dev/null 2>&1 || :
       /usr/sbin/rmitab <%= service.name -%> > /dev/null 2>&1 || :
@@ -310,18 +310,18 @@ if [ "$1" -eq 0 ] ; then
 fi
 
 <%- get_services.each do |service| -%>
-  <%- if @platform.get_service_types.include?("systemd") -%>
+  <%- if @platform.servicetype == "systemd" -%>
     <%- if @platform.is_sles? -%>
       %service_del_preun <%= service.name %>.service
     <%- else -%>
       %systemd_preun <%= service.name %>.service
     <%- end -%>
-  <%- elsif @platform.get_service_types.include?("sysv") -%>
+  <%- elsif @platform.servicetype == "sysv" -%>
     if [ "$1" -eq 0 ]; then
       /sbin/service <%= service.name %> stop >/dev/null 2>&1 || :
       chkconfig --del <%= service.name %> || :
     fi
-  <%- elsif @platform.get_service_types.include?("aix") -%>
+  <%- elsif @platform.servicetype == "aix" -%>
       # stop the service only on a real uninstall, not on upgrades
       if [ "$1" -eq 0 ] ; then
           /usr/bin/stopsrc -s <%= service.name -%> > /dev/null 2>&1 || :

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -33,16 +33,6 @@ end" }
     plat._platform
   }
 
-  let (:dummy_platform_sysv_or_systemd) {
-    plat = Vanagon::Platform::DSL.new('debian-8-x86_64')
-    plat.instance_eval("platform 'debian-8-x86_64' do |plat|
-                       plat.servicetype 'sysv', servicedir: '/etc/init.d'
-                       plat.servicetype 'systemd', servicedir: '/usr/lib/systemd/system'
-                       plat.defaultdir '/etc/default'
-                       end")
-    plat._platform
-  }
-
   let (:dummy_platform_smf) {
     plat = Vanagon::Platform::DSL.new('debian-11-i386')
     plat.instance_eval("platform 'debian-11-i386' do |plat|
@@ -577,15 +567,15 @@ end" }
       expect(comp._component.files).to include(Vanagon::Common::Pathname.file('/etc/init.d/service-test', mode: '0755'))
 
       # The component should now have a service registered
-      expect(comp._component.service.flat_map(&:name).compact).to include('service-test')
+      expect(comp._component.service.name).to eq('service-test')
     end
 
     it 'reads from a file when the OS is AIX for services' do
       comp = Vanagon::Component::DSL.new('service-test', {}, dummy_platform_aix)
       comp.install_service('spec/fixtures/component/mcollective.service', nil, 'mcollective')
-      expect(comp._component.service.flat_map(&:name).compact).to include('mcollective')
-      expect(comp._component.service.flat_map(&:service_command).compact.first).to include('/opt/puppetlabs/puppet/bin/ruby')
-      expect(comp._component.service.flat_map(&:service_command).compact.first).not_to include("\n")
+      expect(comp._component.service.name).to eq('mcollective')
+      expect(comp._component.service.service_command).to include('/opt/puppetlabs/puppet/bin/ruby')
+      expect(comp._component.service.service_command).not_to include("\n")
     end
 
     it 'adds the correct command to the install for the component for systemd platforms' do
@@ -604,34 +594,7 @@ end" }
       expect(comp._component.files).to include(Vanagon::Common::Pathname.file('/usr/lib/systemd/system/service-test.service', mode: '0644'))
 
       # The component should now have a service registered
-      expect(comp._component.service.flat_map(&:name).compact).to include('service-test')
-    end
-
-    it 'adds the correct command when installing both systemd and sysv' do
-      comp = Vanagon::Component::DSL.new('service-test', {}, dummy_platform_sysv_or_systemd)
-      comp.install_service('component-client.init', 'component-client.sysconfig', init_system: 'sysv')
-      comp.install_service('component-client.service', 'component-client.sysconfig', init_system: 'systemd')
-      # Look for servicedir creation and copy - sysv
-      expect(comp._component.install).to include("install -d '/etc/init.d'")
-      expect(comp._component.install).to include("cp -p 'component-client.init' '/etc/init.d/service-test'")
-
-      # Look for servicedir creation and copy - systemd
-      expect(comp._component.install).to include("install -d '/usr/lib/systemd/system'")
-      expect(comp._component.install).to include("cp -p 'component-client.service' '/usr/lib/systemd/system/service-test.service'")
-
-      # Look for defaultdir creation and copy
-      expect(comp._component.install).to include("install -d '/etc/default'")
-      expect(comp._component.install).to include("cp -p 'component-client.sysconfig' '/etc/default/service-test'")
-
-      # Look for files and configfiles - sysv
-      expect(comp._component.configfiles).to include(Vanagon::Common::Pathname.configfile('/etc/default/service-test'))
-      expect(comp._component.files).to include(Vanagon::Common::Pathname.file('/etc/init.d/service-test', mode: '0755'))
-
-      # Look for files and configfiles - systemd
-      expect(comp._component.files).to include(Vanagon::Common::Pathname.file('/usr/lib/systemd/system/service-test.service', mode: '0644'))
-
-      # The component should now have a service registered
-      expect(comp._component.service.flat_map(&:name).compact).to include('service-test')
+      expect(comp._component.service.name).to eq('service-test')
     end
 
     it 'adds the correct command to the install for smf services using a service_type' do
@@ -650,7 +613,7 @@ end" }
       expect(comp._component.files).to include(Vanagon::Common::Pathname.file('/var/svc/manifest/network/service-test.xml', mode: '0644'))
 
       # The component should now have a service registered
-      expect(comp._component.service.flat_map(&:name).compact).to include('service-test')
+      expect(comp._component.service.name).to eq('service-test')
     end
 
     it 'adds the correct command to the install for smf services' do
@@ -669,7 +632,7 @@ end" }
       expect(comp._component.files).to include(Vanagon::Common::Pathname.file('/var/svc/manifest/service-test.xml', mode: '0644'))
 
       # The component should now have a service registered
-      expect(comp._component.service.flat_map(&:name).compact).to include('service-test')
+      expect(comp._component.service.name).to eq('service-test')
     end
 
     it 'installs the file as a link when link_target is specified' do
@@ -690,7 +653,7 @@ end" }
       expect(comp._component.files).to include(Vanagon::Common::Pathname.file('/etc/init.d/service-test'))
 
       # The component should now have a service registered
-      expect(comp._component.service.flat_map(&:name).compact).to include('service-test')
+      expect(comp._component.service.name).to eq('service-test')
     end
   end
 

--- a/spec/lib/vanagon/platform_spec.rb
+++ b/spec/lib/vanagon/platform_spec.rb
@@ -1,33 +1,6 @@
 require 'vanagon/platform'
 
 describe "Vanagon::Platform" do
-  let(:deb_platform_just_servicedir) { "platform 'debian-test-fixture' do |plat|
-                                       plat.servicedir '/etc/init.d'
-                                       end
-                                       "}
-  let(:deb_platform_just_servicetype) { "platform 'debian-test-fixture' do |plat|
-                                       plat.servicetype 'sysv'
-                                       end
-                                       "}
-  let(:deb_platform_multi_servicetypes) { "platform 'debian-test-fixture' do |plat|
-                                       plat.servicetype 'sysv', servicedir: '/etc/init.d'
-                                       plat.servicetype 'systemd', servicedir: '/lib/systemd/system'
-                                       end
-                                       "}
-  let(:deb_platform_no_service) { "platform 'debian-test-fixture' do |plat|
-                                       end
-                                       "}
-  let(:deb_platform_servicetype) { "platform 'debian-test-fixture' do |plat|
-                                       plat.servicetype 'sysv'
-                                       plat.servicedir '/etc/init.d'
-                                       end
-                                       "}
-  let(:deb_platform_bad_servicedir_block) { "platform 'debian-test-fixture' do |plat|
-                                            plat.servicetype 'sysv', servicedir: '/etc/init.d'
-                                            plat.servicetype 'sysv', servicedir: '/etc/rc.d'
-                                            end
-                                            "}
-
   let(:platforms) do
     [
       {
@@ -197,59 +170,6 @@ describe "Vanagon::Platform" do
         cur_plat = Vanagon::Platform.new(plat[:name])
         expect(cur_plat.is_el?).to eq(plat[:is_el])
       end
-    end
-  end
-
-  describe "#get_service_type" do
-    it "returns plat.servicetype if that's the only thing set" do
-      plat = Vanagon::Platform::DSL.new('debian-8-x86_64')
-      plat.instance_eval(deb_platform_just_servicetype)
-      expect(plat._platform.get_service_types).to include('sysv')
-    end
-
-    it "returns from servicetypes if that's set" do
-      plat = Vanagon::Platform::DSL.new('debian-8-x86_64')
-      plat.instance_eval(deb_platform_servicetype)
-      expect(plat._platform.get_service_types).to include('sysv')
-    end
-
-    it "returns multiples if there's more than one" do
-      plat = Vanagon::Platform::DSL.new('debian-8-x86_64')
-      plat.instance_eval(deb_platform_multi_servicetypes)
-      expect(plat._platform.get_service_types).to include('sysv')
-      expect(plat._platform.get_service_types).to include('systemd')
-    end
-
-    it "returns an empty array if nothing is set" do
-      plat = Vanagon::Platform::DSL.new('debian-8-x86_64')
-      plat.instance_eval(deb_platform_no_service)
-      expect(plat._platform.get_service_types.size).to eq(0)
-    end
-  end
-
-  describe "#get_service_dir" do
-    it "returns plat.servicedir if that's the only thing set" do
-      plat = Vanagon::Platform::DSL.new('debian-8-x86_64')
-      plat.instance_eval(deb_platform_just_servicedir)
-      expect(plat._platform.get_service_dir).to eq('/etc/init.d')
-    end
-
-    it "returns servicedirs set via servicetype" do
-      plat = Vanagon::Platform::DSL.new('debian-8-x86_64')
-      plat.instance_eval(deb_platform_servicetype)
-      expect(plat._platform.get_service_dir).to eq('/etc/init.d')
-    end
-
-    it "returns the servicedir based on servicetype" do
-      plat = Vanagon::Platform::DSL.new('debian-8-x86_64')
-      plat.instance_eval(deb_platform_multi_servicetypes)
-      expect(plat._platform.get_service_dir('systemd')).to eq('/lib/systemd/system')
-    end
-
-    it "fails if there are >1 servicedir for a service type" do
-      plat = Vanagon::Platform::DSL.new('debian-8-x86_64')
-      plat.instance_eval(deb_platform_bad_servicedir_block)
-      expect { plat._platform.get_service_dir('sysv') }.to raise_error(Vanagon::Error)
     end
   end
 end


### PR DESCRIPTION
`/run/systemd/system` is not a reliable way to determine if systemd is
enabled on Debian systems, especially when using chroots or when using
a Debian preseed file.

This reverts commit 56bbacb18685d2b87398eab6d78718d9b4e36f5c, reversing
changes made to d71cdc5d6601dcdaa30d61d79d7682e2a79944ff.