### PR TITLE
(maint) Move info output to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.15.34] - released on 2020-04-28
+### Fixed
+- (maint) Move informational output about loading inherited metadata to stderr
+  instead of stdout.
+
 ## [0.15.33] - released on 2020-04-14
 ### Added
 - (VANAGON-144) Add ability to load `build_metadata` from another project. This
@@ -837,7 +842,8 @@ on Debian < 8 and needs more work and testing.
 
 ## Versions <= 0.3.9 do not have a change log entry
 
-[Unreleased]: https://github.com/puppetlabs/vanagon/compare/0.15.33...HEAD
+[Unreleased]: https://github.com/puppetlabs/vanagon/compare/0.15.34...HEAD
+[0.15.34]: https://github.com/puppetlabs/vanagon/compare/0.15.33...0.15.34
 [0.15.33]: https://github.com/puppetlabs/vanagon/compare/0.15.32...0.15.33
 [0.15.32]: https://github.com/puppetlabs/vanagon/compare/0.15.31...0.15.32
 [0.15.31]: https://github.com/puppetlabs/vanagon/compare/0.15.30...0.15.31

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ group(:development, :test) do
   gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99')
   gem 'rake', require: false
   gem 'rspec', '~> 3.0', require: false
-  gem 'rubocop', "~> 0.75", require: false
+  gem 'rubocop', "~> 0.81.0", require: false
   gem 'simplecov', require: false
   gem 'yard', require: false
 end

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -822,7 +822,7 @@ class Vanagon
     end
 
     def load_upstream_metadata(metadata_uri)
-      puts "Loading metadata from #{metadata_uri}"
+      warn "Loading metadata from #{metadata_uri}"
       case metadata_uri
       when /^http/
         @upstream_metadata = JSON.parse(Net::HTTP.get(URI(metadata_uri)))


### PR DESCRIPTION
A variety of projects are very dependent on having minimal output to
stdout, so general practice with vanagon has been to print all
informative log messages to stderr to avoid breakages here.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.