### PR TITLE
(VANAGON-144) Load metadata from upstream projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Added
+- (VANAGON-144) Add ability to load `build_metadata` from another project. This
+  is useful when loading settings from another project. If you're loading settings
+  via `inherit_settings` the `build_metadata` will automatically be loaded. If
+  you're loading settings via `inherit_yaml_settings` you'll need to add the named
+  parameter `metadata_uri` and set that to the `file://` or `http://` location
+  of the upstream metadata json file.
+
 ### Fixed
 - (VANAGON-112) Fix undefined variable in warning message for version/release from git.
 

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -334,8 +334,9 @@ class Vanagon
       #
       # @param yaml_settings_uri [String] URI (file://... or http://...) to a file containing a yaml representation of vanagon settings
       # @param yaml_settings_sha1_uri [String] URI (file://... or http://...) to a file the sha1sum for the settings file
-      def inherit_yaml_settings(yaml_settings_uri, yaml_settings_sha1_uri = nil)
+      def inherit_yaml_settings(yaml_settings_uri, yaml_settings_sha1_uri = nil, metadata_uri: nil)
         @project.load_yaml_settings(yaml_settings_uri, yaml_settings_sha1_uri)
+        @project.load_upstream_metadata(metadata_uri) if metadata_uri
       end
 
       # Set a package override. Will call the platform-specific implementation

--- a/spec/lib/vanagon/platform/windows_spec.rb
+++ b/spec/lib/vanagon/platform/windows_spec.rb
@@ -19,6 +19,7 @@ WORKDIR = "#{WORK_BASE}/workdir"
 WIXTESTFILES = File.expand_path("./spec/fixtures/wix/resources/windows/wix")
 
 describe "Vanagon::Platform::Windows" do
