### PR TITLE
(VANAGON-72) Access `settings` hash from platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ### Added
 - Add Debian and Ubuntu platform utility matchers.
+- (VANAGON-72) Give platform access to the shared `settings` hash used by the
+  projects and components.
 
 ### Fixed
 - (VANAGON-159) Update `parse_and_rewrite` method. It will now do no processing

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -220,6 +220,7 @@ class Vanagon
     # @return [Vanagon::Platform] the platform with the given name
     def initialize(name) # rubocop:disable Metrics/AbcSize
       @name = name
+      @settings = {}
       @os_name = os_name
       @os_version = os_version
       @architecture = architecture

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -412,6 +412,14 @@ class Vanagon
       def add_build_repository(*args)
         @platform.add_build_repository(*args)
       end
+
+      def setting(name, value)
+        @platform.settings[name] = value
+      end
+
+      def settings
+        @platform.settings
+      end
     end
   end
 end

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -139,7 +139,7 @@ class Vanagon
       @components = []
       @requires = []
       @directories = []
-      @settings = {}
+      @settings = platform.settings
       # Environments are like Hashes but with specific constraints
       # around their keys and values.
       @environment = Vanagon::Environment.new
@@ -756,7 +756,8 @@ class Vanagon
         # We don't want to load any of the upstream components, so we're going to
         # pass an array with an empty string as the component list for load_project
         no_components = ['']
-        upstream_project = Vanagon::Project.load_project(upstream_project_name, File.join(working_directory, upstream_source.dirname, "configs", "projects"), platform, no_components)
+        upstream_platform = Vanagon::Platform.load_platform(platform.name, File.join(working_directory, upstream_source.dirname, "configs", "platforms"))
+        upstream_project = Vanagon::Project.load_project(upstream_project_name, File.join(working_directory, upstream_source.dirname, "configs", "projects"), upstream_platform, no_components)
         @settings.merge!(upstream_project.settings)
         upstream_project.cleanup
       end

--- a/spec/lib/vanagon/component/rules_spec.rb
+++ b/spec/lib/vanagon/component/rules_spec.rb
@@ -14,7 +14,7 @@ end
 
 describe Vanagon::Component::Rules do
   let(:platform) do
-    OpenStruct.new(:patch => "/usr/bin/patch", :make => '/usr/bin/make')
+    OpenStruct.new(:patch => "/usr/bin/patch", :make => '/usr/bin/make', :settings => {})
   end
 
   let(:project) do

--- a/spec/lib/vanagon/platform/windows_spec.rb
+++ b/spec/lib/vanagon/platform/windows_spec.rb
@@ -31,6 +31,10 @@ describe "Vanagon::Platform::Windows" do
     },
   ]
 
+  let(:vanagon_platform) do
+    OpenStruct.new(:settings => {})
+  end
+
   platforms.each do |plat|
     context "on #{plat[:name]}" do
       let(:platform) { plat }
@@ -203,7 +207,7 @@ describe "Vanagon::Platform::Windows" do
         describe "generate_wix_dirs" do
 
           it "returns one directory with install_service defaults" do
-            proj = Vanagon::Project::DSL.new('test-fixture', {}, [])
+            proj = Vanagon::Project::DSL.new('test-fixture', vanagon_platform, [])
             proj.instance_eval(project_block)
             cur_plat.instance_eval(plat[:block])
             comp = Vanagon::Component::DSL.new('service-test', {}, cur_plat._platform)
@@ -219,7 +223,7 @@ describe "Vanagon::Platform::Windows" do
           end
 
           it "returns one directory with non-default name" do
-            proj = Vanagon::Project::DSL.new('test-fixture', {}, [])
+            proj = Vanagon::Project::DSL.new('test-fixture', vanagon_platform, [])
             proj.instance_eval(project_block)
             cur_plat.instance_eval(plat[:block])
             comp = Vanagon::Component::DSL.new('service-test', {}, cur_plat._platform)
@@ -235,7 +239,7 @@ describe "Vanagon::Platform::Windows" do
           end
 
           it "returns nested directory correctly with \\" do
-            proj = Vanagon::Project::DSL.new('test-fixture', {}, [])
+            proj = Vanagon::Project::DSL.new('test-fixture', vanagon_platform, [])
             proj.instance_eval(project_block)
             cur_plat.instance_eval(plat[:block])
             comp = Vanagon::Component::DSL.new('service-test', {}, cur_plat._platform)
@@ -255,7 +259,7 @@ describe "Vanagon::Platform::Windows" do
 
 
           it "adds a second directory for the same input but different components" do
-            proj = Vanagon::Project::DSL.new('test-fixture', {}, [])
+            proj = Vanagon::Project::DSL.new('test-fixture', vanagon_platform, [])
             proj.instance_eval(project_block)
             cur_plat.instance_eval(plat[:block])
             comp = Vanagon::Component::DSL.new('service-test', {}, cur_plat._platform)
