### PR TITLE
(VANAGON-153) Use UNIX time for smf version

### DIFF
--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -187,7 +187,7 @@ class Vanagon
           default_mode = '0644'
         when "smf"
           # modify version in smf manifest so service gets restarted after package upgrade
-          @component.install << %{#{@component.platform.sed} -ri 's/(<service.*version=)(".*")/\\1"#{@component.settings[:puppet_runtime_version]}"/' #{service_file}}
+          @component.install << %{#{@component.platform.sed} -ri 's/(<service.*version=)(".*")/\\1"#{Time.now.to_i}"/' #{service_file}}
           target_service_file = File.join(@component.platform.servicedir, service_type.to_s, "#{service_name}.xml")
           target_default_file = File.join(@component.platform.defaultdir, service_name)
           target_mode = '0644'


### PR DESCRIPTION
Given that multiple component versions can be released using the
same puppet-runtime version, we should use UNIX time to ensure no two
releases have the same version.

This also satisfies the SMF constraint that the `version` field should
be an integer.

Tested on Solaris 11.