+  let(:configdir) { '/a/b/c' }
   platforms =[
     {
       :name                   => "windows-2012r2-x64",
@@ -75,7 +76,7 @@ describe "Vanagon::Platform::Windows" do
         it "skips package generation for 'archive' package types" do
           cur_plat.instance_eval(plat[:block])
           cur_plat.package_type 'archive'
-          proj = Vanagon::Project::DSL.new('test-fixture', cur_plat._platform, [])
+          proj = Vanagon::Project::DSL.new('test-fixture', configdir, cur_plat._platform, [])
           proj.instance_eval(project_block)
           expect(cur_plat._platform.generate_package(proj._project)).to eq([])
         end
@@ -83,7 +84,7 @@ describe "Vanagon::Platform::Windows" do
         it "generates a package_name for 'archive' package types" do
           cur_plat.instance_eval(plat[:block])
           cur_plat.package_type 'archive'
-          proj = Vanagon::Project::DSL.new('test-fixture', cur_plat._platform, [])
+          proj = Vanagon::Project::DSL.new('test-fixture', configdir, cur_plat._platform, [])
           proj.instance_eval(project_block)
           expect(cur_plat._platform.package_name(proj._project)).to eq('test-fixture-0.0.0-archive')
         end
@@ -91,7 +92,7 @@ describe "Vanagon::Platform::Windows" do
         it "skips packaging artifact generation for 'archive' package types" do
           cur_plat.instance_eval(plat[:block])
           cur_plat.package_type 'archive'
-          proj = Vanagon::Project::DSL.new('test-fixture', cur_plat._platform, [])
+          proj = Vanagon::Project::DSL.new('test-fixture', configdir, cur_plat._platform, [])
           proj.instance_eval(project_block)
           expect(cur_plat._platform.generate_packaging_artifacts('',proj._project.name,'',proj._project)).to eq(nil)
         end
@@ -207,7 +208,7 @@ describe "Vanagon::Platform::Windows" do
         describe "generate_wix_dirs" do
 
           it "returns one directory with install_service defaults" do
-            proj = Vanagon::Project::DSL.new('test-fixture', vanagon_platform, [])
+            proj = Vanagon::Project::DSL.new('test-fixture', configdir, vanagon_platform, [])
             proj.instance_eval(project_block)
             cur_plat.instance_eval(plat[:block])
             comp = Vanagon::Component::DSL.new('service-test', {}, cur_plat._platform)
@@ -223,7 +224,7 @@ describe "Vanagon::Platform::Windows" do
           end
 
           it "returns one directory with non-default name" do
-            proj = Vanagon::Project::DSL.new('test-fixture', vanagon_platform, [])
+            proj = Vanagon::Project::DSL.new('test-fixture', configdir, vanagon_platform, [])
             proj.instance_eval(project_block)
             cur_plat.instance_eval(plat[:block])
             comp = Vanagon::Component::DSL.new('service-test', {}, cur_plat._platform)
@@ -239,7 +240,7 @@ describe "Vanagon::Platform::Windows" do
           end
 
           it "returns nested directory correctly with \\" do
-            proj = Vanagon::Project::DSL.new('test-fixture', vanagon_platform, [])
+            proj = Vanagon::Project::DSL.new('test-fixture', configdir, vanagon_platform, [])
             proj.instance_eval(project_block)
             cur_plat.instance_eval(plat[:block])
             comp = Vanagon::Component::DSL.new('service-test', {}, cur_plat._platform)
@@ -259,7 +260,7 @@ describe "Vanagon::Platform::Windows" do
 
 
           it "adds a second directory for the same input but different components" do
-            proj = Vanagon::Project::DSL.new('test-fixture', vanagon_platform, [])
+            proj = Vanagon::Project::DSL.new('test-fixture', configdir, vanagon_platform, [])
             proj.instance_eval(project_block)
             cur_plat.instance_eval(plat[:block])
             comp = Vanagon::Component::DSL.new('service-test', {}, cur_plat._platform)
@@ -278,7 +279,7 @@ describe "Vanagon::Platform::Windows" do
           end
 
           it "returns correctly formatted multiple nested directories" do
-            proj = Vanagon::Project::DSL.new('test-fixture', vanagon_platform, [])
+            proj = Vanagon::Project::DSL.new('test-fixture', configdir, vanagon_platform, [])
             proj.instance_eval(project_block)
             cur_plat.instance_eval(plat[:block])
             comp = Vanagon::Component::DSL.new('service-test-1', {}, cur_plat._platform)

--- a/spec/lib/vanagon/project/dsl_spec.rb
+++ b/spec/lib/vanagon/project/dsl_spec.rb
@@ -14,8 +14,7 @@ end" }
 
   describe '#version_from_git' do
     it 'sets the version based on the git describe' do
-      expect(Vanagon::Driver).to receive(:configdir).and_return(configdir)
-      proj = Vanagon::Project::DSL.new('test-fixture', platform)
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform)
       proj.instance_eval(project_block)
 
       # Lying is bad. You shouldn't lie. But sometimes when you're
@@ -37,8 +36,7 @@ end" }
       expect(proj._project.version).to eq('1.2.3.1234')
     end
     it 'sets the version based on the git describe with multiple dashes' do
-      expect(Vanagon::Driver).to receive(:configdir).and_return(configdir)
-      proj = Vanagon::Project::DSL.new('test-fixture', platform)
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform)
       proj.instance_eval(project_block)
 
       # See previous description of "indescribable cyclopean obelisk"
@@ -62,8 +60,7 @@ end" }
       tag = double
       log = double
       diff = double
-      expect(Vanagon::Driver).to receive(:configdir).and_return(configdir)
-      proj = Vanagon::Project::DSL.new('test-fixture', platform)
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform)
       proj.instance_eval(project_block)
       repo = double("repo")
       expect(::Git)
@@ -93,8 +90,7 @@ end" }
         '3.8' => '3.8',
       }
 
-      expect(Vanagon::Driver).to receive(:configdir).exactly(branches.length).times.and_return(configdir)
-      proj = Vanagon::Project::DSL.new('test-fixture', platform)
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform)
       proj.instance_eval(project_block)
 
       branches.each do |branch, version|
