### PR TITLE
(maint) Faster file-list-for-rpm modification with perl

### DIFF
--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -172,11 +172,15 @@ install -d %{buildroot}
 <%- end -%>
 
 # Here we turn all dirs in the file-list into %dir entries to avoid duplicate files
-while read entry; do
-  if [ -n "$entry" -a -d "$entry" -a ! -L "$entry" ]; then
-    <%= @platform.sed %> -i "\|^$entry\$|s|^|%dir |" %{SOURCE1}
-  fi
-done < %{SOURCE1}
+if command -v perl; then
+  perl -i -lne 'if ((-d $_) && !(-l $_)) { print "%dir $_" } else { print }' %{SOURCE1}
+else
+  while read entry; do
+    if [ -n "$entry" -a -d "$entry" -a ! -L "$entry" ]; then
+      <%= @platform.sed %> -i "\|^$entry\$|s|^|%dir |" %{SOURCE1}
+    fi
+  done < %{SOURCE1}
+fi
 
 
 %pre


### PR DESCRIPTION
The existing method of scanning through the file list to find
directories is painfully slow for the PDK builds which contain tens of
thousands of small files.

```
$ time while read entry; do if [ -n "$entry" -a -d "$entry" -a ! -L "$entry" ]; then sed -i "\|^$entry\$|s|^|%dir |" file-list-for-rpm.sed; fi; done < file-list-for-rpm.sed

real	31m31.287s
user	13m18.240s
sys	18m13.089s
```

By rewriting this to use Perl instead, we can eliminate the fork & execs
for each entry in the file list and drastically speed this process up.

```
$ time perl -i -lne 'if ((-d $_) && !(-l $_)) { print "%dir $_" } else { print }' file-list-for-rpm.perl

real	0m0.246s
user	0m0.060s
sys	0m0.179s
```

Both processes started with the same file list (copied with different
extensions for illustrative purposes) and produced identical results.

```
$ diff -s file-list-for-rpm.perl file-list-for-rpm.sed
Files file-list-for-rpm.perl and file-list-for-rpm.sed are identical
```

I chose Perl for this because it commonly installed on platforms by
default, however the rpmspec will fall back to using the sed loop if
perl is not available.

/cc @scotje 