### PR TITLE
(VANAGON-163) Fix engine selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+
+- (VANAGON-163) Vanagon now prioritizes the `--engine` CLI flag over logic
+  that picks the engine based on features used by the platform definition.
+
+### Added
 
 - (VANAGON-100) Allow `--engine docker` to use `docker exec` and `docker cp`
   instead of `ssh` and `rsync` by setting `use_docker_exec true` in a

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -29,7 +29,6 @@ class Vanagon
       components = options[:components] || []
       only_build = options[:only_build]
       target = options[:target]
-      engine = options[:engine] || 'pooler'
 
       @platform = Vanagon::Platform.load_platform(platform, File.join(@@configdir, "platforms"))
       @project = Vanagon::Project.load_project(project, File.join(@@configdir, "projects"), @platform, components)
@@ -40,7 +39,14 @@ class Vanagon
 
       @remote_workdir = options[:"remote-workdir"]
 
-      load_engine(engine, @platform, target)
+      if options[:engine]
+        # Use the explicitly configured engine.
+        load_engine_object(options[:engine], @platform, target)
+      else
+        # Use 'pooler' as a default, but also apply selection logic that may
+        # choose something different based on platform configuration.
+        load_engine('pooler', @platform, target)
+      end
     rescue LoadError => e
       raise Vanagon::Error.wrap(e, "Could not load the desired engine '#{engine}'")
     end

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -47,8 +47,6 @@ class Vanagon
         # choose something different based on platform configuration.
         load_engine('pooler', @platform, target)
       end
-    rescue LoadError => e
-      raise Vanagon::Error.wrap(e, "Could not load the desired engine '#{engine}'")
     end
 
     def filter_out_components(only_build)
@@ -79,8 +77,8 @@ class Vanagon
     def load_engine_object(engine_type, platform, target)
       require "vanagon/engine/#{engine_type}"
       @engine = Object::const_get("Vanagon::Engine::#{camelize(engine_type)}").new(platform, target, remote_workdir: remote_workdir)
-    rescue StandardError
-      fail "No such engine '#{camelize(engine_type)}'"
+    rescue StandardError, ScriptError => e
+      raise Vanagon::Error.wrap(e, "Could not load the desired engine '#{engine_type}'")
     end
 
     def camelize(string)


### PR DESCRIPTION
Vanagon has a bunch of logic for picking an engine based on the
configuration of the platform and other bits of info. This is
all well and good, but the logic was applied even when a user
had explicitly passed the `--engine` option to the CLI.

This patchset updates the Vanagon::Driver to skip the selection
logic when an engine has been explicitly chosen.

Additionally, error handling for engine loads is improved by
preserving the stack trace and original error message raise
instead of claiming all engine load failures are due to the
engine not existing.