### PR TITLE
(maint) Output valid JSON build metadata

### DIFF
--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -504,6 +504,7 @@ class Vanagon
       end
 
       metadata.gsub!(/\n/, '\n')
+      metadata.gsub!(/\"/, '\"')
       [
         "mkdir output",
         "mkdir #{archive_directory}",


### PR DESCRIPTION
As part of the build process we run `echo -e "#{metadata}" >
output/foo.json` where `metadata` is a JSON string. This doesn't
consistently preserve double quotes, causing the resulting file to be
invalid JSON. This PR escapes the double quotes in the metadata before
echoing to ensure the resulting json file can be consumed.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.