### PR TITLE
(VANAGON-100) Allow the use of docker exec instead of SSH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+- (VANAGON-100) Allow `--engine docker` to use `docker exec` and `docker cp`
+  instead of `ssh` and `rsync` by setting `use_docker_exec true` in a
+  platform definition.
+
 ## [0.15.38] - released on 2020-06-16
 ### Fixed
 - (maint) Fix for invalid build metadata JSON when generating compiled archives.

--- a/lib/vanagon/engine/docker.rb
+++ b/lib/vanagon/engine/docker.rb
@@ -10,6 +10,7 @@ class Vanagon
 
         @docker_cmd = Vanagon::Utilities.find_program_on_path('docker')
         @required_attributes << "docker_image"
+        @required_attributes.delete('ssh_port') if @platform.use_docker_exec
       end
 
       # Get the engine name
@@ -33,25 +34,16 @@ class Vanagon
       # This method is used to obtain a vm to build upon using
       # a docker container.
       # @raise [Vanagon::Error] if a target cannot be obtained
-      def select_target # rubocop:disable Metrics/AbcSize
+      def select_target
+        ssh_args = @platform.use_docker_exec ? '' : "-p #{@platform.ssh_port}:22"
         extra_args = @platform.docker_run_args.nil? ? [] : @platform.docker_run_args
 
-        Vanagon::Utilities.ex("#{@docker_cmd} run -d --name #{build_host_name}-builder -p #{@platform.ssh_port}:22 #{extra_args.join(' ')} #{@platform.docker_image}")
+        Vanagon::Utilities.ex("#{@docker_cmd} run -d --name #{build_host_name}-builder #{ssh_args} #{extra_args.join(' ')} #{@platform.docker_image}")
         @target = 'localhost'
 
-        # Wait for ssh to come up in the container. Retry 5 times with a 1
-        # second sleep between errors to account for network resets while SSHD
-        # is starting. Allow a maximum of 5 seconds for SSHD to start.
-        Vanagon::Utilities.retry_with_timeout(5, 5) do
-          begin
-            Vanagon::Utilities.remote_ssh_command("#{@target_user}@#{@target}", 'exit', @platform.ssh_port)
-          rescue StandardError => e
-            sleep(1) # Give SSHD some time to start.
-            raise e
-          end
-        end
+        wait_for_ssh unless @platform.use_docker_exec
       rescue StandardError => e
-        raise Vanagon::Error.wrap(e, "Something went wrong getting a target vm to build on using docker. Ssh was not up in the container after 5 seconds.")
+        raise Vanagon::Error.wrap(e, "Something went wrong getting a target vm to build on using Docker.")
       end
 
       # This method is used to tell the vmpooler to delete the instance of the
@@ -61,6 +53,93 @@ class Vanagon
         Vanagon::Utilities.ex("#{@docker_cmd} rm #{build_host_name}-builder")
       rescue Vanagon::Error => e
         warn "There was a problem tearing down the docker container #{build_host_name}-builder (#{e.message})."
