### PR TITLE
(maint) respond to 'version' deprecation notice from github

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Ruby 2.6
       uses: actions/setup-ruby@v1
       with:
-        version: 2.6.x
+        ruby-version: 2.6.x
     - name: Build and test with Rake
       run: |
         gem install bundler


### PR DESCRIPTION
Github writes:

 .github/workflows/ruby.yml#L1

Input 'version' has been deprecated with message: The version property
will not be supported after October 1, 2019. Use ruby-version instead