### PR TITLE
(VANAGON-153) Update version in SMF manifest

### DIFF
--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -186,6 +186,8 @@ class Vanagon
           target_mode = '0644'
           default_mode = '0644'
         when "smf"
+          # modify version in smf manifest so service gets restarted after package upgrade
+          @component.install << %{#{@component.platform.sed} -ri 's/(<service.*version=)(".*")/\\1"#{@component.settings[:puppet_runtime_version]}"/' #{service_file}}
           target_service_file = File.join(@component.platform.servicedir, service_type.to_s, "#{service_name}.xml")
           target_default_file = File.join(@component.platform.defaultdir, service_name)
           target_mode = '0644'

--- a/lib/vanagon/platform/solaris_11.rb
+++ b/lib/vanagon/platform/solaris_11.rb
@@ -116,6 +116,7 @@ class Vanagon
         @make = "/usr/bin/gmake"
         @tar = "/usr/bin/gtar"
         @patch = "/usr/bin/gpatch"
+        @sed = "/usr/gnu/bin/sed"
         @num_cores = "/usr/bin/kstat cpu_info | /usr/bin/ggrep -E '[[:space:]]+core_id[[:space:]]' | wc -l"
         super(name)
         if @architecture == "sparc"


### PR DESCRIPTION
When upgrading the puppet-agent package, Solaris 11 doesn't automatically restart a service if the SMF manifest contains no changes.

This commit runs a sed on the target service(s) to change the current version (which is always 1) to the puppet-runtime version (since `version` is expected to be an integer value, per SMF documentation).

This commit also changes the Solaris sed to `/usr/gnu/bin/sed` which is the GNU implementation, so that we benefit from in-place editing and extended regular expressions.