@@ -118,8 +114,7 @@ end" }
         'just-a-branch-name'
       ]
 
-      expect(Vanagon::Driver).to receive(:configdir).exactly(branches.length).times.and_return(configdir)
-      proj = Vanagon::Project::DSL.new('test-fixture', platform)
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform)
       proj.instance_eval(project_block)
 
       branches.each do |branch|
@@ -140,7 +135,7 @@ end" }
 
   describe '#directory' do
     it 'adds a directory to the list of directories' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform)
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform)
       proj.instance_eval(project_block)
       proj.directory('/a/b/c/d', mode: '0755')
       expect(proj._project.directories).to include(Vanagon::Common::Pathname.new('/a/b/c/d', mode: '0755'))
@@ -149,7 +144,7 @@ end" }
 
   describe '#user' do
     it 'sets a user for the project' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform)
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform)
       proj.instance_eval(project_block)
       proj.user('test-user')
       expect(proj._project.user).to eq(Vanagon::Common::User.new('test-user'))
@@ -158,7 +153,7 @@ end" }
 
   describe '#target_repo' do
     it 'sets the target_repo for the project' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform)
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform)
       proj.instance_eval(project_block)
       proj.target_repo "pc1"
       expect(proj._project.repo).to eq("pc1")
@@ -167,7 +162,7 @@ end" }
 
   describe '#noarch' do
     it 'sets noarch on the project to true' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform)
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform)
       proj.instance_eval(project_block)
       proj.noarch
       expect(proj._project.noarch).to eq(true)
@@ -176,20 +171,20 @@ end" }
 
   describe '#generate_source_artifacts' do
     it 'defaults to false' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform)
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform)
       proj.instance_eval(project_block)
       expect(proj._project.source_artifacts).to eq(false)
     end
 
     it 'sets source_artifacts to true' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform)
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform)
       proj.instance_eval(project_block)
       proj.generate_source_artifacts true
       expect(proj._project.source_artifacts).to eq(true)
     end
 
     it 'sets source_artifacts to false' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform)
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform)
       proj.instance_eval(project_block)
       proj.generate_source_artifacts false
       expect(proj._project.source_artifacts).to eq(false)
@@ -198,7 +193,7 @@ end" }
 
   describe '#identifier' do
     it 'sets the identifier for the project' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform)
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform)
       proj.instance_eval(project_block)
       proj.identifier "com.example"
       expect(proj._project.identifier).to eq("com.example")
@@ -207,14 +202,14 @@ end" }
 
   describe '#cleanup_during_build' do
     it 'sets @cleanup to true' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform)
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform)
       proj.instance_eval(project_block)
       proj.cleanup_during_build
       expect(proj._project.cleanup).to eq(true)
     end
 
     it 'defaults to nil' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform)
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform)
       proj.instance_eval(project_block)
       expect(proj._project.cleanup).to be_nil
     end
@@ -224,7 +219,7 @@ end" }
     let(:version_file) { '/opt/puppetlabs/puppet/VERSION' }
 
     it 'sets version_file for the project' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform)
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform)
       proj.instance_eval(project_block)
       proj.write_version_file(version_file)
       expect(proj._project.version_file.path).to eq(version_file)
@@ -233,14 +228,14 @@ end" }
 
   describe "#release" do
     it 'sets the release for the project' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform)
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform)
       proj.instance_eval(project_block)
       proj.release '12'
       expect(proj._project.release).to eq('12')
     end
 
     it 'defaults to 1' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform)
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform)
       proj.instance_eval(project_block)
       expect(proj._project.release).to eq('1')
     end
@@ -249,7 +244,6 @@ end" }
   describe "#provides" do
     before do
       allow_any_instance_of(Vanagon::Project::DSL).to receive(:puts)
-      allow(Vanagon::Driver).to receive(:configdir).and_return(configdir)
       @el_plat = Vanagon::Platform::DSL.new('el-5-x86_64')
       @el_plat.instance_eval("platform 'el-5-x86_64' do |plat| end")
       @deb_plat = Vanagon::Platform::DSL.new('ubuntu-16.04-amd64')
