### PR TITLE
(maint) add noninteractive to apt curl install

### DIFF
--- a/lib/vanagon/platform/deb.rb
+++ b/lib/vanagon/platform/deb.rb
@@ -99,7 +99,7 @@ class Vanagon
         # parse the definition and gpg_key if set to ensure they are both valid URIs
         definition = URI.parse(definition)
         gpg_key = URI.parse(gpg_key) if gpg_key
-        provisioning = ["apt-get -qq update && apt-get -qq install curl"]
+        provisioning = ["apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -qq install curl"]
 
         if definition.scheme =~ /^(http|ftp)/
           provisioning << add_repo_target(definition)


### PR DESCRIPTION
When using `add_build_repository` which is installing curl,
puppet-agent jobs hangs becasue the interactive mode is asking to restart some services:

```There are services installed on your system which need to be restarted when
certain libraries, such as libpam, libc, and libssl, are upgraded. Since these
restarts may cause interruptions of service for the system, you will normally be
prompted on each upgrade for the list of services you wish to restart.  You can
choose this option to avoid being prompted; instead, all necessary restarts will
be done for you automatically so you can avoid being asked questions on each
library upgrade.

Restart services during package upgrades without asking? [yes/no]```

This commit ads `noninteractive` to curl install command