### PR TITLE
(maint) Overwrite unchanged config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- (maint) Pristine config files are no longer kept if there are no differences
+  between the pristine and the target config file (OS X and Solaris 10).
 
 ## [0.17.0] - released 2020-11-02
 ### Added

--- a/resources/osx/postinstall.erb
+++ b/resources/osx/postinstall.erb
@@ -5,7 +5,7 @@
 <%- get_configfiles.each do |config|
 dest_file = config.path.gsub(/\.pristine$/, '') -%>
 
-if [ -f "<%= dest_file %>" ]; then
+if [ -f "<%= dest_file %>" ] && ! diff "<%= config.path %>" "<%= dest_file %>" > /dev/null; then
   echo "Detected file at '<%= dest_file %>'; updated file at '<%= config.path %>'."
 else
   mv '<%= config.path %>' '<%= dest_file %>'

--- a/resources/solaris/10/postinstall.erb
+++ b/resources/solaris/10/postinstall.erb
@@ -9,7 +9,7 @@
 <%- get_configfiles.each do |config|
 dest_file = config.path.gsub(/\.pristine$/, '') -%>
 
-if [ -f "<%= dest_file %>" ]; then
+if [ -f "<%= dest_file %>" ] && ! diff "<%= config.path %>" "<%= dest_file %>" > /dev/null; then
   echo "Detected file at '<%= dest_file %>'; updated file at '<%= config.path %>'."
 else
   cp -pr '<%= config.path %>' '<%= dest_file %>'


### PR DESCRIPTION
Configuration files installed with `install_configfile` have the
`.pristine` extension appended to them, as a guard to avoid clobbering
existing configfiles.

OS X and Solaris 10 use postinstall scripts to manage configuration
files, removing the extension if a non-pristine config file does not
exist.

However, we don't need to keep the pristine files if there are no
differences between the pristine file and the target file. So, update
the logic to also run a `diff` between the two files. If there are no
differences, go ahead and override the target file.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.