### PR TITLE
(maint) Disable choco download progress in example

### DIFF
--- a/examples/platforms/windows-platform.rb
+++ b/examples/platforms/windows-platform.rb
@@ -4,10 +4,10 @@ platform "windows-2012r2-x86" do |plat|
 
   # We use chocolatey by default to install build dependancies and provision things.
   # This can be overridden easily
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w64 -version 5.2.0 -debug"
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y Wix310 -version 3.10.2 -debug -x86"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w64 -version 5.2.0 -debug --no-progress"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y Wix310 -version 3.10.2 -debug -x86 --no-progress"
 
-  plat.install_build_dependencies_with "C:/ProgramData/chocolatey/bin/choco.exe install -y"
+  plat.install_build_dependencies_with "C:/ProgramData/chocolatey/bin/choco.exe install -y --no-progress"
 
   plat.make "/usr/bin/make"
   plat.patch "TMP=/var/tmp /usr/bin/patch.exe --binary"


### PR DESCRIPTION
 - Add the --no-progress switch in an effort to shrink the size of
   build logs. Choco describes the feature as:

   Do Not Show Progress - Do not show download progress percentages.

   Currently, build logs include extremely verbose output when choco
   packages are downloading, adding many lines per each 1% of a given
   package download. This commit removes that extraneous output.