### PR TITLE
(VANAGON-122) Add VANAGON_USE_MIRRORS env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,13 @@ when using the hardware engine. It defaults to *redis*, with no domain.
 ##### `LOCK_MANAGER_PORT`
 Port of the system where redis is running. Defaults to *6379*.
 
+##### `VANAGON_USE_MIRRORS`
+Controls whether component sources are downloaded directly from upstream URLs
+or from configured mirrors. Most Puppet projects using Vanagon default to
+fetching components from internal mirrors. Set this variable to `n` when
+building outside of the Puppet private network to download directly from
+upstream sources.
+
 ##### `VANAGON_RETRY_COUNT`
 Some phases of compilation support retries. The default value is *1* but
 setting to any integer value greater than 1 will causes these components

--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -284,7 +284,11 @@ class Vanagon
     def get_source(workdir) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
       opts = options.merge({ workdir: workdir })
       if url || !mirrors.empty?
-        fetch_mirrors(opts) || fetch_url(opts)
+        if ENV['VANAGON_USE_MIRRORS'] == 'n'
+          fetch_url(opts)
+        else
+          fetch_mirrors(opts) || fetch_url(opts)
+        end
         source.verify
         extract_with << source.extract(platform.tar) if source.respond_to? :extract
 

--- a/spec/lib/vanagon/component_spec.rb
+++ b/spec/lib/vanagon/component_spec.rb
@@ -95,6 +95,18 @@ describe "Vanagon::Component" do
       expect(subject).to receive(:fetch_url)
       subject.get_source(@workdir)
     end
+
+    it 'retrieves from a canonical URI if VANAGON_USE_MIRRORS is set to "n"' do
+      allow(ENV).to receive(:[]).with('VANAGON_USE_MIRRORS').and_return('n')
+      allow(subject)
+        .to receive(:fetch_url)
+        .and_return(true)
+
+      # We expect #get_source to skip mirrors
+      expect(subject).not_to receive(:fetch_mirrors)
+      expect(subject).to receive(:fetch_url)
+      subject.get_source(@workdir)
+    end
   end
 
   describe "#get_sources" do


### PR DESCRIPTION
This commit adds a VANAGON_USE_MIRRORS environment variable that can be used
to skip fetches from internal Puppet Inc. mirrors.