@@ -257,7 +251,7 @@ end" }
     end
 
     it 'adds the package provide to the list of provides' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform)
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform)
       proj.instance_eval(project_block)
       proj.provides('thing1')
       proj.provides('thing2')
@@ -269,7 +263,7 @@ end" }
     # we don't actually use deb versions for provides at this point, but
     # testing it works nonetheless
     it 'supports deb versioned provides' do
-      proj = Vanagon::Project::DSL.new('test-fixture', @deb_plat._platform, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, @deb_plat._platform, [])
       proj.instance_eval(project_block)
       proj.provides('thing1', '1.2.3')
       expect(proj._project.get_provides.count).to eq(1)
@@ -288,7 +282,7 @@ end" }
         '=' => '='
       }
       operators.each do |initial, munged|
-        proj = Vanagon::Project::DSL.new('test-fixture', @deb_plat._platform, [])
+        proj = Vanagon::Project::DSL.new('test-fixture', configdir, @deb_plat._platform, [])
         proj.instance_eval(project_block)
         proj.provides('thing1', "#{initial}1.2.3")
         expect(proj._project.get_provides.count).to eq(1)
@@ -300,7 +294,7 @@ end" }
     it 'adds whitespace for rpm versions' do
       operators=['<','>','<=','>=','=']
       operators.each do |operator|
-        proj = Vanagon::Project::DSL.new('test-fixture', @el_plat._platform, [])
+        proj = Vanagon::Project::DSL.new('test-fixture', configdir, @el_plat._platform, [])
         proj.instance_eval(project_block)
         proj.provides('thing1', "#{operator}1.2.3")
         expect(proj._project.get_provides.count).to eq(1)
@@ -310,7 +304,7 @@ end" }
     end
 
     it 'supports versioned provides' do
-      proj = Vanagon::Project::DSL.new('test-fixture', @el_plat._platform, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, @el_plat._platform, [])
       proj.instance_eval(project_block)
       proj.provides('thing1', '1.2.3')
       expect(proj._project.get_provides.count).to eq(1)
@@ -319,7 +313,7 @@ end" }
      end
 
     it 'gets rid of duplicates' do
-      proj = Vanagon::Project::DSL.new('test-fixture', @el_plat._platform, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, @el_plat._platform, [])
       proj.instance_eval(project_block)
       proj.provides('thing1', '1.2.3')
       proj.provides('thing1', '>=1.2.3')
@@ -332,7 +326,6 @@ end" }
   describe "#replaces" do
     before do
       allow_any_instance_of(Vanagon::Project::DSL).to receive(:puts)
-      allow(Vanagon::Driver).to receive(:configdir).and_return(configdir)
       @el_plat = Vanagon::Platform::DSL.new('el-5-x86_64')
       @el_plat.instance_eval("platform 'el-5-x86_64' do |plat| end")
       @deb_plat = Vanagon::Platform::DSL.new('ubuntu-16.04-amd64')
@@ -340,7 +333,7 @@ end" }
     end
 
     it 'adds the package replacement to the list of replacements' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform)
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform)
       proj.instance_eval(project_block)
       proj.replaces('thing1')
       proj.replaces('thing2')
@@ -350,7 +343,7 @@ end" }
      end
 
     it 'supports versioned replaces' do
-      proj = Vanagon::Project::DSL.new('test-fixture', @el_plat._platform, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, @el_plat._platform, [])
       proj.instance_eval(project_block)
       proj.replaces('thing1', '1.2.3')
       expect(proj._project.get_replaces.count).to eq(1)
@@ -359,7 +352,7 @@ end" }
     end
 
     it 'supports deb versioned replaces' do
-      proj = Vanagon::Project::DSL.new('test-fixture', @deb_plat._platform, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, @deb_plat._platform, [])
       proj.instance_eval(project_block)
       proj.replaces('thing1', '1.2.3')
       expect(proj._project.get_replaces.count).to eq(1)
