### PR TITLE
(maint) Don't regenerate build metadata for archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- (maint) Fix for invalid build metadata JSON when generating compiled archives.
 
 ## [0.15.37] - released on 2020-05-06
 ### Changed

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -140,7 +140,7 @@ class Vanagon
       @project.make_bill_of_materials(workdir)
       # Don't generate packaging artifacts if no_packaging is set
       @project.generate_packaging_artifacts(workdir) unless @project.no_packaging
-      @project.save_manifest_json(@platform)
+      @project.save_manifest_json(@platform, workdir)
       @engine.ship_workdir(workdir)
       @engine.dispatch("(cd #{@engine.remote_workdir}; #{@platform.make} #{make_target})")
       @engine.retrieve_built_artifact(@project.artifacts_to_fetch, @project.no_packaging)

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -486,9 +486,9 @@ class Vanagon
     def generate_compiled_archive(project)
       name_and_version = "#{project.name}-#{project.version}"
       name_and_version_and_platform = "#{name_and_version}.#{name}"
+      name_and_platform = "#{project.name}.#{name}"
       final_archive = "output/#{name_and_version_and_platform}.tar.gz"
       archive_directory = "#{project.name}-archive"
-      metadata = project.build_manifest_json(true)
 
       # previously, we weren't properly handling the case of custom BOM paths.
       # If we have a custom BOM path, during Makefile execution, the top-level
@@ -503,7 +503,6 @@ class Vanagon
         bill_of_materials_command = "mv .#{project.bill_of_materials.path}/bill-of-materials ../.."
       end
 
-      metadata.gsub!(/\n/, '\n')
       [
         "mkdir output",
         "mkdir #{archive_directory}",
@@ -511,7 +510,7 @@ class Vanagon
         "rm #{name_and_version}.tar.gz",
         "cd #{archive_directory}/#{name_and_version}; #{bill_of_materials_command}; #{tar} cf ../../#{name_and_version_and_platform}.tar *",
         "gzip -9c #{name_and_version_and_platform}.tar > #{name_and_version_and_platform}.tar.gz",
-        "echo -e \"#{metadata}\" > output/#{name_and_version_and_platform}.json",
+        "cp build_metadata.#{name_and_platform}.json output/#{name_and_version_and_platform}.json",
         "cp bill-of-materials output/#{name_and_version_and_platform}-bill-of-materials ||:",
         "cp #{name_and_version_and_platform}.tar.gz output",
         "#{shasum} #{final_archive} > #{final_archive}.sha1"

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -714,20 +714,27 @@ class Vanagon
     # Writes a json file at `ext/build_metadata.<project>.<platform>.json` containing information
     # about what went into a built artifact
     #
-    # @return [Hash] of build information
-    def save_manifest_json(platform)
+    # @param platform [String] platform we're writing metadata for
+    # @param additional_directories [String|Array[String]] additional
+    #        directories to write build_metadata.<project>.<platform>.json to
+    def save_manifest_json(platform, additional_directories = nil) # rubocop:disable Metrics/AbcSize
       manifest = build_manifest_json
       metadata = metadata_merge(manifest, @upstream_metadata)
 
       ext_directory = 'ext'
       FileUtils.mkdir_p ext_directory
 
+      directories = [ext_directory, additional_directories].compact
       metadata_file_name = "build_metadata.#{name}.#{platform.name}.json"
-      File.open(File.join(ext_directory, metadata_file_name), 'w') do |f|
-        f.write(JSON.pretty_generate(metadata))
+      directories.each do |directory|
+        File.open(File.join(directory, metadata_file_name), 'w') do |f|
+          f.write(JSON.pretty_generate(metadata))
+        end
       end
 
       ## VANAGON-132 Backwards compatibility: make a 'build_metadata.json' file
+      # No need to propagate this backwards compatibility to the new additional
+      # directories
       File.open(File.join(ext_directory, 'build_metadata.json'), 'w') do |f|
         f.write(JSON.pretty_generate(metadata))
       end


### PR DESCRIPTION
We were previously regenerating the build_metadata when building
archives (i.e. for puppet-runtime). This change will make it so that
when we're writing the metadata out to the `ext` directory we also write
it out to the vanagon workdir so we have access to it on the build
host.

Prior to these changes, the build metadata file that landed in the
`output` directory contained invalid json. This fixes that issue.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.