### PR TITLE
(PA-1272) Refactor our use of homebrew to not run as root

### DIFF
--- a/lib/vanagon/platform/osx.rb
+++ b/lib/vanagon/platform/osx.rb
@@ -1,6 +1,19 @@
 class Vanagon
   class Platform
     class OSX < Vanagon::Platform
+      # Because homebrew does not support being run by root
+      # we need to have this method to run it in the context of another user
+      #
+      # @param build_dependencies [Array] list of all build dependencies to install
+      # @return [String] a command to install all of the build dependencies
+      def install_build_dependencies(list_build_dependencies)
+        <<-HERE.undent
+          mkdir -p /etc/homebrew
+          cd /etc/homebrew
+          su test -c '/usr/local/bin/brew install #{list_build_dependencies.join(' ')}'
+        HERE
+      end
+
       # The specific bits used to generate a osx package for a given project
       #
       # @param project [Vanagon::Project] project to build a osx package of


### PR DESCRIPTION
WIP: add specific command for installing build dependencies on osx
This is run if you do not call platform.install_build_dependencies_with
For now is used only by osx-10.12

Related PR's:
 https://github.com/puppetlabs/puppet-runtime/pull/113
 https://github.com/puppetlabs/puppet-agent/pull/1568