### PR TITLE
(VANAGON-139) Update `retrieve_built_artifact` for the local engine

### DIFF
--- a/lib/vanagon/engine/local.rb
+++ b/lib/vanagon/engine/local.rb
@@ -40,9 +40,15 @@ class Vanagon
         FileUtils.cp_r(Dir.glob("#{workdir}/*"), @remote_workdir)
       end
 
-      def retrieve_built_artifact
-        FileUtils.mkdir_p("output")
-        FileUtils.cp_r(Dir.glob("#{@remote_workdir}/output/*"), "output/")
+      def retrieve_built_artifact(artifacts_to_fetch, no_packaging)
+        output_path = 'output/'
+        FileUtils.mkdir_p(output_path)
+        unless no_packaging
+          artifacts_to_fetch << "#{@remote_workdir}/output/*"
+        end
+        artifacts_to_fetch.each do |path|
+          FileUtils.cp_r(Dir.glob(path), "output/")
+        end
       end
     end
   end

--- a/spec/lib/vanagon/engine/local_spec.rb
+++ b/spec/lib/vanagon/engine/local_spec.rb
@@ -26,6 +26,24 @@ describe 'Vanagon::Engine::Local' do
     end
   end
 
+  describe '#retrieve_built_artifacts' do
+    it 'copies everything if we package' do
+      engine = Vanagon::Engine::Local.new(platform)
+      expect(FileUtils).to receive(:mkdir_p).with('output/').and_return true
+      expect(Dir).to receive(:glob).with('/output/*').and_return(['tmp/foo', 'tmp/bar'])
+      expect(FileUtils).to receive(:cp_r).with(['tmp/foo', 'tmp/bar'], 'output/')
+      engine.retrieve_built_artifact([], false)
+    end
+
+    it "only copies what you tell it to if we don't package" do
+      engine = Vanagon::Engine::Local.new(platform)
+      expect(FileUtils).to receive(:mkdir_p).with('output/').and_return true
+      expect(Dir).to receive(:glob).with('tmp/bar').and_return(['tmp/bar'])
+      expect(FileUtils).to receive(:cp_r).with(['tmp/bar'], 'output/')
+      engine.retrieve_built_artifact(['tmp/bar'], true)
+    end
+  end
+
   it 'returns "local" name' do
     expect(Vanagon::Engine::Local.new(platform).name).to eq('local')
   end


### PR DESCRIPTION
The method signature for `retrieve_built_artifact` changed in
https://github.com/puppetlabs/vanagon/commit/0d841370852b9d4666adc0a0d63ccebafa3f0d52,
but it was not updated for the local engine. This updates the local
engine to match the new method signature.