### PR TITLE
(PA-2670) Add support for `get_version_forced` in the vanagon component

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -383,6 +383,23 @@ class Vanagon
       end
     end
 
+    # Force version determination for components
+    #
+    # If the component doesn't already have a version set (which normally happens for git sources),
+    # the source will be fetched into a temporary directory to attempt to figure out the version if the
+    # source type supports :version. This directory will be cleaned once the get_sources method returns
+    #
+    # @raise Vanagon::Error raises a vanagon error if we're unable to determine the version
+    def force_version
+      if @version.nil?
+        Dir.mktmpdir do |dir|
+          get_source(dir)
+        end
+      end
+      raise Vanagon::Error, "Unable to determine source version for component #{@name}!" if @version.nil?
+      @version
+    end
+
     # Prints the environment in a way suitable for use in a Makefile
     # or shell script. This is deprecated, because all Env. Vars. are
     # moving directly into the Makefile (and out of recipe subshells).

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -512,6 +512,17 @@ class Vanagon
         @component.preremove_actions << OpenStruct.new(:pkg_state => pkg_state, :scripts => scripts)
       end
 
+      # Force version determination for components
+      #
+      # If the component doesn't already have a version set (which normally happens for git sources),
+      # the source will be fetched into a temporary directory to attempt to figure out the version if the
+      # source type supports :version. This directory will be cleaned once the get_sources method returns
+      #
+      # @raise Vanagon::Error raises a vanagon error if we're unable to determine the version
+      def get_version_forced
+        @component.force_version
+      end
+
       # Adds action to run during the postremoval phase of packaging
       #
       # @param pkg_state [Array] the state in which the scripts should execute. Can be


### PR DESCRIPTION
This will allow us to force an additional clone of git sources to
determine the version while the component is still being processed. This
is needed to allow for including the component version in the gemspec
file for facter, puppet, and hiera so that ruby correctly identifies
those as installed gems.