### PR TITLE
(maint) Build el-8 packages without build-id files

### DIFF
--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -36,6 +36,9 @@
 # This breaks on el8. This is a hack to unblock development.
 <%- if @platform.is_el8? %>
 %undefine __debug_package
+
+# Build el-8 packages without build-id files to prevent collision
+%define _build_id_links none
 <% end -%>
 
 


### PR DESCRIPTION
this was causing collision errors

Please add all notable changes to the "Unreleased" section of the CHANGELOG.