### PR TITLE
(DIO-1066) Update vanagon to go through ABS for VMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+- (DIO-1066) Update vanagon to go through ABS for VMs. Before this change,
+  the ABS engine was partially implemented.
+  This engine is a level of abstraction that supports any downstream
+  engine (vmpooler, nspooler, AWS) and is forward compatible with
+  ondemand Vmpooler pools. Used internally at Puppet
 
 ## [0.16.1] - released 2020-09-18
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Added
 - (DIO-1066) Update vanagon to go through ABS for VMs. Before this change,
   the ABS engine was partially implemented.
   This engine is a level of abstraction that supports any downstream

--- a/Gemfile
+++ b/Gemfile
@@ -29,5 +29,6 @@ group(:development, :test) do
   gem 'rspec', '~> 3.0', require: false
   gem 'rubocop', "~> 0.81.0", require: false
   gem 'simplecov', require: false
+  gem 'webmock', '3.9.3'
   gem 'yard', require: false
 end

--- a/README.md
+++ b/README.md
@@ -154,9 +154,10 @@ Currently supported engines are:
 * `base` - Pure ssh backend; no teardown currently defined
 * `local` - Build on the local machine; platform name must match the local machine
 * `docker` - Builds in a docker container
-* `pooler` - Selects a vm from Puppet Labs' vm pooler to build on
+* `pooler` - Selects a vm from Puppet's internal vmpooler to build on
 * `hardware` - Build on a specific taget and lock it in redis
 * `ec2` - Build on a specific AWS instance.
+* `ABS` - Selects a vm from Puppet's internal Always-be-scheduling service to build on
 
 #### Flags
 
@@ -310,6 +311,16 @@ platform "el-7-x86_64" do |plat|
 end
 ```
 
+### ABS (internal)
+When using the ABS engine, there is a variety of ways you can specify your token: 
+- the environment variable ABS_TOKEN
+- or vanagon token file ~/.vanagon-token (note this is the same file read by the pooler engine)
+- or [vmfloaty](https://github.com/puppetlabs/vmfloaty)'s config file ~/.vmfloaty.yml
+
+In order to modify or track the VM via floaty or bit-bar you can optionally add the vmpooler token (different from the ABS token) via
+- VMPOOLER_TOKEN
+- or as a second line to the file ~/.vanagon-token
+- or by using the existing mechanism in floaty using a vmpooler_fallback
 
 Contributing
 ---

--- a/lib/vanagon/engine/always_be_scheduling.rb
+++ b/lib/vanagon/engine/always_be_scheduling.rb
@@ -1,5 +1,6 @@
-require 'vanagon/engine/base'
 require 'json'
+require 'vanagon/engine/base'
+require 'yaml'
 
 class Vanagon
   class Engine
@@ -82,9 +83,15 @@ class Vanagon
     # {"name":"aix-53-ppc","engine":"always_be_scheduling"}
     # ```
     class AlwaysBeScheduling < Base
+      attr_reader :token
+      attr_reader :token_vmpooler
+
       def initialize(platform, target, **opts)
         super
 
+        @available_abs_endpoint = "https://abs-prod.k8s.infracore.puppet.net/api/v2"
+        @token_vmpooler = ENV['VMPOOLER_TOKEN']
+        @token = load_token
         Vanagon::Driver.logger.debug "AlwaysBeScheduling engine invoked."
       end
 
@@ -94,6 +101,7 @@ class Vanagon
       end
 
       # return the platform name as the "host" name
+      # order of preference: abs_resource_name, vmpooler_template or name
       def build_host_name
         if @platform.abs_resource_name
           @platform.abs_resource_name
@@ -102,6 +110,272 @@ class Vanagon
         else
           @platform.name
         end
