### PR TITLE
(RE-13296) Follow redirects when installing rpm or deb repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ## [Unreleased]
 ### Fixed
 - (maint) Fix for invalid build metadata JSON when generating compiled archives.
+- (RE-13296) Follow redirects when installing rpm/deb repos.
 
 ## [0.15.37] - released on 2020-05-06
 ### Changed

--- a/lib/vanagon/platform/deb.rb
+++ b/lib/vanagon/platform/deb.rb
@@ -140,7 +140,7 @@ class Vanagon
         @tar = "tar"
         @patch = "/usr/bin/patch"
         @num_cores = "/usr/bin/nproc"
-        @curl = "curl --silent --show-error --fail"
+        @curl = "curl --silent --show-error --fail --location"
         @valid_operators = ['<', '>', '<=', '>=', '=', '<<', '>>']
         super(name)
       end

--- a/lib/vanagon/platform/rpm.rb
+++ b/lib/vanagon/platform/rpm.rb
@@ -103,7 +103,7 @@ class Vanagon
         @patch ||= "/usr/bin/patch"
         @num_cores ||= "/bin/grep -c 'processor' /proc/cpuinfo"
         @rpmbuild ||= "/usr/bin/rpmbuild"
-        @curl = "curl --silent --show-error --fail"
+        @curl = "curl --silent --show-error --fail --location"
         super(name)
       end
     end


### PR DESCRIPTION
This adds the `--location` tag to the curl call to follow any redirects.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.