### PR TITLE
(maint) Move `package_overrides` higher up in the RPM SPEC file

### DIFF
--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -21,6 +21,11 @@
 %global __debug_package %{nil}
 # to resolve: "ERROR: No build ID note found"
 %undefine _missing_build_ids_terminate_build
+
+<% @package_overrides.each do |var| %>
+<%= var %>
+<% end -%>
+
 # To avoid files installed but not packaged errors
 %global __os_install_post %{__os_install_post} \
     rm -rf %{buildroot}/usr/lib/debug
@@ -33,10 +38,6 @@
 # cross-compiled static libs to end up with "no machine" as their
 # architure, breaking builds:
 %global __os_install_post %(echo '%{__os_install_post}' | <%= @platform.sed %> -e 's!/usr/lib[^[:space:]]*/brp-strip-static-archive[[:space:]].*$!!g')
-<% end -%>
-
-<% @package_overrides.each do |var| %>
-<%= var %>
 <% end -%>
 
 Name:           <%= @name %>


### PR DESCRIPTION
If you're trying to set additional defines/globals/etc that are called
during the `__os_install_post`, those need to be set before we reset
`__os_install_post` for debug symbol stripping.