+      end
+
+      # Retrieve the ABS token from an environment variable
+      # ("ABS_TOKEN") or from a number of potential configuration
+      # files (~/.vanagon-token or ~/.vmfloaty.yml).
+      # @return [String, nil] token for use with the vmpooler
+      def load_token
+        ENV['ABS_TOKEN'] || token_from_file
+      end
+
+      # a wrapper method around retrieving a token,
+      # with an explicitly ordered preference for a Vanagon-specific
+      # token file or a preexisting vmfoaty yaml file.
+      #
+      # @return [String, nil] token for use with the vmpooler
+      def token_from_file
+        read_vanagon_token || read_vmfloaty_token
+      end
+      private :token_from_file
+
+      # Read an ABS/vmpooler token from the plaintext vanagon-token file,
+      # as outlined in the project README.
+      # The first line should be the ABS token
+      # and the second (optional) line should be the vmpooler token
+      # Saves the second line into the @token_vmpooler variable
+      #
+      # @return [String, nil] the vanagon vmpooler token value
+      def read_vanagon_token(path = "~/.vanagon-token")
+        absolute_path = File.expand_path(path)
+        return nil unless File.exist?(absolute_path)
+
+        warn "Reading ABS token from: #{path}"
+        contents = File.read(absolute_path).chomp
+        lines = []
+        contents.each_line do |l|
+          lines << l.chomp
+        end
+
+        abs = lines.shift
+        @token_vmpooler = lines.shift
+
+        warn "Please add a second line with the vmpooler token to be able to modify or see the VM in floaty/bit-bar" if @token_vmpooler.nil?
+        return abs
+      end
+      private :read_vanagon_token
+
+      # Read a vmpooler token from the yaml formatted vmfloaty config,
+      # as outlined by the vmfloaty project:
+      # https://github.com/puppetlabs/vmfloaty
+      #
+      # It returns the top-level token value or the first 'abs' service
+      # token value it finds in the services list
+      # it sets @token_vmpooler with the optional vmpooler token
+      # if the abs services has a vmpooler_fallback, and that service
+      # has a token eg
+      #
+      # TOP-LEVEL DEFINED  => would get only the abs token
+      # user: 'jdoe'
+      # url: 'https://abs.example.net'
+      # token: '456def789'
+      #
+      # MULTIPLE SERVICES DEFINED => would get the abs token in 'abs-prod' and the vmpooler token in 'vmpooler-prod'
+      # user: 'jdoe'
+      # services:
+      #   abs-prod:
+      #     type: 'abs'
+      #     url: 'https://abs.example.net/api/v2'
+      #     token: '123abc456'
+      #     vmpooler_fallback: 'vmpooler-prod'
+      #   vmpooler-dev:
+      #     type: 'vmpooler'
+      #     url: 'https://vmpooler-dev.example.net'
+      #     token: '987dsa654'
+      #   vmpooler-prod:
+      #     type: 'vmpooler'
+      #     url: 'https://vmpooler.example.net'
+      #     token: '456def789'
+      #
+      # @return [String, nil] the vmfloaty vmpooler token value
+      def read_vmfloaty_token(path = "~/.vmfloaty.yml") # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
+        absolute_path = File.expand_path(path)
+        return nil unless File.exist?(absolute_path)
+
+        yaml_config = YAML.load_file(absolute_path)
+        abs_token = nil
+        abs_service_name = nil
+        if yaml_config['token'] # top level
+          abs_token = yaml_config['token']
+        elsif yaml_config['services']
+          yaml_config['services'].each do |name, value|
+            if value['type'] == "abs" && value['token']
+              abs_token = value['token']
+              abs_service_name = name
+              vmpooler_fallback = value['vmpooler_fallback']
+              unless vmpooler_fallback.nil? || yaml_config['services'][vmpooler_fallback].nil? || yaml_config['services'][vmpooler_fallback]['token'].nil?
+                @token_vmpooler = yaml_config['services'][vmpooler_fallback]['token']
+              end
+              break
+            end
+          end
+        end
+        message = "Reading ABS token from: #{path}"
+        if abs_service_name
+          message.concat(" for service named #{abs_service_name}")
+          if @token_vmpooler.nil?
+            message.concat(" but there was no vmpooler_fallback value, please add one if you want to be able to modify the VM via bit-bar/floaty")
+          else
+            message.concat(" with a vmpooler_fallback token")
+          end
+        end
+        warn message
+        abs_token
+      end
+      private :read_vmfloaty_token
+
+      # This method is used to obtain a vm to build upon using Puppet's internal
+      # ABS (https://github.com/puppetlabs/always-be-scheduling) which is a level of abstraction for other
+      # engines using similar APIs
+      # @raise [Vanagon::Error] if a target cannot be obtained
+      def select_target
+        @pooler = select_target_from(@available_abs_endpoint)
+        raise Vanagon::Error, "Something went wrong getting a target vm to build on" if @pooler.empty?
+      end
+
+      # Attempt to provision a host from a specific pooler.
+      def select_target_from(pooler) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
+        req_obj = build_request_object
+
+        warn "Requesting VMs with job_id: #{@saved_job_id}.  Will poll for up to an hour."
+        #the initial request is always replied with "come back again"
+        response = Vanagon::Utilities.http_request_generic(
+          "#{pooler}/request",
+          'POST',
+          req_obj.to_json,
+          { 'X-AUTH-TOKEN' => @token }
+        )
+
+        unless response.code == "202"
+          warn "failed to request ABS with code #{response.code}"
+          if valid_json?(response.body)
+            response_json = JSON.parse(response.body)
+            warn "reason: #{response_json['reason']}"
+          end
+          return ''
+        end
+
+        retries = 360 # ~ one hour
+        begin
+          (1..retries).each do |i|
+            response = check_queue(pooler, req_obj)
+            break if response
+
+            sleep_seconds = 10 if i >= 10
+            sleep_seconds = i if i < 10
+            warn "Waiting #{sleep_seconds} seconds to check if ABS request has been filled. (x#{i})"
+
+            sleep(sleep_seconds)
+          end
+        rescue SystemExit, Interrupt
+          warn "\nVanagon interrupted during mains ABS polling. Make sure you delete the requested job_id #{@saved_job_id}"
+          raise
+        end
+
+        res_body = translated(response, @saved_job_id)
+        if res_body["ok"]
+          @target = res_body[build_host_name]['hostname']
+          Vanagon::Driver.logger.info "Reserving #{@target} (#{build_host_name}) [#{@token ? 'token used' : 'no token used'}]"
+        else
+          pooler = ''
+        end
+        pooler
+      end
+
+      def check_queue(pooler, req_obj)
+        response = Vanagon::Utilities.http_request_generic(
+          "#{pooler}/request",
+          'POST',
+          req_obj.to_json,
+          { 'X-AUTH-TOKEN' => @token }
+        )
+        res_body = validate_queue_status_response(response.code, response.body)
+        res_body
+      end
+
+      def validate_queue_status_response(status_code, body)
+        case status_code
+        when "200"
+          return JSON.parse(body) unless body.empty? || !valid_json?(body)
+        when "202"
+          return nil
+        when "401"
+          raise Vanagon::Error, "HTTP #{status_code}: The token provided could not authenticate.\n#{body}"
+        when "503"
+          return nil
+        else
+          raise Vanagon::Error, "HTTP #{status_code}: request to ABS failed!\n#{body}"
+        end
+      end
+
+      # This method is used to tell the ABS to delete the job_id requested
+      # otherwise the resources will eventually get allocated asynchronously
+      # and will keep running until the end of their lifetime.
+      def teardown # rubocop:disable Metrics/AbcSize
+        req_obj = {
+            'job_id' => @saved_job_id,
+        }
+
+        response = Vanagon::Utilities.http_request_generic(
+          "#{@available_abs_endpoint}/return",
+          "POST",
+          req_obj.to_json,
+          { 'X-AUTH-TOKEN' => @token }
+        )
+        if response && response.body == 'OK'
+          Vanagon::Driver.logger.info "#{@saved_job_id} has been scheduled for removal"
+          warn "#{@saved_job_id} has been scheduled for removal"
+        else
+          Vanagon::Driver.logger.info "#{@saved_job_id} could not be scheduled for removal: #{response.body}"
+          warn "#{@saved_job_id} could not be scheduled for removal"
+        end
+      rescue Vanagon::Error => e
+        Vanagon::Driver.logger.info "#{@saved_job_id} could not be scheduled for removal (#{e.message})"
+        warn "#{@saved_job_id} could not be scheduled for removal (#{e.message})"
+      end
+
+      private
+
+      def translated(res_body, job_id)
+        vmpooler_formatted_body = { 'job_id' => job_id }
+
+        res_body.each do |host| # in this context there should be only one host
+          vmpooler_formatted_body[host['type']] = { 'hostname' => host['hostname'] }
+        end
+        vmpooler_formatted_body['ok'] = true
+
+        vmpooler_formatted_body
+      end
+
+      def build_request_object
+        user = ENV['USER'] || ENV['USERNAME'] || 'unknown'
+
+        @saved_job_id = user + "-" + DateTime.now.strftime('%Q')
+        req_obj       = {
+            :resources => { build_host_name => 1 },
+            :job       => {
+                :id   => @saved_job_id,
+                :tags => {
+                    :jenkins_build_url => ENV['BUILD_URL'],
+                    :project           => ENV['JOB_NAME'] || 'vanagon',
+                    :created_by        => user,
+                    :user              => user
+                },
+            },
+            :priority => 1, # DO NOT use priority 1 in automated CI runs
+        }
+        unless @token_vmpooler.nil?
+          req_obj[:vm_token] = @token_vmpooler
+        end
+        req_obj
+      end
+
+      def valid_json?(json)
+        JSON.parse(json)
+        return true
+      rescue TypeError, JSON::ParserError
+        return false
       end
     end
   end

