### PR TITLE
(VANAGON-150) Allow platforms to specify docker run args

### DIFF
--- a/lib/vanagon/engine/docker.rb
+++ b/lib/vanagon/engine/docker.rb
@@ -34,7 +34,9 @@ class Vanagon
       # a docker container.
       # @raise [Vanagon::Error] if a target cannot be obtained
       def select_target
-        Vanagon::Utilities.ex("#{@docker_cmd} run -d --name #{build_host_name}-builder -p #{@platform.ssh_port}:22 #{@platform.docker_image}")
+        extra_args = @platform.docker_run_args.nil? ? [] : @platform.docker_run_args
+
+        Vanagon::Utilities.ex("#{@docker_cmd} run -d --name #{build_host_name}-builder -p #{@platform.ssh_port}:22 #{extra_args.join(' ')} #{@platform.docker_image}")
         @target = 'localhost'
 
         # Wait for ssh to come up in the container

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -114,6 +114,7 @@ class Vanagon
 
     # Docker engine specific
     attr_accessor :docker_image
+    attr_accessor :docker_run_args
 
     # AWS engine specific
     attr_accessor :aws_ami

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -277,6 +277,13 @@ class Vanagon
         @platform.docker_image = image_name
       end
 
+      # Set additional `docker run` arguments to pass when creating containers
+      #
+      # @param args [Array<String>] array of CLI arguments for `docker run`
+      def docker_run_args(args)
+        @platform.docker_run_args = Array(args)
+      end
+
       # Set the ami for the platform to use
       #
       # @param ami [String] the ami id used.


### PR DESCRIPTION
This commit updates the Platform DSL to include a new `docker_run_args` method.
This method can be used to specify an additional list of CLI arguments that
the Docker engine will pass to `docker run` when creating containers.