@@ -376,7 +369,7 @@ end" }
         '=' => '='
       }
       operators.each do |initial, munged|
-        proj = Vanagon::Project::DSL.new('test-fixture', @deb_plat._platform, [])
+        proj = Vanagon::Project::DSL.new('test-fixture', configdir, @deb_plat._platform, [])
         proj.instance_eval(project_block)
         proj.replaces('thing1', "#{initial}1.2.3")
         expect(proj._project.get_replaces.count).to eq(1)
@@ -388,7 +381,7 @@ end" }
     it 'adds whitespace for rpm versions' do
       operators=['<','>','<=','>=','=']
       operators.each do |operator|
-        proj = Vanagon::Project::DSL.new('test-fixture', @el_plat._platform, [])
+        proj = Vanagon::Project::DSL.new('test-fixture', configdir, @el_plat._platform, [])
         proj.instance_eval(project_block)
         proj.replaces('thing1', "#{operator}1.2.3")
         expect(proj._project.get_replaces.count).to eq(1)
@@ -398,7 +391,7 @@ end" }
     end
 
     it 'gets rid of duplicates' do
-      proj = Vanagon::Project::DSL.new('test-fixture', @el_plat._platform, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, @el_plat._platform, [])
       proj.instance_eval(project_block)
       proj.replaces('thing1', '1.2.3')
       proj.replaces('thing1', '<1.2.3')
@@ -411,7 +404,6 @@ end" }
   describe "#conflicts" do
     before do
       allow_any_instance_of(Vanagon::Project::DSL).to receive(:puts)
-      allow(Vanagon::Driver).to receive(:configdir).and_return(configdir)
       @el_plat = Vanagon::Platform::DSL.new('el-5-x86_64')
       @el_plat.instance_eval("platform 'el-5-x86_64' do |plat| end")
       @deb_plat = Vanagon::Platform::DSL.new('ubuntu-16.04-amd64')
@@ -419,7 +411,7 @@ end" }
     end
 
     it 'adds the package conflict to the list of conflicts' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform)
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform)
       proj.instance_eval(project_block)
       proj.conflicts('thing1')
       proj.conflicts('thing2')
@@ -429,7 +421,7 @@ end" }
      end
 
     it 'supports versioned conflicts' do
-      proj = Vanagon::Project::DSL.new('test-fixture', @el_plat._platform, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, @el_plat._platform, [])
       proj.instance_eval(project_block)
       proj.conflicts('thing1', '1.2.3')
       expect(proj._project.get_conflicts.count).to eq(1)
@@ -438,7 +430,7 @@ end" }
      end
 
     it 'supports deb versioned conflicts' do
-      proj = Vanagon::Project::DSL.new('test-fixture', @deb_plat._platform, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, @deb_plat._platform, [])
       proj.instance_eval(project_block)
       proj.conflicts('thing1', '1.2.3')
       expect(proj._project.get_conflicts.count).to eq(1)
@@ -455,7 +447,7 @@ end" }
         '=' => '='
       }
       operators.each do |initial, munged|
-        proj = Vanagon::Project::DSL.new('test-fixture', @deb_plat._platform, [])
+        proj = Vanagon::Project::DSL.new('test-fixture', configdir, @deb_plat._platform, [])
         proj.instance_eval(project_block)
         proj.conflicts('thing1', "#{initial}1.2.3")
         expect(proj._project.get_conflicts.count).to eq(1)
@@ -467,7 +459,7 @@ end" }
     it 'adds whitespace for rpm versions' do
       operators=['<','>','<=','>=','=']
       operators.each do |operator|
-        proj = Vanagon::Project::DSL.new('test-fixture', @el_plat._platform, [])
+        proj = Vanagon::Project::DSL.new('test-fixture', configdir, @el_plat._platform, [])
         proj.instance_eval(project_block)
         proj.conflicts('thing1', "#{operator}1.2.3")
         expect(proj._project.get_conflicts.count).to eq(1)
