### PR TITLE
RE-12096 Set filesystem type when creating OSX packages

### DIFF
--- a/lib/vanagon/platform/osx.rb
+++ b/lib/vanagon/platform/osx.rb
@@ -65,9 +65,14 @@ class Vanagon
           --resources $(tempdir)/osx/build/resources  \
           --plugins $(tempdir)/osx/build/plugins  \
           pkg/#{project.name}-#{project.version}-#{project.release}-installer.pkg)",
-         # Create a dmg and ship it to the output dir
-         "(cd $(tempdir)/osx/build/; #{@hdiutil} create -volname #{project.name}-#{project.version} \
-          -srcfolder pkg/ dmg/#{project.package_name})",
+         # Create a dmg and ship it to the output directory
+         "(cd $(tempdir)/osx/build; \
+           #{@hdiutil} create \
+            -volname #{project.name}-#{project.version} \
+            -fs JHFS+ \
+            -format UDBZ \
+            -srcfolder pkg \
+            dmg/#{project.package_name})",
          "mkdir -p output/#{target_dir}",
          "cp $(tempdir)/osx/build/dmg/#{project.package_name} ./output/#{target_dir}"].flatten.compact
       end


### PR DESCRIPTION
Build tested with puppet-agent but had trouble with testing signing:

Executing 'set -e; mkdir -p /tmp/6092442922992217/mount /tmp/6092442922992217/signed' on -i /home/jenkins/.ssh/id_signing jenkins@osx-signer.delivery.puppetlabs.net
Warning: Identity file /home/jenkins/.ssh/id_signing not accessible: Permission denied.
Permission denied (publickey,gssapi-with-mic,keyboard-interactive).
rake aborted!

If anyone knows the way to fix this, I can re-test.