### PR TITLE
(maint) el-8 __debug_package breakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- (maint) Another el-8 debug_package fix that we missed the first time.
 
 ## [0.15.35] - released on 2020-04-29
 ### Fixed

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -331,6 +331,10 @@ class Vanagon
       return !!@name.match(/^(el|redhat|redhatfips)-.*$/)
     end
 
+    def is_el8?
+      return !!@name.match(/^(el|redhat|redhatfips)-8.*$/)
+    end
+
     # Utility matcher to determine is the platform is a sles variety
     #
     # @return [true, false] true if it is a sles variety, false otherwise

--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -33,6 +33,12 @@
 <%= var %>
 <% end -%>
 
+# This breaks on el8. This is a hack to unblock development.
+<%- if @platform.is_el8? %>
+%undefine __debug_package
+<% end -%>
+
+
 # To avoid files installed but not packaged errors
 %global __os_install_post %{__os_install_post} \
     rm -rf %{buildroot}/usr/lib/debug


### PR DESCRIPTION
The __debug_package macro handling on el8 suddenly broke. Not sure
why. This will hack around the problem until we understand it more.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.