### PR TITLE
(VANAGON-138) Verify yaml settings SHA

### DIFF
--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -743,6 +743,7 @@ class Vanagon
                                                    sum: settings_sha1_uri,
                                                    sum_type: 'sha1')
         source.fetch
+        source.verify
         yaml_path = source.file
         if source_type == :http
           yaml_path = File.join(working_directory, source.file)

--- a/spec/lib/vanagon/project_spec.rb
+++ b/spec/lib/vanagon/project_spec.rb
@@ -165,6 +165,7 @@ describe 'Vanagon::Project' do
       allow(Vanagon::Component::Source::Http).to receive(:valid_url?).with(http_yaml_uri).and_return(true)
       http_source = instance_double(Vanagon::Component::Source::Http)
       allow(Vanagon::Component::Source).to receive(:source).and_return(http_source)
+      allow(http_source).to receive(:verify).and_return(true)
 
       expect { project.load_yaml_settings(http_yaml_uri) }.to raise_error(Vanagon::Error)
     end
@@ -173,6 +174,7 @@ describe 'Vanagon::Project' do
       before(:each) do
         local_source = instance_double(Vanagon::Component::Source::Local)
         allow(local_source).to receive(:fetch)
+        allow(local_source).to receive(:verify).and_return(true)
         allow(local_source).to receive(:file).and_return(yaml_path)
 
         allow(Vanagon::Component::Source).to receive(:determine_source_type).and_return(:local)


### PR DESCRIPTION
When I wrote the yaml settings functionality, I made two mistakes:
- I didn't realize it was necessary to explicitly call `verify` to make use of an http source's sha1 file, and
- I didn't correctly collect the `system` output for the sha1 file

The net result was that we were getting sha1 files for settings.yaml that were empty, but not catching that. I've built some puppet-runtime projects using this branch [here](http://builds.puppetlabs.lan/puppet-runtime/8f9b7f88d2b6e877a9342c825dc1cdf9a50b1778/artifacts/), and sha1 files look  valid now.