### PR TITLE
(VANAGON-157) Make curl be more clear about fetch errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- (VANAGON-157) Make curl calls fail on error
 
 ## [0.15.29] - released on 2019-09-25
 ### Changed

--- a/lib/vanagon/platform/deb.rb
+++ b/lib/vanagon/platform/deb.rb
@@ -72,11 +72,11 @@ class Vanagon
       def add_repo_target(definition)
         if File.extname(definition.path) == '.deb'
           # repo definition is an deb (like puppetlabs-release)
-          "curl -o local.deb '#{definition}' && dpkg -i local.deb; rm -f local.deb"
+          "#{@curl} -o local.deb '#{definition}' && dpkg -i local.deb; rm -f local.deb"
         else
           reponame = "#{SecureRandom.hex}-#{File.basename(definition.path)}"
           reponame = "#{reponame}.list" if File.extname(reponame) != '.list'
-          "curl -o '/etc/apt/sources.list.d/#{reponame}' '#{definition}'"
+          "#{@curl} -o '/etc/apt/sources.list.d/#{reponame}' '#{definition}'"
         end
       end
 
@@ -87,7 +87,7 @@ class Vanagon
       def add_gpg_key(gpg_key)
         gpgname = "#{SecureRandom.hex}-#{File.basename(gpg_key.path)}"
         gpgname = "#{gpgname}.gpg" if gpgname !~ /\.gpg$/
-        "curl -o '/etc/apt/trusted.gpg.d/#{gpgname}' '#{gpg_key}'"
+        "#{@curl} -o '/etc/apt/trusted.gpg.d/#{gpgname}' '#{gpg_key}'"
       end
 
       # Returns the commands to add a given repo target and optionally a gpg key to the build system
@@ -140,6 +140,7 @@ class Vanagon
         @tar = "tar"
         @patch = "/usr/bin/patch"
         @num_cores = "/usr/bin/nproc"
+        @curl = "curl --silent --show-error --fail"
         @valid_operators = ['<', '>', '<=', '>=', '=', '<<', '>>']
         super(name)
       end

--- a/lib/vanagon/platform/rpm.rb
+++ b/lib/vanagon/platform/rpm.rb
@@ -68,14 +68,14 @@ class Vanagon
         if definition.scheme =~ /^(http|ftp)/
           if File.extname(definition.path) == '.rpm'
             # repo definition is an rpm (like puppetlabs-release)
-            commands << "curl -o local.rpm '#{definition}'; rpm -Uvh local.rpm; rm -f local.rpm"
+            commands << "#{@curl} -o local.rpm '#{definition}'; rpm -Uvh local.rpm; rm -f local.rpm"
           else
             reponame = "#{SecureRandom.hex}-#{File.basename(definition.path)}"
             reponame = "#{reponame}.repo" if File.extname(reponame) != '.repo'
             if is_cisco_wrlinux?
-              commands << "curl -o '/etc/yum/repos.d/#{reponame}' '#{definition}'"
+              commands << "#{@curl} -o '/etc/yum/repos.d/#{reponame}' '#{definition}'"
             else
-              commands << "curl -o '/etc/yum.repos.d/#{reponame}' '#{definition}'"
+              commands << "#{@curl} -o '/etc/yum.repos.d/#{reponame}' '#{definition}'"
             end
           end
         end
@@ -103,6 +103,7 @@ class Vanagon
         @patch ||= "/usr/bin/patch"
         @num_cores ||= "/bin/grep -c 'processor' /proc/cpuinfo"
         @rpmbuild ||= "/usr/bin/rpmbuild"
+        @curl = "curl --silent --show-error --fail"
         super(name)
       end
     end

--- a/lib/vanagon/platform/rpm/sles.rb
+++ b/lib/vanagon/platform/rpm/sles.rb
@@ -21,7 +21,7 @@ class Vanagon
           if definition.scheme =~ /^(http|ftp)/
             if File.extname(definition.path) == '.rpm'
               # repo definition is an rpm (like puppetlabs-release)
-              commands << "curl -o local.rpm '#{definition}'; rpm -Uvh local.rpm; rm -f local.rpm"
+              commands << "curl --silent --show-error --fail -o local.rpm '#{definition}'; rpm -Uvh local.rpm; rm -f local.rpm"
             else
               commands << "yes | zypper -n --no-gpg-checks #{flag} -t YUM --repo '#{definition}'"
             end

