### PR TITLE
(VANAGON-35) Update `find_program_on_path` to work on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
   if there aren't any rewrite rules. If there are rewrite rules and you're
   specifying your git source with `git:http[...]`, this method will sub out the
   `git:` to get around some of the extra processing fustigit does to URIs.
+- (VANAGON-35) Update `find_program_on_path` to support windows files with
+  extensions.
 
 ## [0.15.29] - released on 2019-09-25
 ### Changed

--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -112,9 +112,12 @@ class Vanagon
     # @return [String, false] Returns either the full path to the command or false if the command cannot be found
     # @raise [RuntimeError] If the command is required and cannot be found
     def find_program_on_path(command, required = true)
+      extensions = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
       ENV['PATH'].split(File::PATH_SEPARATOR).each do |path_elem|
-        location = File.join(path_elem, command)
-        return location if FileTest.executable?(location)
+        extensions.each do |ext|
+          location = File.join(path_elem, "#{command}#{ext}")
+          return location if FileTest.executable?(location)
+        end
       end
 
       if required


### PR DESCRIPTION
`find_program_on_path` needs to look for files with allowable extensions
when determining whether or not an executable exists.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.