### PR TITLE
(VANAGON-159) Updates to `parse_and_rewrite` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ## [Unreleased]
 ### Changed
 - (VANAGON-157) Make curl calls fail on error
+
+### Added
 - Add Debian and Ubuntu platform utility matchers.
+
+### Fixed
+- (VANAGON-159) Update `parse_and_rewrite` method. It will now do no processing
+  if there aren't any rewrite rules. If there are rewrite rules and you're
+  specifying your git source with `git:http[...]`, this method will sub out the
+  `git:` to get around some of the extra processing fustigit does to URIs.
 
 ## [0.15.29] - released on 2019-09-25
 ### Changed

--- a/lib/vanagon/component/source/rewrite.rb
+++ b/lib/vanagon/component/source/rewrite.rb
@@ -74,6 +74,16 @@ class Vanagon
           # @deprecated Please use the component DSL method #mirror(<URI>)
           #   instead. This method will be removed before Vanagon 1.0.0.
           def parse_and_rewrite(uri)
+            return uri if rewrite_rules.empty?
+            if uri.match?(/^git:http/)
+              warn <<-HERE.undent
+                `fustigit` parsing doesn't get along with how we specify the source
+                type by prefixing `git`. As `rewrite_rules` are deprecated, we'll
+                replace `git:http` with `http` in your uri. At some point this will
+                break.
+              HERE
+              uri.sub!(/^git:http/, 'http')
+            end
             url = URI.parse(uri)
             return url unless url.scheme
             rewrite(url.to_s, url.scheme)


### PR DESCRIPTION
* If there are no rewrite rules specified, don't do any processing on
the URI, just return it directly.
* If there are rewrite rules and the URI begins with `git:http` (to
specify a git source with an http url), substitute `git:http` with
`http` since fustigit gets rid of additional `/`. **Note** This will
result in deprecation warnings, and will break at some point in the
future.
* If there are rewrite rules and the URI doesn't begin with `git:http`,
keep existing behavior.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.