### PR TITLE
(VANAGON-155) Add 'none' repo target to the repo binary

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,7 +21,7 @@ Lint/EnsureReturn:
   Enabled: true
 
 # MAYBE useful - errors when rescue {} happens.
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Enabled: true
 
 Lint/ShadowingOuterLocalVariable:
@@ -115,7 +115,7 @@ Lint/ParenthesesAsGroupedExpression:
 Lint/RescueException:
   Enabled: false
 
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Enabled: false
 
 Lint/UnusedBlockArgument:
@@ -145,13 +145,13 @@ Style/Alias:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-Layout/AlignArray:
+Layout/ArrayAlignment:
   Enabled: false
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: false
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Enabled: false
 
 Metrics/BlockNesting:
@@ -190,7 +190,7 @@ Style/RedundantCondition:
 Style/SafeNavigation:
   Enabled: false
 
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Enabled: false
 
 Naming/RescuedExceptionsVariableName:
@@ -224,7 +224,7 @@ Style/WordArray:
 Style/RedundantPercentQ:
   Enabled: false
 
-Layout/AlignArguments:
+Layout/ArgumentAlignment:
   Enabled: false
 
 Layout/Tab:
@@ -233,7 +233,7 @@ Layout/Tab:
 Layout/SpaceBeforeSemicolon:
   Enabled: true
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: false
 
 Layout/SpaceInsideBlockBraces:
@@ -318,10 +318,10 @@ Style/EachWithObject:
 Layout/EmptyLineBetweenDefs:
   Enabled: false
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   Enabled: false
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   Enabled: false
 
 Layout/IndentationConsistency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Added
+- (VANAGON-155) Added `none` option to the `repo` binary so that repo can be
+  called without deb or rpm packages. This will be helpful in packaging pipelines
+  that do not always build deb or rpm packages.
 
 ## [0.15.31] - released on 2019-11-14
 ### Fixed

--- a/bin/repo
+++ b/bin/repo
@@ -20,6 +20,8 @@ when 'rpm'
   Pkg::Util::RakeUtils.invoke_task('pl:jenkins:rpm_repos')
 when 'deb'
   Pkg::Util::RakeUtils.invoke_task('pl:jenkins:deb_repos')
+when 'none'
+  $stdout.puts "Skipping repo generation since repo target is set to 'none'"
 else
   Pkg::Util::RakeUtils.invoke_task('pl:jenkins:rpm_repos')
   Pkg::Util::RakeUtils.invoke_task('pl:jenkins:deb_repos')


### PR DESCRIPTION
This will enable users to run `repo` when there are no rpm or deb
packages. This will be helpful in pipelines where you may only be
building for platforms without repositories.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.