--- a/lib/vanagon/engine/pooler.rb
+++ b/lib/vanagon/engine/pooler.rb
@@ -1,6 +1,10 @@
 require 'vanagon/engine/base'
 require 'yaml'
 
+### Note this class is deprecated in favor of using the ABS Engine. The pooler has changed it's API with regards to
+# getting VMs for ondemand provisioning and would need to be updated here.
+# See DIO-1066
+
 class Vanagon
   class Engine
     class Pooler < Base
@@ -10,7 +14,7 @@ class Vanagon
       def initialize(platform, target = nil, **opts)
         super
 
-        @available_poolers = ["http://vmpooler.delivery.puppetlabs.net", "https://nspooler-service-prod-1.delivery.puppetlabs.net"]
+        @available_poolers = ["https://vmpooler.delivery.puppetlabs.net", "https://nspooler-service-prod-1.delivery.puppetlabs.net"]
         @token = load_token
         @required_attributes << "vmpooler_template"
       end
@@ -63,7 +67,7 @@ class Vanagon
 
       # Read a vmpooler token from the yaml formatted vmfloaty config,
       # as outlined by the vmfloaty project:
-      # https://github.com/briancain/vmfloaty
+      # https://github.com/puppetlabs/vmfloaty
       #
       # @return [String, nil] the vmfloaty vmpooler token value
       def read_vmfloaty_token(path = "~/.vmfloaty.yml")
