### PR TITLE
(maint) Add Ubuntu and Debian utility matchers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -184,7 +184,7 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   Enabled: false
 
-Style/UnneededCondition:
+Style/RedundantCondition:
   Enabled: false
 
 Style/SafeNavigation:
@@ -221,7 +221,7 @@ Style/WhenThen:
 Style/WordArray:
   Enabled: false
 
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: false
 
 Layout/AlignArguments:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ## [Unreleased]
 ### Changed
 - (VANAGON-157) Make curl calls fail on error
+- Add Debian and Ubuntu platform utility matchers.
 
 ## [0.15.29] - released on 2019-09-25
 ### Changed

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -344,6 +344,20 @@ class Vanagon
       return !!@name.match(/^fedora-.*$/)
     end
 
+    # Utility matcher to determine is the platform is a debian variety
+    #
+    # @return [true, false] true if it is a debian variety, false otherwise
+    def is_debian?
+      return !!@name.match(/^debian-.*$/)
+    end
+
+    # Utility matcher to determine is the platform is a ubuntu variety
+    #
+    # @return [true, false] true if it is a ubuntu variety, false otherwise
+    def is_ubuntu?
+      return !!@name.match(/^ubuntu-.*$/)
+    end
+
     # Utility matcher to determine is the platform is an aix variety
     #
     # @return [true, false] true if it is an aix variety, false otherwise


### PR DESCRIPTION
~~This commit adds a utility matcher to determine whether the platform uses the system provided toolchain as opposed to pl-build-tools.~~

~~This is useful in the long term when adding new platforms to puppet-runtime and puppet-agent, because we avoid code duplication on building various C++ projects. It should also be future proof (except for when we are adding a new OS altogether).~~

Changed this PR to only add Ubuntu and Debian OS matchers. We'll rework the system toolchain/pl-build-tools issue inside puppet-runtime/puppet-agent.