--- a/lib/vanagon/platform/solaris_10.rb
+++ b/lib/vanagon/platform/solaris_10.rb
@@ -156,7 +156,7 @@ class Vanagon
           if build_dependency =~ /^http.*\.gz/
             # Fetch, unpack, install...this assumes curl is present.
             package = build_dependency.sub(/^http.*\//, '')
-            http << "tmpdir=$(#{mktemp}); (cd ${tmpdir} && curl -O #{build_dependency} && gunzip -c #{package} | pkgadd -d /dev/stdin -a /var/tmp/noask all)"
+            http << "tmpdir=$(#{mktemp}); (cd ${tmpdir} && curl --silent --show-error --fail -O #{build_dependency} && gunzip -c #{package} | pkgadd -d /dev/stdin -a /var/tmp/noask all)"
           else
             # Opencsw dependencies. At this point we assume that pkgutil is installed.
             pkgutil << build_dependency
@@ -199,5 +199,3 @@ class Vanagon
     end
   end
 end
-
-

--- a/spec/lib/vanagon/platform/dsl_spec.rb
+++ b/spec/lib/vanagon/platform/dsl_spec.rb
@@ -33,14 +33,20 @@ describe 'Vanagon::Platform::DSL' do
       expect(SecureRandom).to receive(:hex).and_return(hex_value)
       plat.instance_eval(deb_platform_block)
       plat.apt_repo(apt_definition)
-      expect(plat._platform.provisioning).to include("curl -o '/etc/apt/sources.list.d/#{hex_value}-pl-puppet-agent-0.2.1-wheezy.list' '#{apt_definition}'")
+      expect(plat._platform.provisioning[0]).to include('apt-get', 'install', 'curl')
+      expect(plat._platform.provisioning[1]).to include(
+        'curl', '--silent', '--show-error', '--fail',
+        "-o '/etc/apt/sources.list.d/#{hex_value}-pl-puppet-agent-0.2.1-wheezy.list' '#{apt_definition}'")
     end
 
     it "installs a deb when given a deb" do
       plat = Vanagon::Platform::DSL.new('debian-test-fixture')
       plat.instance_eval(deb_platform_block)
       plat.apt_repo(apt_definition_deb)
-      expect(plat._platform.provisioning).to include("curl -o local.deb '#{apt_definition_deb}' && dpkg -i local.deb; rm -f local.deb")
+      expect(plat._platform.provisioning[0]).to include('apt-get', 'install', 'curl')
+      expect(plat._platform.provisioning[1]).to include(
+        'curl', '--silent', '--show-error', '--fail',
+        "-o local.deb '#{apt_definition_deb}' && dpkg -i local.deb; rm -f local.deb")
     end
 
     it "installs a gpg key if given one" do
@@ -48,7 +54,9 @@ describe 'Vanagon::Platform::DSL' do
       expect(SecureRandom).to receive(:hex).and_return(hex_value).twice
       plat.instance_eval(deb_platform_block)
       plat.apt_repo(apt_definition, apt_definition_gpg)
-      expect(plat._platform.provisioning).to include("curl -o '/etc/apt/trusted.gpg.d/#{hex_value}-keyring.gpg' '#{apt_definition_gpg}'")
+      expect(plat._platform.provisioning[0]).to include('apt-get', 'install', 'curl')
+      expect(plat._platform.provisioning[1]).to include(
+        'curl', '--silent', '--show-error', '--fail', "-o '/etc/apt", hex_value)
     end
   end
 
@@ -58,7 +66,10 @@ describe 'Vanagon::Platform::DSL' do
       expect(SecureRandom).to receive(:hex).and_return(hex_value)
       plat.instance_eval(el_5_platform_block)
       plat.yum_repo(el_definition)
-      expect(plat._platform.provisioning).to include("curl -o '/etc/yum.repos.d/#{hex_value}-pl-puppet-agent-0.2.1-el-7-x86_64.repo' '#{el_definition}'")
+      expect(plat._platform.provisioning[0]).to include('rpm -q curl', 'yum -y install curl')
+      expect(plat._platform.provisioning[1]).to include(
+        'curl', '--silent', '--show-error', '--fail',
+        "-o '/etc/yum.repos.d/#{hex_value}-pl-puppet-agent-0.2.1-el-7-x86_64.repo' '#{el_definition}'")
     end
 
     it "works for specifically redhat platforms" do
@@ -66,7 +77,10 @@ describe 'Vanagon::Platform::DSL' do
       expect(SecureRandom).to receive(:hex).and_return(hex_value)
       plat.instance_eval(redhat_7_platform_block)
       plat.yum_repo(el_definition)
-      expect(plat._platform.provisioning).to include("curl -o '/etc/yum.repos.d/#{hex_value}-pl-puppet-agent-0.2.1-el-7-x86_64.repo' '#{el_definition}'")
+      expect(plat._platform.provisioning[0]).to include('rpm -q curl', 'yum -y install curl')
+      expect(plat._platform.provisioning[1]).to include(
+        'curl','--silent', '--show-error', '--fail',
+        "-o '/etc/yum.repos.d/#{hex_value}-pl-puppet-agent-0.2.1-el-7-x86_64.repo' '#{el_definition}'")
     end
 
     # This test currently covers wrlinux 5 and 7
@@ -75,7 +89,10 @@ describe 'Vanagon::Platform::DSL' do
       expect(SecureRandom).to receive(:hex).and_return(hex_value)
       plat.instance_eval(cicso_wrlinux_platform_block)
       plat.yum_repo(cisco_wrlinux_definition)
-      expect(plat._platform.provisioning).to include("curl -o '/etc/yum/repos.d/#{hex_value}-pl-puppet-agent-0.2.1-cisco-wrlinux-5-x86_64.repo' '#{cisco_wrlinux_definition}'")
+      expect(plat._platform.provisioning[0]).to include('rpm -q curl', 'yum -y install curl')
+      expect(plat._platform.provisioning[1]).to include(
+        'curl','--silent', '--show-error', '--fail',
+         "-o '/etc/yum/repos.d/#{hex_value}-pl-puppet-agent-0.2.1-cisco-wrlinux-5-x86_64.repo' '#{cisco_wrlinux_definition}'")
     end
 
     describe "installs a rpm when given a rpm" do
@@ -83,8 +100,9 @@ describe 'Vanagon::Platform::DSL' do
         plat = Vanagon::Platform::DSL.new('el-5-fixture')
         plat.instance_eval(el_5_platform_block)
         plat.yum_repo(el_definition_rpm)
-        expect(plat._platform.provisioning).to include("rpm -q curl > /dev/null || yum -y install curl")
-        expect(plat._platform.provisioning).to include("curl -o local.rpm '#{el_definition_rpm}'; rpm -Uvh local.rpm; rm -f local.rpm")
+        expect(plat._platform.provisioning[0]).to include('rpm -q curl', 'yum -y install curl')
+        expect(plat._platform.provisioning[1]).to include(
+          'curl', '--silent', '--show-error', '--fail', "-o local.rpm '#{el_definition_rpm}'; rpm -Uvh local.rpm; rm -f local.rpm")
       end
     end
   end
@@ -101,7 +119,9 @@ describe 'Vanagon::Platform::DSL' do
       plat = Vanagon::Platform::DSL.new('sles-test-fixture')
       plat.instance_eval(sles_platform_block)
       plat.zypper_repo(sles_definition_rpm)
-      expect(plat._platform.provisioning).to include("curl -o local.rpm '#{sles_definition_rpm}'; rpm -Uvh local.rpm; rm -f local.rpm")
+      expect(plat._platform.provisioning[0]).to include(
+        'curl', '--silent', '--show-error', '--fail',
+        "-o local.rpm '#{sles_definition_rpm}'; rpm -Uvh local.rpm; rm -f local.rpm")
     end
   end
 


### PR DESCRIPTION
This commit adds the '--silent' '--show-error' and '--fail' flags to
calls made by vanagon to force bad fetches to return non-zero exit
status in the shell.

As a side-effect, some of the curl output statistics is silenced. I
think this silencing is desirable.

The previous behavior looked like this upon success:

$ curl -o STUFF https://artifactory.delivery.puppetlabs.net/artifactory/scratchpad__local/exg-test/foo.txt
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    29  100    29    0     0    159      0 --:--:-- --:--:-- --:--:--   160
$ echo $?
0

The previous behavior looked like this upon  failure:

$ curl -o STUFF https://artifactory.delivery.puppetlabs.net/artifactory/scratchpad__local/exg-test/foo.txt.BAD
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    80    0    80    0     0    419      0 --:--:-- --:--:-- --:--:--   421
$ echo $?
0

The new behavior looks like this upon success:

$ curl --silent --show-error --fail -o STUFF https://artifactory.delivery.puppetlabs.net/artifactory/scratchpad__local/exg-test/foo.txt
$ echo $?
0

The new behavior looks like this upon failure:

$ curl --silent --show-error --fail -o STUFF https://artifactory.delivery.puppetlabs.net/artifactory/scratchpad__local/exg-test/foo.txt.BAD
curl: (22) The requested URL returned error: 404 Not Found
$ echo $?
22