### PR TITLE
(RE-13776) target argument handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ### Fixed
 - (maint) Pristine config files are no longer kept if there are no differences
   between the pristine and the target config file (OS X and Solaris 10).
+- (RE-13776) When target argument is specified, do not load the engine
 
 ## [0.17.0] - released 2020-11-02
 ### Added

--- a/lib/vanagon/cli/build.rb
+++ b/lib/vanagon/cli/build.rb
@@ -38,7 +38,7 @@ class Vanagon
 
         platform_list.zip(target_list).each do |pair|
           platform, target = pair
-          artifact = Vanagon::Driver.new(platform, project, options.merge({ 'target' => target }))
+          artifact = Vanagon::Driver.new(platform, project, options.merge({ :target => target }))
           artifact.run
         end
       end

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -20,7 +20,7 @@ class Vanagon
       @retry_count ||= @project.retry_count || ENV["VANAGON_RETRY_COUNT"] || 1
     end
 
-    def initialize(platform, project, options = { workdir: nil, configdir: nil, target: nil, engine: nil, components: nil, skipcheck: false, verbose: false, preserve: false, only_build: nil, remote_workdir: nil }) # rubocop:disable Metrics/AbcSize
+    def initialize(platform, project, options = { workdir: nil, configdir: nil, target: nil, engine: nil, components: nil, skipcheck: false, verbose: false, preserve: false, only_build: nil, remote_workdir: nil }) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
       @verbose = options[:verbose]
       @preserve = options[:preserve]
       @workdir = options[:workdir] || Dir.mktmpdir
@@ -28,7 +28,6 @@ class Vanagon
       @@configdir = options[:configdir] || File.join(Dir.pwd, "configs")
       components = options[:components] || []
       only_build = options[:only_build]
-      target = options[:target]
 
       @platform = Vanagon::Platform.load_platform(platform, File.join(@@configdir, "platforms"))
       @project = Vanagon::Project.load_project(project, File.join(@@configdir, "projects"), @platform, components)
@@ -39,8 +38,9 @@ class Vanagon
 
       @remote_workdir = options[:"remote-workdir"]
 
-      if options[:engine]
-        # Use the explicitly configured engine.
+      target = options[:target]
+      if options[:engine] && !target
+        # Use the explicitly configured engine if no target was provided.
         load_engine_object(options[:engine], @platform, target)
       else
         # Use 'pooler' as a default, but also apply selection logic that may


### PR DESCRIPTION
After commit https://github.com/puppetlabs/vanagon/commit/ac44f694dfa68de71c6e4153e9bf35dc129bfca5 the options hash passed to
https://github.com/puppetlabs/vanagon/blob/94573411754397aa1efc47bbb09705f088835eb0/lib/vanagon/driver.rb#L23
was changed and now contains `:engine` key, making code at
https://github.com/puppetlabs/vanagon/blob/94573411754397aa1efc47bbb09705f088835eb0/lib/vanagon/driver.rb#L42-L44
to always load the engine, even if `target` option is also present

After this commit, the specified engine will be loaded only if target argument is missing.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.