### PR TITLE
(maint) Don't use `match?` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- Don't use `match?` method that wasn't added until ruby 2.4.
 
 ## [0.15.30] - released on 2019-11-12
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [0.15.31] - released on 2019-11-14
 ### Fixed
 - Don't use `match?` method that wasn't added until ruby 2.4.
 
@@ -812,7 +814,8 @@ on Debian < 8 and needs more work and testing.
 
 ## Versions <= 0.3.9 do not have a change log entry
 
-[Unreleased]: https://github.com/puppetlabs/vanagon/compare/0.15.30...HEAD
+[Unreleased]: https://github.com/puppetlabs/vanagon/compare/0.15.31...HEAD
+[0.15.31]: https://github.com/puppetlabs/vanagon/compare/0.15.30...0.15.31
 [0.15.30]: https://github.com/puppetlabs/vanagon/compare/0.15.29...0.15.30
 [0.15.29]: https://github.com/puppetlabs/vanagon/compare/0.15.28...0.15.29
 [0.15.28]: https://github.com/puppetlabs/vanagon/compare/0.15.27...0.15.28

--- a/lib/vanagon/component/source/rewrite.rb
+++ b/lib/vanagon/component/source/rewrite.rb
@@ -75,7 +75,7 @@ class Vanagon
           #   instead. This method will be removed before Vanagon 1.0.0.
           def parse_and_rewrite(uri)
             return uri if rewrite_rules.empty?
-            if uri.match?(/^git:http/)
+            if !!uri.match(/^git:http/)
               warn <<-HERE.undent
                 `fustigit` parsing doesn't get along with how we specify the source
                 type by prefixing `git`. As `rewrite_rules` are deprecated, we'll


### PR DESCRIPTION
This wasn't added until Ruby 2.4 and vanagon supports back to 2.3.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.