@@ -75,7 +79,7 @@ class Vanagon
       end
       private :read_vmfloaty_token
 
-      # This method is used to obtain a vm to build upon using the Puppet Labs'
+      # This method is used to obtain a vm to build upon using Puppet's internal
       # vmpooler (https://github.com/puppetlabs/vmpooler) or other pooler technologies
       # leveraging the same API
       # @raise [Vanagon::Error] if a target cannot be obtained

--- a/spec/lib/vanagon/engine/always_be_scheduling_spec.rb
+++ b/spec/lib/vanagon/engine/always_be_scheduling_spec.rb
@@ -2,6 +2,7 @@ require 'vanagon/engine/always_be_scheduling'
 require 'vanagon/driver'
 require 'vanagon/platform'
 require 'logger'
+require 'spec_helper'
 
 class Vanagon
   class Driver
@@ -45,6 +46,8 @@ describe 'Vanagon::Engine::AlwaysBeScheduling' do
                     end")
     plat._platform
   }
+  let(:pooler_token_file) { File.expand_path('~/.vanagon-token') }
+  let(:floaty_config) { File.expand_path('~/.vmfloaty.yml') }
 
   describe '#validate_platform' do
     it 'returns true if the platform has the required attributes' do
@@ -79,6 +82,115 @@ describe 'Vanagon::Engine::AlwaysBeScheduling' do
     it 'returns "always_be_scheduling" engine name' do
       expect(Vanagon::Engine::AlwaysBeScheduling.new(platform, nil).name)
         .to eq('always_be_scheduling')
