### PR TITLE
(RE-11270) Create `ext` directory before writing build_metadata

### DIFF
--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -661,6 +661,7 @@ class Vanagon
     # @return [Hash] of build information
     def save_manifest_json
       manifest = build_manifest_json(true)
+      FileUtils.mkdir_p 'ext'
       File.open(File.join('ext', 'build_metadata.json'), 'w') do |f|
         f.write(manifest)
       end


### PR DESCRIPTION
As we move towards using the new metadata service, files that previously lived
in the `ext` directory may be removed, removing the whole directory as well.
This commit ensures that the `ext` directory is created before trying to write
a new file to it.