### PR TITLE
(maint) add windowsfips as a windows platform

### DIFF
--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -44,7 +44,7 @@ class Vanagon
                       Vanagon::Platform::Solaris10.new(@name)
                     when /^solaris-11/
                       Vanagon::Platform::Solaris11.new(@name)
-                    when /^windows-/
+                    when /^windows/
                       Vanagon::Platform::Windows.new(@name)
                     else
                       fail "Platform not implemented for '#{@name}' yet. Please go do so..."


### PR DESCRIPTION
Building puppet runtime for windowsfips fails with the following error:
```04:29:32 Error loading platform 'windowsfips-2012r2-x64' using '/tmp/jenkins/workspace/platform_agent-runtime_runtime-vanagon-prep-project_5.5.x/puppet-runtime/configs/platforms/windowsfips-2012r2-x64.rb':
04:29:32 Platform not implemented for 'windowsfips-2012r2-x64' yet. Please go do so..
```

This PR adds `windowsfips` as a Windows-based platform.