### PR TITLE
(VANAGON-146) Improve parsing of project vendor field

### DIFF
--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -6,6 +6,9 @@ require 'vanagon/utilities'
 require 'digest'
 require 'ostruct'
 
+# Used to parse the vendor field into name and email
+VENDOR_REGEX = /^(.*) <(.*)>$/
+
 class Vanagon
   class Project
     include Vanagon::Utilities
@@ -17,7 +20,7 @@ class Vanagon
     attr_accessor :release
     attr_accessor :license
     attr_accessor :homepage
-    attr_accessor :vendor
+    attr_reader :vendor
     attr_accessor :description
     attr_accessor :components
     attr_accessor :conflicts
@@ -175,6 +178,31 @@ class Vanagon
     #   @platform's Environment with the project's environment.
     def merged_environment
       environment.merge(@platform.environment)
+    end
+
+    # Setter for the vendor field.
+    #
+    # @param vend [String] name and email address of vendor
+    # @raise [Vanagon::Error] when `vend` does not include email address
+    def vendor=(vend)
+      raise Vanagon::Error, 'Project vendor field must include email address in angle brackets, e.g. "Puppet Inc. <release@puppet.com>"' unless vend.match(VENDOR_REGEX)
+      @vendor = vend
+    end
+
+    # Parses the vendor for the project by cutting off the email address
+    # field (e.g. `<email@example.com>`).
+    #
+    # @return [String] Vendor name without email address
+    def vendor_name_only
+      return @vendor.match(VENDOR_REGEX)[1]
+    end
+
+    # Parses the vendor for the project by taking only the email address field
+    # (e.g. `<email@example.com>`).
+    #
+    # @return [String] Vendor email address
+    def vendor_email_only
+      return @vendor.match(VENDOR_REGEX)[2]
     end
 
     # Collects all sources and patches into the provided workdir

--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -43,7 +43,7 @@ Name:           <%= @name %>
 Version:        <%= @version %>
 Release:        <%= @release %>%{?dist}
 Summary:        <%= @description.lines.first.chomp %>
-Vendor:         <%= @vendor.match(/^(.*) <.*>$/)[1] %>
+Vendor:         <%= vendor_name_only %>
 License:        <%= @license %>
 Group:          System Environment/Base
 URL:            <%= @homepage %>

--- a/resources/solaris/10/pkginfo.erb
+++ b/resources/solaris/10/pkginfo.erb
@@ -6,7 +6,7 @@ CLASSES=none
 CATEGORY=application
 VENDOR=<%= @vendor %>
 PSTAMP=<%= Time.now.strftime('%Y-%m-%d.%H%M%S') %>
-EMAIL=<%= @vendor.match(/<([^>]*)>/)[1] %>
+EMAIL=<%= vendor_email_only %>
 ISTATES=S s 1 2 3
 RSTATES=S s 1 2 3
 BASEDIR=/

--- a/resources/windows/nuget/project.nuspec.erb
+++ b/resources/windows/nuget/project.nuspec.erb
@@ -4,8 +4,8 @@
     <id><%= "#{@name}-#{@platform.architecture}" %></id>
     <version><%= @platform.nuget_package_version(@version, @release) %></version>
     <title><%= @name %></title>
-    <authors><%= @vendor.match(/^(.*) <.*>$/)[1] %></authors>
-    <owners><%= @vendor.match(/^(.*) <.*>$/)[1] %></owners>
+    <authors><%= vendor_name_only %></authors>
+    <owners><%= vendor_name_only %></owners>
     <projectUrl><%= @homepage %></projectUrl>
     <packageSourceUrl><%= @homepage %></packageSourceUrl>
     <projectSourceUrl><%= @homepage %></projectSourceUrl>
@@ -19,7 +19,7 @@
     </description>
     <summary><%= @description.lines.first.chomp %></summary>
     <releaseNotes><%= @homepage %></releaseNotes>
-    <copyright><%= @vendor.match(/^(.*) <.*>$/)[1] %></copyright>
+    <copyright><%= vendor_name_only %></copyright>
     <tags>puppet configuration management infrastructure automation facter hiera mco mcollective marionette collective</tags>
     <provides><%= get_replaces.map { |replace| "#{replace.replacement}" }.join(" ") %></provides>
     <replaces><%= get_replaces.map { |replace| "#{replace.replacement}" }.join(" ") %></replaces>

--- a/spec/lib/vanagon/project_spec.rb
+++ b/spec/lib/vanagon/project_spec.rb
@@ -55,6 +55,39 @@ describe 'Vanagon::Project' do
     plat._platform
   }
 
+  describe '#vendor=' do
+    dummy_platform = Vanagon::Platform.new('el-7-x86_64')
+    good_vendor = 'Puppet Inc. <release@puppet.com>'
+    bad_vendor = 'Puppet Inc.'
+
+    it 'fails if vendor field does not include email address' do
+      project = Vanagon::Project.new('vendor-test', dummy_platform)
+      expect { project.vendor = bad_vendor }.to raise_error(Vanagon::Error, /Project vendor field must include email address/)
+    end
+
+    it 'sets project vendor to the supplied value' do
+      project = Vanagon::Project.new('vendor-test', dummy_platform)
+      project.vendor = good_vendor
+      expect(project.vendor).to eq(good_vendor)
+    end
+  end
+
+  describe '#vendor_name_only' do
+    it 'returns just the name of the vendor' do
+      project = Vanagon::Project.new('vendor-test', Vanagon::Platform.new('el-7-x86_64'))
+      project.vendor = 'Puppet Inc. <release@puppet.com>'
+      expect(project.vendor_name_only).to eq('Puppet Inc.')
+    end
+  end
+
+  describe '#vendor_email_only' do
+    it 'returns just the email address of the vendor' do
+      project = Vanagon::Project.new('vendor-test', Vanagon::Platform.new('el-7-x86_64'))
+      project.vendor = 'Puppet Inc. <release@puppet.com>'
+      expect(project.vendor_email_only).to eq('release@puppet.com')
+    end
+  end
+
   describe '#get_root_directories' do
 
     before do


### PR DESCRIPTION
This commit replaces several instances of regex matching on the vendor field
with methods `vendor_name_only` and `vendor_field_only` to parse out either just
the name or just the email address, respectively, from a vendor value of the
form 'Name of Vendor \<email@vendor.com\>'.
This commit also adds a `vendor=` setter to the `Vanagon::Project` class in
order to validate that the vendor value is of the appropriate form. Previously,
if the email portion was not included, erb template parsing would fail with
"undefined method `[]' for nil:NilClass". Now we provide a helpful error message
if the vendor value is not of the correct form.