### PR TITLE
(RE-13303) Add support for signing additional files for windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ### Fixed
 - (maint) Fix for invalid build metadata JSON when generating compiled archives.
 
+### Added
+- (RE-13303) Add the ability to sign additional files on windows during the MSI
+build step.
+
 ## [0.15.37] - released on 2020-05-06
 ### Changed
 - (maint) Build el-8 packages without build-id files to prevent collision errors.

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -108,6 +108,14 @@ class Vanagon
     # you just want to perform installation and pull down a file.
     attr_accessor :no_packaging
 
+    # Extra files to sign
+    # Right now just supported on windows, useful for signing powershell scripts
+    # that need to be signed between build and MSI creation
+    attr_accessor :extra_files_to_sign
+    attr_accessor :signing_hostname
+    attr_accessor :signing_username
+    attr_accessor :signing_command
+
     # Loads a given project from the configdir
     #
     # @param name [String] the name of the project
@@ -156,6 +164,10 @@ class Vanagon
       @upstream_metadata = {}
       @no_packaging = false
       @artifacts_to_fetch = []
+      @extra_files_to_sign = []
+      @signing_hostname = ''
+      @signing_username = ''
+      @signing_command = ''
     end
 
     # Magic getter to retrieve settings in the project

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -363,6 +363,39 @@ class Vanagon
       def no_packaging(var)
         @project.no_packaging = var
       end
+
+      # Set to sign additional files during buildtime. Only implemented for
+      # windows. Can be specified more than once
+      #
+      # @param [String] file to sign
+      def extra_file_to_sign(file)
+        @project.extra_files_to_sign << file
+      end
+
+      # The hostname to sign additional files on. Only does anything when there
+      # are extra files to sign
+      #
+      # @param [String] hostname of the machine to run the extra file signing on
+      def signing_hostname(hostname)
+        @project.signing_hostname = hostname
+      end
+
+      # The username to log in to the signing_hostname as. Only does anything
+      # when there are extra files to sign
+      #
+      # @param [String] the username to log in to `signing_hostname` as
+      def signing_username(username)
+        @project.signing_username = username
+      end
+
+      # The command to run to sign additional files. The command should assume
+      # it will have the file path appended to the end of the command, since
+      # files end up in a temp directory.
+      #
+      # @param [String] the command to sign additional files
+      def signing_command(command)
+        @project.signing_command = command
+      end
     end
   end
 end


### PR DESCRIPTION
This will allow us to do things like sign installer powershell scripts
that get bundled into the MSI.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.