### PR TITLE
(maint) Add build_requirements command

### DIFF
--- a/bin/build_requirements
+++ b/bin/build_requirements
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+require 'json'
+require 'vanagon/extensions/ostruct/json'
+require 'vanagon/extensions/set/json'
+require 'vanagon/extensions/hashable'
+
+load File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "vanagon.rb"))
+
+optparse = Vanagon::OptParse.new("#{File.basename(__FILE__)} <project-name> <platform-name> [options]", %i[workdir configdir engine])
+options = optparse.parse! ARGV
+
+project = ARGV[0]
+platform = ARGV[1]
+
+unless project and platform
+  warn "project and platform are both required arguments."
+  warn optparse
+  exit 1
+end
+
+driver = Vanagon::Driver.new(platform, project)
+components = driver.project.components
+component_names = components.map(&:name)
+build_requirements = []
+components.each do |component|
+  build_requirements << component.build_requires.reject do |req|
+    # only include external requirements: i.e. those that do not match
+    # other components in the project
+    component_names.include?(req)
+  end
+end
+$stdout.puts
+$stdout.puts "**** External packages required to build #{project} on #{platform}: ***"
+$stdout.puts JSON.pretty_generate(build_requirements.flatten.uniq.sort)
+

--- a/vanagon.gemspec
+++ b/vanagon.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('packaging')
   gem.require_path = 'lib'
   gem.bindir       = 'bin'
-  gem.executables  = %w[build inspect ship render repo sign build_host_info]
+  gem.executables  = %w[build inspect ship render repo sign build_host_info build_requirements]
 
   # Ensure the gem is built out of versioned files
   gem.files = Dir['{bin,lib,spec,resources}/**/*', 'README*', 'LICENSE*'] & %x(git ls-files -z).split("\0")


### PR DESCRIPTION
Sometimes it's useful to list the external build requirements (those that
aren't other components) of a project. This commit adds the build_requirements
command to vanagon to list out a sorted array of those requirements