@@ -274,7 +278,7 @@ describe "Vanagon::Platform::Windows" do
           end
 
           it "returns correctly formatted multiple nested directories" do
-            proj = Vanagon::Project::DSL.new('test-fixture', {}, [])
+            proj = Vanagon::Project::DSL.new('test-fixture', vanagon_platform, [])
             proj.instance_eval(project_block)
             cur_plat.instance_eval(plat[:block])
             comp = Vanagon::Component::DSL.new('service-test-1', {}, cur_plat._platform)

--- a/spec/lib/vanagon/project/dsl_spec.rb
+++ b/spec/lib/vanagon/project/dsl_spec.rb
@@ -8,11 +8,14 @@ describe 'Vanagon::Project::DSL' do
 "project 'test-fixture' do |proj|
 end" }
   let(:configdir) { '/a/b/c' }
+  let(:platform) do
+    OpenStruct.new(:settings => {})
+  end
 
   describe '#version_from_git' do
     it 'sets the version based on the git describe' do
       expect(Vanagon::Driver).to receive(:configdir).and_return(configdir)
-      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj = Vanagon::Project::DSL.new('test-fixture', platform)
       proj.instance_eval(project_block)
 
       # Lying is bad. You shouldn't lie. But sometimes when you're
@@ -35,7 +38,7 @@ end" }
     end
     it 'sets the version based on the git describe with multiple dashes' do
       expect(Vanagon::Driver).to receive(:configdir).and_return(configdir)
-      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj = Vanagon::Project::DSL.new('test-fixture', platform)
       proj.instance_eval(project_block)
 
       # See previous description of "indescribable cyclopean obelisk"
@@ -60,7 +63,7 @@ end" }
       log = double
       diff = double
       expect(Vanagon::Driver).to receive(:configdir).and_return(configdir)
-      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj = Vanagon::Project::DSL.new('test-fixture', platform)
       proj.instance_eval(project_block)
       repo = double("repo")
       expect(::Git)
@@ -91,7 +94,7 @@ end" }
       }
 
       expect(Vanagon::Driver).to receive(:configdir).exactly(branches.length).times.and_return(configdir)
-      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj = Vanagon::Project::DSL.new('test-fixture', platform)
       proj.instance_eval(project_block)
 
       branches.each do |branch, version|
@@ -116,7 +119,7 @@ end" }
       ]
 
       expect(Vanagon::Driver).to receive(:configdir).exactly(branches.length).times.and_return(configdir)
-      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj = Vanagon::Project::DSL.new('test-fixture', platform)
       proj.instance_eval(project_block)
 
       branches.each do |branch|
@@ -137,7 +140,7 @@ end" }
 
   describe '#directory' do
     it 'adds a directory to the list of directories' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj = Vanagon::Project::DSL.new('test-fixture', platform)
       proj.instance_eval(project_block)
       proj.directory('/a/b/c/d', mode: '0755')
       expect(proj._project.directories).to include(Vanagon::Common::Pathname.new('/a/b/c/d', mode: '0755'))
@@ -146,7 +149,7 @@ end" }
 
   describe '#user' do
     it 'sets a user for the project' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj = Vanagon::Project::DSL.new('test-fixture', platform)
       proj.instance_eval(project_block)
       proj.user('test-user')
       expect(proj._project.user).to eq(Vanagon::Common::User.new('test-user'))
@@ -155,7 +158,7 @@ end" }
 
   describe '#target_repo' do
     it 'sets the target_repo for the project' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj = Vanagon::Project::DSL.new('test-fixture', platform)
       proj.instance_eval(project_block)
       proj.target_repo "pc1"
       expect(proj._project.repo).to eq("pc1")
@@ -164,7 +167,7 @@ end" }
 
   describe '#noarch' do
     it 'sets noarch on the project to true' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj = Vanagon::Project::DSL.new('test-fixture', platform)
       proj.instance_eval(project_block)
       proj.noarch
       expect(proj._project.noarch).to eq(true)
@@ -173,20 +176,20 @@ end" }
 
   describe '#generate_source_artifacts' do
     it 'defaults to false' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj = Vanagon::Project::DSL.new('test-fixture', platform)
       proj.instance_eval(project_block)
       expect(proj._project.source_artifacts).to eq(false)
     end
 
     it 'sets source_artifacts to true' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj = Vanagon::Project::DSL.new('test-fixture', platform)
       proj.instance_eval(project_block)
       proj.generate_source_artifacts true
       expect(proj._project.source_artifacts).to eq(true)
     end
 
     it 'sets source_artifacts to false' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj = Vanagon::Project::DSL.new('test-fixture', platform)
       proj.instance_eval(project_block)
       proj.generate_source_artifacts false
       expect(proj._project.source_artifacts).to eq(false)
@@ -195,7 +198,7 @@ end" }
 
   describe '#identifier' do
     it 'sets the identifier for the project' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj = Vanagon::Project::DSL.new('test-fixture', platform)
       proj.instance_eval(project_block)
       proj.identifier "com.example"
       expect(proj._project.identifier).to eq("com.example")