+    end
+  end
+
+  describe '#read_vanagon_token' do
+    it 'takes the first line for abs token, second line is optional' do
+      token_value = 'decade'
+      allow(File).to receive(:exist?)
+                         .with(pooler_token_file)
+                         .and_return(true)
+
+      allow(File).to receive(:read)
+                         .with(pooler_token_file)
+                         .and_return(token_value)
+
+      abs_service = Vanagon::Engine::AlwaysBeScheduling.new(platform, nil)
+      expect(abs_service.token).to eq('decade')
+      expect(abs_service.token_vmpooler).to eq(nil)
+    end
+    it 'takes the second line as vmpooler token' do
+      token_value = "decade\nanddaycade"
+      allow(File).to receive(:exist?)
+                         .with(pooler_token_file)
+                         .and_return(true)
+
+      allow(File).to receive(:read)
+                         .with(pooler_token_file)
+                         .and_return(token_value)
+
+      abs_service = Vanagon::Engine::AlwaysBeScheduling.new(platform, nil)
+      expect(abs_service.token).to eq('decade')
+      expect(abs_service.token_vmpooler).to eq('anddaycade')
+    end
+  end
+
+  describe '#read_vmfloaty_token' do
+    before :each do
+      allow(File).to receive(:exist?)
+                         .with(pooler_token_file)
+                         .and_return(false)
+
+      allow(File).to receive(:exist?)
+                         .with(floaty_config)
+                         .and_return(true)
+    end
+    token_value = 'decade'
+    it %(reads a token from '~/.vmfloaty.yml at the top level') do
+      allow(YAML).to receive(:load_file)
+                         .with(floaty_config)
+                         .and_return({'token' => token_value})
+
+      abs_service = Vanagon::Engine::AlwaysBeScheduling.new(platform, nil)
+      expect(abs_service.token).to eq(token_value)
+      expect(abs_service.token_vmpooler).to eq(nil)
+    end
+    it %(reads a token from '~/.vmfloaty.yml in the abs service') do
+      allow(YAML).to receive(:load_file)
+                         .with(floaty_config)
+                         .and_return({'services' =>
+                                          {'MYabs' => {'type'=>'abs', 'token'=>token_value, 'url'=>'foo'}}
+                                     })
+
+      abs_service = Vanagon::Engine::AlwaysBeScheduling.new(platform, nil)
+      expect(abs_service.token).to eq(token_value)
+      expect(abs_service.token_vmpooler).to eq(nil)
+    end
+    it %(reads a token from '~/.vmfloaty.yml in the abs service and includes the vmpooler token') do
+      vmp_token_value = 'deecade'
+      allow(YAML).to receive(:load_file)
+                         .with(floaty_config)
+                         .and_return({'services' =>
+                                          {'MYabs' => {'type'=>'abs', 'token'=>token_value, 'url'=>'foo', 'vmpooler_fallback' => 'myvmp'},
+                                           'myvmp' => {'token'=>vmp_token_value, 'url'=>'bar'}}
+                                     })
+
+      abs_service = Vanagon::Engine::AlwaysBeScheduling.new(platform, nil)
+      expect(abs_service.token).to eq(token_value)
+      expect(abs_service.token_vmpooler).to eq(vmp_token_value)
+    end
+  end
+  describe '#select_target_from' do
+    it 'runs successfully' do
+      hostname = 'faint-whirlwind.puppet.com'
+      stub_request(:post, "https://foobar/request").
+          to_return({status: 202, body: "", headers: {}},{status: 200, body: '[{"hostname":"'+hostname+'","type":"aix-6.1-ppc","engine":"nspooler"}]', headers: {}})
+      abs_service = Vanagon::Engine::AlwaysBeScheduling.new(platform, nil)
+      abs_service.select_target_from("https://foobar")
+      expect(abs_service.target).to eq(hostname)
+    end
+    it 'returns a warning if the first request is not a 202' do
+      hostname = 'fainter-whirlwind.puppet.com'
+      stub_request(:post, "https://foobar/request").
+          to_return({status: 404, body: "", headers: {}},{status: 200, body: '[{"hostname":"'+hostname+'","type":"aix-6.1-ppc","engine":"nspooler"}]', headers: {}})
+      allow_any_instance_of(Object).to receive(:warn)
+      expect_any_instance_of(Object).to receive(:warn).with("failed to request ABS with code 404")
+      abs_service = Vanagon::Engine::AlwaysBeScheduling.new(platform, nil)
+      pooler = abs_service.select_target_from("https://foobar")
+      expect(pooler).to eq('')
+    end
+    it 'returns a warning and retries until request is a 200' do
+      hostname = 'faintest-whirlwind.puppet.com'
+      stub_request(:post, "https://foobar/request").
+          to_return({status: 202, body: "", headers: {}},
+                    {status: 503, body: "", headers: {}},
+                    {status: 200, body: '[{"hostname":"'+hostname+'","type":"aix-6.1-ppc","engine":"nspooler"}]', headers: {}})
+      allow_any_instance_of(Object).to receive(:warn)
+      expect_any_instance_of(Object).to receive(:warn).with(/Waiting 1 seconds to check if ABS request has been filled/)
+      abs_service = Vanagon::Engine::AlwaysBeScheduling.new(platform, nil)
+      abs_service.select_target_from("https://foobar")
+      expect(abs_service.target).to eq(hostname)
     end
   end
 end