+      end
+
+      def dispatch(command, return_output = false)
+        if @platform.use_docker_exec
+          docker_exec(command, return_output)
+        else
+          super
+        end
+      end
+
+      def ship_workdir(workdir)
+        if @platform.use_docker_exec
+          docker_cp_globs_to("#{workdir}/*", @remote_workdir)
+        else
+          super
+        end
+      end
+
+      def retrieve_built_artifact(artifacts_to_fetch, no_packaging)
+        if @platform.use_docker_exec
+          output_path = 'output/'
+          FileUtils.mkdir_p(output_path)
+          unless no_packaging
+            artifacts_to_fetch << "#{@remote_workdir}/output/*"
+          end
+
+          docker_cp_globs_from(artifacts_to_fetch, 'output/')
+        else
+          super
+        end
+      end
+
+      # Execute a command on a container via docker exec
+      def docker_exec(command, return_output = false)
+        command = command.gsub("'", "'\\\\''")
+        Vanagon::Utilities.local_command("#{@docker_cmd} exec #{build_host_name}-builder /bin/sh -c '#{command}'",
+                                         return_command_output: return_output)
+      end
+
+      # Copy files between a container and the host
+      def docker_cp(source, target)
+        Vanagon::Utilities.ex("#{@docker_cmd} cp '#{source}' '#{target}'")
+      end
+
+      # Copy files matching a glob pattern from the host to the container
+      def docker_cp_globs_to(globs, container_path)
+        Array(globs).each do |glob|
+          Dir.glob(glob).each do |path|
+            docker_cp(path, "#{build_host_name}-builder:#{container_path}")
+          end
+        end
+      end
+
+      # Copy files matching a glob pattern from the container to the host
+      #
+      # @note Globs are expanded by running `/bin/sh` in the container, which
+      #   may not support the same variety of expressions as Ruby's `Dir.glob`.
+      #   For example, `**` may not work.
+      def docker_cp_globs_from(globs, host_path)
+        Array(globs).each do |glob|
+          paths = docker_exec(%(for file in #{glob};do [ -e "$file" ] && printf '%s\\0' "${file}";done), true).split("\0")
+
+          paths.each do |path|
+            docker_cp("#{build_host_name}-builder:#{path}", host_path)
+          end
+        end
+      end
+
+      # Wait for ssh to come up in the container
+      #
+      # Retry 5 times with a 1 second sleep between errors to account for
+      # network resets while SSHD is starting. Allow a maximum of 5 seconds for
+      # SSHD to start.
+      #
+      # @raise [Vanagon::Error] if a SSH connection cannot be established.
+      # @return [void]
+      def wait_for_ssh
+        Vanagon::Utilities.retry_with_timeout(5, 5) do
+          begin
+            Vanagon::Utilities.remote_ssh_command("#{@target_user}@#{@target}", 'exit', @platform.ssh_port)
+          rescue StandardError => e
+            sleep(1) # Give SSHD some time to start.
+            raise e
+          end
+        end
+      rescue StandardError => e
+        raise Vanagon::Error.wrap(e, "SSH was not up in the container after 5 seconds.")
       end
     end
   end

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -115,6 +115,7 @@ class Vanagon
     # Docker engine specific
     attr_accessor :docker_image
     attr_accessor :docker_run_args
+    attr_accessor :use_docker_exec
 
     # AWS engine specific
     attr_accessor :aws_ami
@@ -237,6 +238,8 @@ class Vanagon
       @sort ||= "sort"
       @copy ||= "cp"
       @shasum ||= "sha1sum"
+
+      @use_docker_exec = false
 
       # Our first attempt at defining metadata about a platform
       @cross_compiled ||= false

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -284,6 +284,17 @@ class Vanagon
         @platform.docker_run_args = Array(args)
       end
 
+      # Specify whether to use Docker exec instead of SSH to run commands
+      #
+      # This also causes Vanagon to use `docker cp` instead of `rsync` when
+      # copying files.
+      #
+      # @param bool [Boolean] a boolean value indicating whether to use
+      #   `docker exec` and `docker cp` over `ssh` and `rsync`.
+      def use_docker_exec(bool)
+        @platform.use_docker_exec = bool
+      end
+
       # Set the ami for the platform to use
       #
       # @param ami [String] the ami id used.

--- a/spec/lib/vanagon/engine/docker_spec.rb
+++ b/spec/lib/vanagon/engine/docker_spec.rb
@@ -2,20 +2,24 @@ require 'vanagon/engine/docker'
 require 'vanagon/platform'
 
 describe Vanagon::Engine::Docker do
-  let (:platform_with_docker_image) {
-    plat = Vanagon::Platform::DSL.new('debian-6-i386')
-    plat.instance_eval("platform 'debian-6-i386' do |plat|
-                      plat.docker_image 'debian-6-i386'
-                    end")
+  let (:platform_with_docker_image) do
+    plat = Vanagon::Platform::DSL.new('debian-10-amd64')
+    plat.instance_eval(<<~EOF)
+      platform 'debian-10-amd64' do |plat|
+        plat.docker_image 'debian:10-slim'
+      end
+    EOF
     plat._platform
-  }
+  end
 
-  let (:platform_without_docker_image) {
-    plat = Vanagon::Platform::DSL.new('debian-6-i386')
-    plat.instance_eval("platform 'debian-6-i386' do |plat|
-                    end")
+  let (:platform_without_docker_image) do
+    plat = Vanagon::Platform::DSL.new('debian-10-amd64')
+    plat.instance_eval(<<~EOF)
+      platform 'debian-10-amd64' do |plat|
+      end
+    EOF
     plat._platform
-  }
+  end
 
   let(:platform_with_docker_exec) do
     plat = Vanagon::Platform::DSL.new('debian-10-amd64')
@@ -34,25 +38,25 @@ describe Vanagon::Engine::Docker do
         expect(FileTest).to receive(:executable?).with(File.join(path_elem, 'docker')).and_return(false)
       end
 
-      expect { Vanagon::Engine::Docker.new(platform_with_docker_image) }.to raise_error(RuntimeError)
+      expect { described_class.new(platform_with_docker_image) }.to raise_error(RuntimeError)
     end
   end
 
   describe "#validate_platform" do
     it 'raises an error if the platform is missing a required attribute' do
       expect(Vanagon::Utilities).to receive(:find_program_on_path).with('docker').and_return('/usr/bin/docker')
-      expect { Vanagon::Engine::Docker.new(platform_without_docker_image).validate_platform }.to raise_error(Vanagon::Error)
+      expect { described_class.new(platform_without_docker_image).validate_platform }.to raise_error(Vanagon::Error)
     end
 
     it 'returns true if the platform has the required attributes' do
       expect(Vanagon::Utilities).to receive(:find_program_on_path).with('docker').and_return('/usr/bin/docker')
-      expect(Vanagon::Engine::Docker.new(platform_with_docker_image).validate_platform).to be(true)
+      expect(described_class.new(platform_with_docker_image).validate_platform).to be(true)
     end
   end
 
   it 'returns "docker" name' do
     expect(Vanagon::Utilities).to receive(:find_program_on_path).with('docker').and_return('/usr/bin/docker')
-    expect(Vanagon::Engine::Docker.new(platform_with_docker_image).name).to eq('docker')
+    expect(described_class.new(platform_with_docker_image).name).to eq('docker')
   end
 
   describe '#dispatch' do


### PR DESCRIPTION
This changeset updates the Vanagon Docker image to allow the use of
`docker exec` and `docker cp` to be selected over `ssh` and `rsync`
by setting the `use_docker_exec` attribute to `true` in a
platform definition.

This change allows platform definitions to dispense with custom images
and SSH settings, which dramatically simplifies Docker configuration:

    platform 'debian-10-amd64' do |plat|
      # ...

      plat.docker_image 'debian:10-slim'
      # Vanagon starts detached containers, adding `--tty` and using a shell as
      # the entry point causes the container to persist for other commands to run.
      plat.docker_run_args ['--tty', '--entrypoint=/bin/sh']
      plat.use_docker_exec true
    end