### PR TITLE
(VANAGON-147) Disable automatic shebang munging

### DIFF
--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -22,6 +22,13 @@
 # to resolve: "ERROR: No build ID note found"
 %undefine _missing_build_ids_terminate_build
 
+# Starting in Fedora 28 and RHEL 8, automatic shebang (#!) munging was added.
+# We don't want this in our software and it will interfere with third-party
+# dependencies that we don't control. See
+# https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/2PD5RNJRKPN2DVTNGJSBHR5RUSVZSDZI/
+# for more info.
+%undefine __brp_mangle_shebangs
+
 <% @package_overrides.each do |var| %>
 <%= var %>
 <% end -%>


### PR DESCRIPTION
This commit updates the rpm spec file template to disable automatic shebang
munging, which was introduced in Fedora 28 and RHEL 8. Without this, certain
builds fail on these platforms because the python shebang gets munged
ambiguously. For more info, see
https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/2PD5RNJRKPN2DVTNGJSBHR5RUSVZSDZI/.