--- a/spec/lib/vanagon/engine/ec2_spec.rb
+++ b/spec/lib/vanagon/engine/ec2_spec.rb
@@ -27,6 +27,8 @@ if defined? ::Aws
     end
 
     it 'returns "ec2" name' do
+      stub_request(:get, "http://169.254.169.254/latest/meta-data/iam/security-credentials/").
+          to_return(status: 200, body: "", headers: {})
       expect(Vanagon::Engine::Ec2.new(platform_ec2).name).to eq('ec2')
     end
   end

--- a/spec/lib/vanagon/engine/pooler_spec.rb
+++ b/spec/lib/vanagon/engine/pooler_spec.rb
@@ -6,7 +6,7 @@ describe 'Vanagon::Engine::Pooler' do
   let (:platform_with_vcloud_name) {
     plat = Vanagon::Platform::DSL.new('debian-6-i386')
     plat.instance_eval("platform 'debian-6-i386' do |plat|
-                      plat.vcloud_name 'debian-6-i386'
+                      plat.vmpooler_template 'debian-6-i386'
                     end")
     plat._platform
   }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ end
 
 require 'tmpdir'
 require 'vanagon'
+require 'webmock/rspec'
 
 RSpec.configure do |c|
   c.before do


### PR DESCRIPTION
Before this change, the ABS engine was partially implemented.
It now includes the select_target and teardown methods needed for
vanagon build lifecycle.

This engine is thus a level of abstraction that supports any downstream
engine (vmpooler, nspooler, AWS) and is forward compatible with
ondemand Vmpooler pools.

The ABS token is read from env var ABS_TOKEN or the first line of ~/.vanagon-token
or the vmfloaty config (using top-level token or the first abs type service found)

The vmpooler token optionaly can be provided through an env var VMPOOLER_TOKEN
or the second line of ~/.vanagon-token or via vmfloaty's existing vmpooler_fallback config

The ABS request is done and checked for up to an hour, with feedback given on the
availability of resources. Teardown is done at the end using the job_id.

Users can track vm usage via bitbar or floaty if they provide a vmpooler token.