@@ -204,14 +207,14 @@ end" }
 
   describe '#cleanup_during_build' do
     it 'sets @cleanup to true' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj = Vanagon::Project::DSL.new('test-fixture', platform)
       proj.instance_eval(project_block)
       proj.cleanup_during_build
       expect(proj._project.cleanup).to eq(true)
     end
 
     it 'defaults to nil' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj = Vanagon::Project::DSL.new('test-fixture', platform)
       proj.instance_eval(project_block)
       expect(proj._project.cleanup).to be_nil
     end
@@ -221,7 +224,7 @@ end" }
     let(:version_file) { '/opt/puppetlabs/puppet/VERSION' }
 
     it 'sets version_file for the project' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj = Vanagon::Project::DSL.new('test-fixture', platform)
       proj.instance_eval(project_block)
       proj.write_version_file(version_file)
       expect(proj._project.version_file.path).to eq(version_file)
@@ -230,14 +233,14 @@ end" }
 
   describe "#release" do
     it 'sets the release for the project' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj = Vanagon::Project::DSL.new('test-fixture', platform)
       proj.instance_eval(project_block)
       proj.release '12'
       expect(proj._project.release).to eq('12')
     end
 
     it 'defaults to 1' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj = Vanagon::Project::DSL.new('test-fixture', platform)
       proj.instance_eval(project_block)
       expect(proj._project.release).to eq('1')
     end
@@ -254,7 +257,7 @@ end" }
     end
 
     it 'adds the package provide to the list of provides' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj = Vanagon::Project::DSL.new('test-fixture', platform)
       proj.instance_eval(project_block)
       proj.provides('thing1')
       proj.provides('thing2')
@@ -337,7 +340,7 @@ end" }
     end
 
     it 'adds the package replacement to the list of replacements' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj = Vanagon::Project::DSL.new('test-fixture', platform)
       proj.instance_eval(project_block)
       proj.replaces('thing1')
       proj.replaces('thing2')
@@ -416,7 +419,7 @@ end" }
     end
 
     it 'adds the package conflict to the list of conflicts' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {})
+      proj = Vanagon::Project::DSL.new('test-fixture', platform)
       proj.instance_eval(project_block)
       proj.conflicts('thing1')
       proj.conflicts('thing2')
@@ -529,19 +532,19 @@ end"
     end
 
     it 'stores the component in the project if the included components set is empty' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {}, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', platform, [])
       proj.instance_eval(project_block)
       expect(proj._project.components).to include(component)
     end
 
     it 'stores the component in the project if the component name is listed in the included components set' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {}, ['some-component'])
+      proj = Vanagon::Project::DSL.new('test-fixture', platform, ['some-component'])
       proj.instance_eval(project_block)
       expect(proj._project.components).to include(component)
     end
 
     it 'does not store the component if the included components set is not empty and does not include the component name' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {}, ['some-different-component'])
+      proj = Vanagon::Project::DSL.new('test-fixture', platform, ['some-different-component'])
       proj.instance_eval(project_block)
       expect(proj._project.components).to_not include(component)
     end
@@ -565,19 +568,19 @@ end"
     }
 
     it 'has an empty project.fetch_artifact when fetch_artifact is not called' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {}, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', platform, [])
       proj.instance_eval(empty_project_block)
       expect(proj._project.artifacts_to_fetch).to eq([])
     end
 
     it 'Adds a path to project.fetch_artifact when fetch_artifact is called' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {}, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', platform, [])
       proj.instance_eval(project_block)
       expect(proj._project.artifacts_to_fetch).to eq(['foo/bar/baz.file'])
     end
 
     it 'Adds multiple paths to project.fetch_artifact when fetch_artifact is called more than once' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {}, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', platform, [])
       proj.instance_eval(project_block_multiple)
       expect(proj._project.artifacts_to_fetch).to eq(['foo/bar/baz.file', 'foo/foobar/foobarbaz.file'])
     end
@@ -600,19 +603,19 @@ end"
     }
 
     it 'has no_packaging set to false by default' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {}, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', platform, [])
       proj.instance_eval(empty_project_block)
       expect(proj._project.no_packaging).to eq(false)
     end
 
     it 'sets no_packaging to true when proj.no_packaging true is called' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {}, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', platform, [])
       proj.instance_eval(project_block)
       expect(proj._project.no_packaging).to eq(true)
     end
 
     it 'sets no_packaging to false when proj.no_packaging false is called' do
-      proj = Vanagon::Project::DSL.new('test-fixture', {}, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', platform, [])
       proj.instance_eval(project_block_false)
       expect(proj._project.no_packaging).to eq(false)
     end


### PR DESCRIPTION
This updates the `settings` hash to be initialized in the platform and
then copied to the project and components. This will allow the platform
to access the settings hash and set settings to be shared with the
project/component.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.