### PR TITLE
Solaris packages should not create content in system/volatile

### DIFF
--- a/resources/solaris/11/p5m.erb
+++ b/resources/solaris/11/p5m.erb
@@ -26,13 +26,6 @@ depend fmri=pkg:/<%= requirement %> type=require
 <transform dir path=usr$ -> drop>
 <transform dir path=var$ -> drop>
 
-# (CPR-251) In solaris 11, /var/run is a symlink to /system/volatile, which
-# causes conflicts during package installation. To avoid this, we transform any
-# directory under /var/run to repoint under /system/volatile and drop
-# /system/volatile itself to avoid conflicts.
-<transform dir -> edit path var/run system/volatile>
-<transform dir path=system/volatile$ -> drop>
-
 <%- get_root_directories.each do |dir| -%>
 <transform dir path=<%= strip_and_escape(dir.split('/')[0..-2].join('/')) %>$ -> drop>
 <%- end -%>


### PR DESCRIPTION
puppet-agent deployment fails on Solaris 11.4 with the following error:
```
root@rf8l60qft5p9c7f:~/mitza# pkg install puppet-agent@6.0.2.88.50778,5.11-1
Creating Plan (Merging actions): |
pkg install: The package pkg://puppetlabs.com/puppet-agent@6.0.2.88.50778,5.11-1:20181017T124140Z delivers items to reserved directories and can not be installed.
The following items are delivered to reserved directories:
      dir system/volatile/puppetlabs
```
This is because system/volatile is considered a "reserved" directory and no Solaris packages should deliver contents into it. 
If an application needs to have the PID file into this folder, it should handle this in its init script. Example:
- https://github.com/puppetlabs/puppet/pull/7176/files#diff-6a024706b7725919079035ac75eb7621R29
- https://github.com/oracle/solaris-userland/blob/master/components/openssh/sources/sshd.sh#L10