@@ -477,7 +469,7 @@ end" }
     end
 
     it 'gets rid of duplicates' do
-      proj = Vanagon::Project::DSL.new('test-fixture', @el_plat._platform, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, @el_plat._platform, [])
       proj.instance_eval(project_block)
       proj.conflicts('thing1', '1.2.3')
       proj.conflicts('thing1', '<1.2.3')
@@ -496,7 +488,6 @@ end"
 
     before do
       allow_any_instance_of(Vanagon::Project::DSL).to receive(:puts)
-      allow(Vanagon::Driver).to receive(:configdir).and_return(configdir)
       @el_plat = Vanagon::Platform::DSL.new('el-5-x86_64')
       @el_plat.instance_eval("platform 'el-5-x86_64' do |plat| end")
       @osx_plat = Vanagon::Platform::DSL.new('osx-10.10-x86_64')
@@ -505,13 +496,13 @@ end"
     end
 
     it 'adds package_overrides on supported platforms' do
-      proj = Vanagon::Project::DSL.new('test-fixture', @el_plat._platform, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, @el_plat._platform, [])
       proj.instance_eval(project_block)
       expect(proj._project.package_overrides).to include("TEST_VAR='foo'")
     end
 
     it 'fails on usupported platforms' do
-      proj = Vanagon::Project::DSL.new('test-fixture', @osx_plat._platform, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, @osx_plat._platform, [])
       expect{ proj.instance_eval(project_block) }.to raise_error(RuntimeError)
     end
   end
@@ -527,24 +518,23 @@ end"
 
     before do
       allow_any_instance_of(Vanagon::Project::DSL).to receive(:puts)
-      allow(Vanagon::Driver).to receive(:configdir).and_return(configdir)
       allow(Vanagon::Component).to receive(:load_component).with('some-component', any_args).and_return(component)
     end
 
     it 'stores the component in the project if the included components set is empty' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform, [])
       proj.instance_eval(project_block)
       expect(proj._project.components).to include(component)
     end
 
     it 'stores the component in the project if the component name is listed in the included components set' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform, ['some-component'])
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform, ['some-component'])
       proj.instance_eval(project_block)
       expect(proj._project.components).to include(component)
     end
 
     it 'does not store the component if the included components set is not empty and does not include the component name' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform, ['some-different-component'])
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform, ['some-different-component'])
       proj.instance_eval(project_block)
       expect(proj._project.components).to_not include(component)
     end
@@ -568,19 +558,19 @@ end"
     }
 
     it 'has an empty project.fetch_artifact when fetch_artifact is not called' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform, [])
       proj.instance_eval(empty_project_block)
       expect(proj._project.artifacts_to_fetch).to eq([])
     end
 
     it 'Adds a path to project.fetch_artifact when fetch_artifact is called' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform, [])
       proj.instance_eval(project_block)
       expect(proj._project.artifacts_to_fetch).to eq(['foo/bar/baz.file'])
     end
 
     it 'Adds multiple paths to project.fetch_artifact when fetch_artifact is called more than once' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform, [])
       proj.instance_eval(project_block_multiple)
       expect(proj._project.artifacts_to_fetch).to eq(['foo/bar/baz.file', 'foo/foobar/foobarbaz.file'])
     end
@@ -603,19 +593,19 @@ end"
     }
 
     it 'has no_packaging set to false by default' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform, [])
       proj.instance_eval(empty_project_block)
       expect(proj._project.no_packaging).to eq(false)
     end
 
     it 'sets no_packaging to true when proj.no_packaging true is called' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform, [])
       proj.instance_eval(project_block)
       expect(proj._project.no_packaging).to eq(true)
     end
 
     it 'sets no_packaging to false when proj.no_packaging false is called' do
-      proj = Vanagon::Project::DSL.new('test-fixture', platform, [])
+      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform, [])
       proj.instance_eval(project_block_false)
       expect(proj._project.no_packaging).to eq(false)
     end


### PR DESCRIPTION
Add ability to load upstream metadata when inheriting settings from other projects.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.