### PR TITLE
(VANAGON-141) Ensure git ref defaults to HEAD

### DIFF
--- a/lib/vanagon/component/source/git.rb
+++ b/lib/vanagon/component/source/git.rb
@@ -49,7 +49,7 @@ class Vanagon
         # @param ref [String] ref to checkout from git repo
         # @param workdir [String] working directory to clone into
         def initialize(url, workdir:, **options)
-          opts = default_options.merge(options)
+          opts = default_options.merge(options.reject { |k, v| v.nil? })
 
           # Ensure that #url returns a URI object
           @url = URI.parse(url.to_s)

--- a/spec/lib/vanagon/component/source/git_spec.rb
+++ b/spec/lib/vanagon/component/source/git_spec.rb
@@ -60,5 +60,11 @@ describe "Vanagon::Component::Source::Git" do
       expect(git_source.ref)
         .to eq('HEAD')
     end
+
+    it "returns a default value of HEAD when Git reference is nil" do
+      git_source = @klass.new(@url, ref: nil, workdir: @workdir)
+      expect(git_source.ref)
+        .to eq('HEAD')
+    end
   end
 end


### PR DESCRIPTION
Some code paths result in passing `ref: nil`, which was not treated the
same as not passing `ref`. Now it is.