### PR TITLE
(VANAGON-79) Use VanagonLogger to classify output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
   `vanagon completion --shell SHELL`.Source the script to enable tab completion.
 - (PA-3497) Build arm64 debian packages for aarch64
 
+### Changed
+- (VANAGON-79) Use VanagonLogger class for  output instead of puts, warn, and 
+  and stderr. 
+
 ### Fixed
 - (maint) Pristine config files are no longer kept if there are no differences
   between the pristine and the target config file (OS X and Solaris 10).

--- a/bin/build
+++ b/bin/build
@@ -1,8 +1,10 @@
 #!/usr/bin/env ruby
 
+require 'vanagon/logger'
+
 script = File.basename($0)
 
-warn "#{script}: Warning: use of stand alone '#{script}' command is deprecated and may be removed.
+VanagonLogger.info "#{script}: Warning: use of stand alone '#{script}' command is deprecated and may be removed.
      Use: 'vanagon #{script}' instead."
 
 exec "vanagon", script, *ARGV

--- a/bin/build_host_info
+++ b/bin/build_host_info
@@ -1,8 +1,10 @@
 #!/usr/bin/env ruby
 
+require 'vanagon/logger'
+
 script = File.basename($0)
 
-warn "#{script}: Warning: use of stand alone '#{script}' command is deprecated and may be removed.
+VanagonLogger.info "#{script}: Warning: use of stand alone '#{script}' command is deprecated and may be removed.
      Use: 'vanagon #{script}' instead."
 
 exec "vanagon", script, *ARGV

--- a/bin/build_requirements
+++ b/bin/build_requirements
@@ -1,8 +1,10 @@
 #!/usr/bin/env ruby
 
+require 'vanagon/logger'
+
 script = File.basename($0)
 
-warn "#{script}: Warning: use of stand alone '#{script}' command is deprecated and may be removed.
+VanagonLogger.info "#{script}: Warning: use of stand alone '#{script}' command is deprecated and may be removed.
      Use: 'vanagon #{script}' instead."
 
 exec "vanagon", script, *ARGV

--- a/bin/inspect
+++ b/bin/inspect
@@ -1,8 +1,10 @@
 #!/usr/bin/env ruby
 
+require 'vanagon/logger'
+
 script = File.basename($0)
 
-warn "#{script}: Warning: use of stand alone '#{script}' command is deprecated and may be removed.
+VanagonLogger.info "#{script}: Warning: use of stand alone '#{script}' command is deprecated and may be removed.
      Use: 'vanagon #{script}' instead."
 
 exec "vanagon", script, *ARGV

--- a/bin/render
+++ b/bin/render
@@ -1,8 +1,10 @@
 #!/usr/bin/env ruby
 
+require 'vanagon/logger'
+
 script = File.basename($0)
 
-warn "#{script}: Warning: use of stand alone '#{script}' command is deprecated and may be removed.
+VanagonLogger.info "#{script}: Warning: use of stand alone '#{script}' command is deprecated and may be removed.
      Use: 'vanagon #{script}' instead."
 
 exec "vanagon", script, *ARGV

--- a/bin/repo
+++ b/bin/repo
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+require 'vanagon/logger'
+
 ENV["PROJECT_ROOT"] = Dir.pwd
 
 # Begin warning: This ship script is an internal tool.
@@ -21,7 +23,7 @@ when 'rpm'
 when 'deb'
   Pkg::Util::RakeUtils.invoke_task('pl:jenkins:deb_repos')
 when 'none'
-  $stdout.puts "Skipping repo generation since repo target is set to 'none'"
+  VanagonLogger.warn "Skipping repo generation since repo target is set to 'none'"
 else
   Pkg::Util::RakeUtils.invoke_task('pl:jenkins:rpm_repos')
   Pkg::Util::RakeUtils.invoke_task('pl:jenkins:deb_repos')

--- a/bin/ship
+++ b/bin/ship
@@ -1,8 +1,10 @@
 #!/usr/bin/env ruby
 
+require 'vanagon/logger'
+
 script = File.basename($0)
 
-warn "#{script}: Warning: use of stand alone '#{script}' command is deprecated and may be removed.
+VanagonLogger.info "#{script}: Warning: use of stand alone '#{script}' command is deprecated and may be removed.
      Use: 'vanagon #{script}' instead."
 
 exec "vanagon", script, *ARGV

--- a/bin/sign
+++ b/bin/sign
@@ -1,8 +1,10 @@
 #!/usr/bin/env ruby
 
+require 'vanagon/logger'
+
 script = File.basename($0)
 
-warn "#{script}: Warning: use of stand alone '#{script}' command is deprecated and may be removed.
+VanagonLogger.info "#{script}: Warning: use of stand alone '#{script}' command is deprecated and may be removed.
      Use: 'vanagon #{script}' instead."
 
 exec "vanagon", script, *ARGV

--- a/lib/vanagon/cli.rb
+++ b/lib/vanagon/cli.rb
@@ -15,6 +15,8 @@ require 'vanagon/cli/render'
 require 'vanagon/cli/ship'
 require 'vanagon/cli/sign'
 
+require 'vanagon/logger'
+
 
 class Vanagon
   class InvalidArgument < StandardError
@@ -66,7 +68,7 @@ class Vanagon
         puts DOCUMENTATION
         exit 0
       else
-        warn "vanagon: Error: unknown command: \"#{sub_command}\"\n\n#{DOCUMENTATION}"
+        VanagonLogger.error "vanagon: Error: unknown command: \"#{sub_command}\"\n\n#{DOCUMENTATION}"
         exit 1
       end
 
@@ -95,7 +97,7 @@ class Vanagon
     def parse_options(argv)
       Docopt.docopt(DOCUMENTATION, { argv: argv, options_first: true })
     rescue Docopt::Exit => e
-      puts e.message
+      VanagonLogger.error e.message
       exit 1
     end
   end

--- a/lib/vanagon/cli/build.rb
+++ b/lib/vanagon/cli/build.rb
@@ -1,4 +1,5 @@
 require 'docopt'
+require 'vanagon/logger'
 
 class Vanagon
   class CLI
@@ -24,7 +25,7 @@ class Vanagon
       def parse(argv)
         Docopt.docopt(DOCUMENTATION, { argv: argv })
       rescue Docopt::Exit => e
-        puts e.message
+        VanagonLogger.error e.message
         exit 1
       end
 

--- a/lib/vanagon/cli/build_host_info.rb
+++ b/lib/vanagon/cli/build_host_info.rb
@@ -1,4 +1,5 @@
 require 'docopt'
+require 'vanagon/logger'
 
 class Vanagon
   class CLI
@@ -18,7 +19,7 @@ class Vanagon
       def parse(argv)
         Docopt.docopt(DOCUMENTATION, { argv: argv })
       rescue Docopt::Exit => e
-        puts e.message
+        VanagonLogger.error e.message
         exit 1
       end
 
@@ -28,7 +29,7 @@ class Vanagon
 
         platforms.each do |platform|
           driver = Vanagon::Driver.new(platform, project, options)
-          $stdout.puts JSON.generate(driver.build_host_info)
+          VanagonLogger.warn JSON.generate(driver.build_host_info)
         end
       end
 

--- a/lib/vanagon/cli/build_requirements.rb
+++ b/lib/vanagon/cli/build_requirements.rb
@@ -1,5 +1,6 @@
 require 'docopt'
 require 'json'
+require 'vanagon/logger'
 
 class Vanagon
   class CLI
@@ -19,7 +20,7 @@ class Vanagon
       def parse(argv)
         Docopt.docopt(DOCUMENTATION, { argv: argv })
       rescue Docopt::Exit => e
-        puts e.message
+        VanagonLogger.error e.message
         exit 1
       end
 
@@ -39,9 +40,8 @@ class Vanagon
           end
         end
 
-        $stdout.puts
-        $stdout.puts "**** External packages required to build #{project} on #{platform}: ***"
-        $stdout.puts JSON.pretty_generate(build_requirements.flatten.uniq.sort)
+        VanagonLogger.warn "**** External packages required to build #{project} on #{platform}: ***"
+        VanagonLogger.warn JSON.pretty_generate(build_requirements.flatten.uniq.sort)
       end
 
       def options_translate(docopt_options)

--- a/lib/vanagon/cli/completion.rb
+++ b/lib/vanagon/cli/completion.rb
@@ -1,4 +1,5 @@
 require 'docopt'
+require 'vanagon/logger'
 
 class Vanagon
   class CLI
@@ -15,7 +16,7 @@ class Vanagon
       def parse(argv)
         Docopt.docopt(DOCUMENTATION, { argv: argv })
       rescue Docopt::Exit => e
-        puts e.message
+        VanagonLogger.error e.message
         exit 1
       end
 
@@ -24,10 +25,10 @@ class Vanagon
         completion_file = File.expand_path(File.join('..', '..', '..', '..', 'extras', 'completions', "vanagon.#{shell}"), __FILE__)
 
         if File.exist?(completion_file)
-          puts completion_file
+          VanagonLogger.warn completion_file
           exit 0
         else
-          puts "Could not find completion file for '#{shell}': No such file #{completion_file}"
+          VanagonLogger.error "Could not find completion file for '#{shell}': No such file #{completion_file}"
           exit 1
         end
       end

--- a/lib/vanagon/cli/inspect.rb
+++ b/lib/vanagon/cli/inspect.rb
@@ -1,5 +1,6 @@
 require 'docopt'
 require 'json'
+require 'vanagon/logger'
 
 class Vanagon
   class CLI
@@ -22,7 +23,7 @@ class Vanagon
       def parse(argv)
         Docopt.docopt(DOCUMENTATION, { argv: argv })
       rescue Docopt::Exit => e
-        puts e.message
+        VanagonLogger.error e.message
         exit 1
       end
 
@@ -33,7 +34,7 @@ class Vanagon
         platforms.each do |platform|
           driver = Vanagon::Driver.new(platform, project, options)
           components = driver.project.components.map(&:to_hash)
-          $stdout.puts JSON.pretty_generate(components)
+          VanagonLogger.warn JSON.pretty_generate(components)
         end
       end
 

--- a/lib/vanagon/cli/list.rb
+++ b/lib/vanagon/cli/list.rb
@@ -1,4 +1,5 @@
 require 'docopt'
+require 'vanagon/logger'
 
 class Vanagon
   class CLI
@@ -18,7 +19,7 @@ class Vanagon
       def parse(argv)
         Docopt.docopt(DOCUMENTATION, { argv: argv })
       rescue Docopt::Exit => e
-        puts e.message
+        VanagonLogger.error e.message
         exit 1
       end
 
@@ -31,7 +32,7 @@ class Vanagon
         if Dir.exist?(File.join(options[:configdir], 'platforms')) == false ||
            Dir.exist?(File.join(options[:configdir], 'projects')) == false
 
-          warn "Path to #{File.join(options[:configdir], 'platforms')} or #{File.join(options[:configdir], 'projects')} not found."
+          VanagonLogger.error "Path to #{File.join(options[:configdir], 'platforms')} or #{File.join(options[:configdir], 'projects')} not found."
           exit 1
         end
 
@@ -49,14 +50,12 @@ class Vanagon
         end
 
         if options[:projects]
-          puts "- Projects"
-          puts output(project_list, options[:use_spaces])
+          puts "- Projects", output(project_list, options[:use_spaces])
           return
         end
 
         if options[:platforms]
-          puts "- Platforms"
-          puts output(platform_list, options[:use_spaces])
+          puts "- Platforms", output(platform_list, options[:use_spaces])
           return
         end
       end

--- a/lib/vanagon/cli/render.rb
+++ b/lib/vanagon/cli/render.rb
@@ -1,5 +1,6 @@
 require 'docopt'
 require 'json'
+require 'vanagon/logger'
 
 class Vanagon
   class CLI
@@ -19,7 +20,7 @@ class Vanagon
       def parse(argv)
         Docopt.docopt(DOCUMENTATION, { argv: argv })
       rescue Docopt::Exit => e
-        puts e.message
+        VanagonLogger.error e.message
         exit 1
       end
 

--- a/lib/vanagon/cli/ship.rb
+++ b/lib/vanagon/cli/ship.rb
@@ -1,4 +1,5 @@
 require 'docopt'
+require 'vanagon/logger'
 
 class Vanagon
   class CLI
@@ -14,7 +15,7 @@ class Vanagon
       def parse(argv)
         Docopt.docopt(DOCUMENTATION, { argv: argv })
       rescue Docopt::Exit => e
-        puts e.message
+        VanagonLogger.error e.message
         exit 1
       end
 
@@ -32,7 +33,7 @@ class Vanagon
         DOC
 
         if Dir['output/**/*'].select { |entry| File.file?(entry) }.empty?
-          warn 'vanagon: Error: No packages to ship in the "output" directory. Maybe build some first?'
+          VanagonLogger.error 'vanagon: Error: No packages to ship in the "output" directory. Maybe build some first?'
           exit 1
         end
 
@@ -42,9 +43,9 @@ class Vanagon
         begin
           Pkg::Util::RakeUtils.invoke_task('pl:jenkins:ship_to_artifactory', 'output')
         rescue LoadError
-          warn artifactory_warning
+          VanagonLogger.error artifactory_warning
         rescue StandardError
-          warn artifactory_warning
+          VanagonLogger.error artifactory_warning
         end
       end
     end

--- a/lib/vanagon/cli/sign.rb
+++ b/lib/vanagon/cli/sign.rb
@@ -1,4 +1,5 @@
 require 'docopt'
+require 'vanagon/logger'
 
 class Vanagon
   class CLI
@@ -14,14 +15,14 @@ class Vanagon
       def parse(argv)
         Docopt.docopt(DOCUMENTATION, { argv: argv })
       rescue Docopt::Exit => e
-        puts e.message
+        VanagonLogger.error e.message
         exit 1
       end
 
       def run(_)
         ENV['PROJECT_ROOT'] = Dir.pwd
         if Dir['output/**/*'].select { |entry| File.file?(entry) }.empty?
-          warn 'sign: Error: No packages to sign in the "output" directory. Maybe build some first?'
+          VanagonLogger.error 'sign: Error: No packages to sign in the "output" directory. Maybe build some first?'
           exit 1
         end
 

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -1,4 +1,5 @@
 require 'vanagon/component'
+require 'vanagon/logger'
 require 'vanagon/patch'
 require 'ostruct'
 require 'json'
@@ -237,7 +238,7 @@ class Vanagon
 
         if @component.platform.is_windows?
           unless mode.nil? && owner.nil? && group.nil?
-            warn "You're trying to set the mode, owner, or group for windows. I don't know how to do that, ignoring!"
+            VanagonLogger.info "You're trying to set the mode, owner, or group for windows. I don't know how to do that, ignoring!"
           end
         else
           mode ||= '0644'
@@ -407,7 +408,7 @@ class Vanagon
         install_flags = ['-d']
         if @component.platform.is_windows?
           unless mode.nil? && owner.nil? && group.nil?
-            warn "You're trying to set the mode, owner, or group for windows. I don't know how to do that, ignoring!"
+            VanagonLogger.info "You're trying to set the mode, owner, or group for windows. I don't know how to do that, ignoring!"
           end
         else
           install_flags << "-m '#{mode}'" unless mode.nil?
@@ -422,7 +423,7 @@ class Vanagon
       # @param env [Hash] mapping of keys to values to add to the environment for the component
       def environment(*env)
         if env.size == 1 && env.first.is_a?(Hash)
-          warn <<-WARNING.undent
+          VanagonLogger.info <<-WARNING.undent
             the component DSL method signature #environment({Key => Value}) is deprecated
             and will be removed by Vanagon 1.0.0.
 

--- a/lib/vanagon/component/source.rb
+++ b/lib/vanagon/component/source.rb
@@ -1,4 +1,5 @@
 require 'fustigit'
+require 'vanagon/logger'
 require 'vanagon/component/source/http'
 require 'vanagon/component/source/git'
 require 'vanagon/component/source/local'
@@ -66,7 +67,7 @@ class Vanagon
           timeout = 5
           if Vanagon::Component::Source::Git.valid_remote?(uri, timeout)
             if uri =~ /^http/
-              warn "Passing git URLs as http(s) addresses is deprecated! Please prefix your source URL with `git:`"
+              VanagonLogger.info "Passing git URLs as http(s) addresses is deprecated! Please prefix your source URL with `git:`"
             end
             return :git
           end

--- a/lib/vanagon/component/source/git.rb
+++ b/lib/vanagon/component/source/git.rb
@@ -1,5 +1,6 @@
 require 'vanagon/utilities'
 require 'vanagon/errors'
+require 'vanagon/logger'
 # This stupid library requires a capital 'E' in its name
 # but it provides a wealth of useful constants
 require 'English'
@@ -81,7 +82,7 @@ class Vanagon
         # There is no md5 to manually verify here, so this is a noop.
         def verify
           # nothing to do here, so just tell users that and return
-          warn "Nothing to verify for '#{dirname}' (using Git reference '#{ref}')"
+          VanagonLogger.info "Nothing to verify for '#{dirname}' (using Git reference '#{ref}')"
         end
 
         # The dirname to reference when building from the repo
@@ -131,8 +132,8 @@ class Vanagon
         # Clone a remote repo, make noise about it, and fail entirely
         # if we're unable to retrieve the remote repo
         def clone!
-          warn "Cloning Git repo '#{url}'"
-          warn "Successfully cloned '#{dirname}'" if clone
+          VanagonLogger.info "Cloning Git repo '#{url}'"
+          VanagonLogger.info "Successfully cloned '#{dirname}'" if clone
         rescue ::Git::GitExecuteError
           raise Vanagon::InvalidRepo, "Unable to clone from '#{url}'"
         end
@@ -141,7 +142,7 @@ class Vanagon
         # Checkout desired ref/sha, make noise about it, and fail
         # entirely if we're unable to checkout that given ref/sha
         def checkout!
-          warn "Checking out '#{ref}' from Git repo '#{dirname}'"
+          VanagonLogger.info "Checking out '#{ref}' from Git repo '#{dirname}'"
           clone.checkout(ref)
         rescue ::Git::GitExecuteError
           raise Vanagon::CheckoutFailed, "unable to checkout #{ref} from '#{url}'"
@@ -151,7 +152,7 @@ class Vanagon
         # Attempt to update submodules, and do not panic
         # if there are no submodules to initialize
         def update_submodules
-          warn "Attempting to update submodules for repo '#{dirname}'"
+          VanagonLogger.info "Attempting to update submodules for repo '#{dirname}'"
           clone.update_submodules(init: true)
         end
         private :update_submodules
@@ -163,7 +164,7 @@ class Vanagon
         def describe
           clone.describe(ref, tags: true)
         rescue ::Git::GitExecuteError
-          warn "Directory '#{dirname}' cannot be versioned by Git. Maybe it hasn't been tagged yet?"
+          VanagonLogger.info "Directory '#{dirname}' cannot be versioned by Git. Maybe it hasn't been tagged yet?"
         end
         private :describe
       end

--- a/lib/vanagon/component/source/http.rb
+++ b/lib/vanagon/component/source/http.rb
@@ -1,4 +1,5 @@
 require 'vanagon/utilities'
+require 'vanagon/logger'
 require 'vanagon/component/source/local'
 require 'net/http'
 require 'uri'
@@ -93,7 +94,7 @@ class Vanagon
         #
         # @raise [RuntimeError] an exception is raised if the sum does not match the sum of the file
         def verify # rubocop:disable Metrics/AbcSize
-          warn "Verifying file: #{file} against sum: '#{sum}'"
+          VanagonLogger.info "Verifying file: #{file} against sum: '#{sum}'"
           actual = get_sum(File.join(workdir, file), sum_type)
           return true if sum == actual
 
@@ -107,7 +108,7 @@ class Vanagon
           uri = URI.parse(target_url.to_s)
           target_file ||= File.basename(uri.path)
 
-          warn "Downloading file '#{target_file}' from url '#{target_url}'"
+          VanagonLogger.info "Downloading file '#{target_file}' from url '#{target_url}'"
 
           Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
             http.request(Net::HTTP::Get.new(uri, headers)) do |response|

--- a/lib/vanagon/component/source/local.rb
+++ b/lib/vanagon/component/source/local.rb
@@ -1,4 +1,5 @@
 require 'vanagon/utilities'
+require 'vanagon/logger'
 
 class Vanagon
   class Component
@@ -57,7 +58,7 @@ class Vanagon
         #
         # @raise [RuntimeError, Vanagon::Error] an exception is raised if the URI scheme cannot be handled
         def copy
-          warn "Copying file '#{url.basename}' to workdir"
+          VanagonLogger.info "Copying file '#{url.basename}' to workdir"
 
           FileUtils.cp_r(url, file)
         end

--- a/lib/vanagon/component/source/rewrite.rb
+++ b/lib/vanagon/component/source/rewrite.rb
@@ -1,4 +1,5 @@
 require 'vanagon/component/source'
+require 'vanagon/logger'
 
 class Vanagon
   class Component
@@ -16,7 +17,7 @@ class Vanagon
           # @deprecated Please use the component DSL method #mirror(<URI>)
           #   instead. This method will be removed before Vanagon 1.0.0.
           def register_rewrite_rule(protocol, rule)
-            warn <<-HERE.undent
+            VanagonLogger.info <<-HERE.undent
               rewrite rule support is deprecated and will be removed before Vanagon 1.0.0.
               Rewritten URLs will be automatically converted into mirror URLs for now but
               please use the component DSL method '#mirror url' to define new mirror URL
@@ -76,7 +77,7 @@ class Vanagon
           def parse_and_rewrite(uri)
             return uri if rewrite_rules.empty?
             if !!uri.match(/^git:http/)
-              warn <<-HERE.undent
+              VanagonLogger.info <<-HERE.undent
                 `fustigit` parsing doesn't get along with how we specify the source
                 type by prefixing `git`. As `rewrite_rules` are deprecated, we'll
                 replace `git:http` with `http` in your uri. At some point this will

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -4,6 +4,7 @@ require 'vanagon/component'
 require 'vanagon/utilities'
 require 'vanagon/common'
 require 'vanagon/errors'
+require 'vanagon/logger'
 require 'tmpdir'
 require 'logger'
 
@@ -54,8 +55,8 @@ class Vanagon
       # flatten all the results in to one array and set project.components to that.
       @project.components = only_build.flat_map { |comp| @project.filter_component(comp) }.uniq
       if @verbose
-        warn "Only building:"
-        @project.components.each { |comp| warn comp.name }
+        VanagonLogger.info "Only building:"
+        @project.components.each { |comp| VanagonLogger.info comp.name }
       end
     end
 
@@ -134,7 +135,7 @@ class Vanagon
       end
 
       @engine.startup(workdir)
-      warn "Target is #{@engine.target}"
+      VanagonLogger.info "Target is #{@engine.target}"
       Vanagon::Utilities.retry_with_timeout(retry_count, timeout) do
         install_build_dependencies
       end
@@ -159,8 +160,8 @@ class Vanagon
         @engine.teardown
         cleanup_workdir
       end
-      warn e
-      warn e.backtrace.join("\n")
+      VanagonLogger.error(e)
+      VanagonLogger.error e.backtrace.join("\n")
       raise e
     ensure
       if ["hardware", "ec2"].include?(@engine.name)
@@ -174,7 +175,7 @@ class Vanagon
         raise Vanagon::Error, "Project requires a version set, all is lost."
       end
 
-      warn "rendering Makefile"
+      VanagonLogger.info "rendering Makefile"
       @project.fetch_sources(workdir, retry_count, timeout)
       @project.make_bill_of_materials(workdir)
       @project.generate_packaging_artifacts(workdir)

--- a/lib/vanagon/engine/docker.rb
+++ b/lib/vanagon/engine/docker.rb
@@ -1,4 +1,5 @@
 require 'vanagon/engine/base'
+require 'vanagon/logger'
 
 class Vanagon
   class Engine
@@ -52,7 +53,7 @@ class Vanagon
         Vanagon::Utilities.ex("#{@docker_cmd} stop #{build_host_name}-builder")
         Vanagon::Utilities.ex("#{@docker_cmd} rm #{build_host_name}-builder")
       rescue Vanagon::Error => e
-        warn "There was a problem tearing down the docker container #{build_host_name}-builder (#{e.message})."
+        VanagonLogger.error "There was a problem tearing down the docker container #{build_host_name}-builder (#{e.message})."
       end
 
       def dispatch(command, return_output = false)

--- a/lib/vanagon/engine/ec2.rb
+++ b/lib/vanagon/engine/ec2.rb
@@ -2,6 +2,7 @@ require 'aws-sdk'
 require 'erb'
 require 'base64'
 require 'vanagon/engine/base'
+require 'vanagon/logger'
 
 class Vanagon
   class Engine
@@ -57,17 +58,17 @@ class Vanagon
       end
 
       def select_target
-        warn "Instance created id: #{instance.id}"
-        warn "Created instance waiting for status ok"
+        VanagonLogger.info "Instance created id: #{instance.id}"
+        VanagonLogger.info "Created instance waiting for status ok"
         @ec2.wait_until(:instance_status_ok, instance_ids: [instance.id])
-        warn "Instance running"
+        VanagonLogger.info "Instance running"
         @target = instance.private_ip_address
       rescue ::Aws::Waiters::Errors::WaiterFailed => error
         fail "Failed to wait for ec2 instance to start got error #{error}"
       end
 
       def teardown
-        warn "Destroying instance on AWS id: #{instance.id}"
+        VanagonLogger.info "Destroying instance on AWS id: #{instance.id}"
         instances.batch_terminate!
       end
     end

--- a/lib/vanagon/engine/hardware.rb
+++ b/lib/vanagon/engine/hardware.rb
@@ -1,4 +1,5 @@
 require 'vanagon/engine/base'
+require 'vanagon/logger'
 require 'json'
 require 'lock_manager'
 
@@ -23,7 +24,7 @@ class Vanagon
         Vanagon::Driver.logger.info "Polling for a lock on #{host}."
         @lockman.polling_lock(host, VANAGON_LOCK_USER, "Vanagon automated lock")
         Vanagon::Driver.logger.info "Lock acquired on #{host}."
-        warn "Lock acquired on #{host} for #{VANAGON_LOCK_USER}."
+        VanagonLogger.info "Lock acquired on #{host} for #{VANAGON_LOCK_USER}."
         host
       end
 
@@ -33,7 +34,7 @@ class Vanagon
           Vanagon::Driver.logger.info "Attempting  to lock #{h}."
           if @lockman.lock(h, VANAGON_LOCK_USER, "Vanagon automated lock")
             Vanagon::Driver.logger.info "Lock acquired on #{h}."
-            warn "Lock acquired on #{h} for #{VANAGON_LOCK_USER}."
+            VanagonLogger.info "Lock acquired on #{h} for #{VANAGON_LOCK_USER}."
             return h
           end
         end
@@ -45,7 +46,7 @@ class Vanagon
       # complete. In this case, we'll attempt to unlock the hardware
       def teardown
         Vanagon::Driver.logger.info "Removing lock on #{@target}."
-        warn "Removing lock on #{@target}."
+        VanagonLogger.info "Removing lock on #{@target}."
         @lockman.unlock(@target, VANAGON_LOCK_USER)
       end
 

--- a/lib/vanagon/engine/pooler.rb
+++ b/lib/vanagon/engine/pooler.rb
@@ -1,4 +1,5 @@
 require 'vanagon/engine/base'
+require 'vanagon/logger'
 require 'yaml'
 
 ### Note this class is deprecated in favor of using the ABS Engine. The pooler has changed it's API with regards to
@@ -60,7 +61,7 @@ class Vanagon
         absolute_path = File.expand_path(path)
         return nil unless File.exist?(absolute_path)
 
-        warn "Reading vmpooler token from: #{path}"
+        VanagonLogger.info "Reading vmpooler token from: #{path}"
         File.read(absolute_path).chomp
       end
       private :read_vanagon_token
@@ -74,7 +75,7 @@ class Vanagon
         absolute_path = File.expand_path(path)
         return nil unless File.exist?(absolute_path)
 
-        warn "Reading vmpooler token from: #{path}"
+        VanagonLogger.info "Reading vmpooler token from: #{path}"
         YAML.load_file(absolute_path)['token']
       end
       private :read_vmfloaty_token
@@ -145,14 +146,14 @@ class Vanagon
         )
         if response and response["ok"]
           Vanagon::Driver.logger.info "#{@target} has been destroyed"
-          warn "#{@target} has been destroyed"
+          VanagonLogger.info "#{@target} has been destroyed"
         else
           Vanagon::Driver.logger.info "#{@target} could not be destroyed"
-          warn "#{@target} could not be destroyed"
+          VanagonLogger.info "#{@target} could not be destroyed"
         end
       rescue Vanagon::Error => e
         Vanagon::Driver.logger.info "#{@target} could not be destroyed (#{e.message})"
-        warn "#{@target} could not be destroyed (#{e.message})"
+        VanagonLogger.error "#{@target} could not be destroyed (#{e.message})"
       end
     end
   end

--- a/lib/vanagon/environment.rb
+++ b/lib/vanagon/environment.rb
@@ -1,5 +1,6 @@
 require 'forwardable'
 require 'vanagon/extensions/string'
+require 'vanagon/logger'
 
 class Vanagon
   # Environment is a validating wrapper around a delegated Hash,
@@ -147,7 +148,7 @@ class Vanagon
         update your project's parameters.
       WARNING
 
-      warn warning.join("\n")
+      VanagonLogger.info warning.join("\n")
       str.gsub(pattern, '$(shell \1)')
     end
     private :sanitize_subshells
@@ -165,7 +166,7 @@ class Vanagon
         update your project's parameters.
       WARNING
 
-      warn warning.join("\n")
+      VanagonLogger.info warning.join("\n")
       str.gsub(pattern, '$(\1)')
     end
     private :sanitize_variables

--- a/lib/vanagon/logger.rb
+++ b/lib/vanagon/logger.rb
@@ -1,0 +1,31 @@
+require 'logger'
+
+class VanagonLogger < ::Logger
+  def self.logger
+    @@logger ||= VanagonLogger.new
+  end
+
+  def self.debug_logger
+    @@debug_logger ||= VanagonLogger.new(STDERR)
+  end
+
+  def self.info(msg)
+    VanagonLogger.debug_logger.info msg
+  end
+
+  def self.warn(msg)
+    VanagonLogger.logger.warn msg
+  end
+
+  def self.error(msg)
+    VanagonLogger.logger.error msg
+  end
+
+  def initialize(output = STDOUT)
+    super(output)
+    self.level = ::Logger::INFO
+    self.formatter = proc do |severity, datetime, progname, msg|
+      "#{msg}\n"
+    end
+  end
+end

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -1,6 +1,7 @@
 require 'vanagon/environment'
 require 'vanagon/platform/dsl'
 require 'vanagon/utilities'
+require 'vanagon/logger'
 
 class Vanagon
   class Platform
@@ -152,9 +153,9 @@ class Vanagon
       dsl.instance_eval(File.read(platfile), platfile, 1)
       dsl._platform
     rescue StandardError => e
-      warn "Error loading platform '#{name}' using '#{platfile}':"
-      warn e
-      warn e.backtrace.join("\n")
+      VanagonLogger.error "Error loading platform '#{name}' using '#{platfile}':"
+      VanagonLogger.error(e)
+      VanagonLogger.error e.backtrace.join("\n")
       raise e
     end
 
@@ -401,7 +402,7 @@ class Vanagon
     # @deprecated Please use is_macos? instead
     # @return [true, false] true if it is an osx variety, false otherwise
     def is_osx?
-      warn "is_osx? is a deprecated method, please use #is_macos? instead."
+      VanagonLogger.info "is_osx? is a deprecated method, please use #is_macos? instead."
       is_macos?
     end
 
@@ -539,7 +540,7 @@ class Vanagon
       match = version_string.match(VERSION_REGEX)
 
       if match.nil?
-        warn "Passing a version without an operator is deprecated!"
+        VanagonLogger.info "Passing a version without an operator is deprecated!"
         operator = default
         version = version_string
       end

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -8,6 +8,7 @@ require 'vanagon/platform/osx'
 require 'vanagon/platform/solaris_10'
 require 'vanagon/platform/solaris_11'
 require 'vanagon/platform/windows'
+require 'vanagon/logger'
 require 'securerandom'
 require 'uri'
 
@@ -259,7 +260,7 @@ class Vanagon
       # @param name [String] name that the pooler uses for this platform
       # @deprecated Please use vmpooler_template instead, this will be removed in a future vanagon release.
       def vcloud_name(cloud_name)
-        warn "vcloud_name is a deprecated platform DSL method, and will be removed in a future vanagon release. Please use vmpooler_template instead."
+        VanagonLogger.info "vcloud_name is a deprecated platform DSL method, and will be removed in a future vanagon release. Please use vmpooler_template instead."
         self.vmpooler_template(cloud_name)
       end
 
@@ -394,7 +395,7 @@ class Vanagon
       # @param gpg_key [String] optional gpg key to be fetched via curl and installed
       # @deprecated Please use the add_build_repository DSL method instead. apt_repo will be removed in a future vanagon release.
       def apt_repo(definition, gpg_key = nil)
-        warn "Please use the add_build_repository DSL method instead. apt_repo will be removed in a future vanagon release."
+        VanagonLogger.info "Please use the add_build_repository DSL method instead. apt_repo will be removed in a future vanagon release."
         self.add_build_repository(definition, gpg_key)
       end
 
@@ -403,7 +404,7 @@ class Vanagon
       # @param definition [String] the repo setup URI or RPM file
       # @deprecated Please use the add_build_repository DSL method instead. yum_repo will be removed in a future vanagon release.
       def yum_repo(definition)
-        warn "Please use the add_build_repository DSL method instead. yum_repo will be removed in a future vanagon release."
+        VanagonLogger.info "Please use the add_build_repository DSL method instead. yum_repo will be removed in a future vanagon release."
         self.add_build_repository(definition)
       end
 
@@ -412,7 +413,7 @@ class Vanagon
       # @param definition [String] the repo setup URI or RPM file
       # @deprecated Please use the add_build_repository DSL method instead. zypper_repo will be removed in a future vanagon release.
       def zypper_repo(definition)
-        warn "Please use the add_build_repository DSL method instead. zypper_repo will be removed in a future vanagon release."
+        VanagonLogger.info "Please use the add_build_repository DSL method instead. zypper_repo will be removed in a future vanagon release."
         self.add_build_repository(definition)
       end
 

--- a/lib/vanagon/platform/windows.rb
+++ b/lib/vanagon/platform/windows.rb
@@ -1,3 +1,5 @@
+require 'vanagon/logger'
+
 class Vanagon
   class Platform
     class Windows < Vanagon::Platform
@@ -231,7 +233,7 @@ class Vanagon
               ]
             end
           rescue RuntimeError
-            warn "Unable to connect to #{project.signing_username}@#{project.signing_hostname}, skipping signing extra files: #{project.extra_files_to_sign.join(',')}"
+            VanagonLogger.error "Unable to connect to #{project.signing_username}@#{project.signing_hostname}, skipping signing extra files: #{project.extra_files_to_sign.join(',')}"
           end
         end
         make_commands << [

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -1,5 +1,6 @@
 require 'vanagon/component'
 require 'vanagon/environment'
+require 'vanagon/logger'
 require 'vanagon/platform'
 require 'vanagon/project/dsl'
 require 'vanagon/utilities'
@@ -130,9 +131,9 @@ class Vanagon
       dsl.instance_eval(File.read(projfile), projfile, 1)
       dsl._project
     rescue StandardError => e
-      warn "Error loading project '#{name}' using '#{projfile}':"
-      warn e
-      warn e.backtrace.join("\n")
+      VanagonLogger.error "Error loading project '#{name}' using '#{projfile}':"
+      VanagonLogger.error(e)
+      VanagonLogger.error e.backtrace.join("\n")
       raise e
     end
 
@@ -841,7 +842,7 @@ class Vanagon
     end
 
     def load_upstream_metadata(metadata_uri)
-      warn "Loading metadata from #{metadata_uri}"
+      VanagonLogger.info "Loading metadata from #{metadata_uri}"
       case metadata_uri
       when /^http/
         @upstream_metadata = JSON.parse(Net::HTTP.get(URI(metadata_uri)))

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -1,4 +1,5 @@
 require 'vanagon/errors'
+require 'vanagon/logger'
 require 'vanagon/project'
 require 'vanagon/utilities'
 require 'vanagon/component/source'
@@ -185,7 +186,7 @@ class Vanagon
         last_tag = repo_object.describe('HEAD', { :abbrev => 0 })
         release(repo_object.rev_list("#{last_tag}..HEAD", { :count => true }))
       rescue Git::GitExecuteError
-        warn "Directory '#{File.expand_path('..', @configdir)}' cannot be versioned by git. Maybe it hasn't been tagged yet?"
+        VanagonLogger.error "Directory '#{File.expand_path('..', @configdir)}' cannot be versioned by git. Maybe it hasn't been tagged yet?"
       end
 
       # Sets the version for the project based on a git describe of the
@@ -196,7 +197,7 @@ class Vanagon
         git_version = Git.open(File.expand_path("..", @configdir)).describe('HEAD', tags: true)
         version(git_version.split('-').reject(&:empty?).join('.'))
       rescue Git::GitExecuteError
-        warn "Directory '#{File.expand_path('..', @configdir)}' cannot be versioned by git. Maybe it hasn't been tagged yet?"
+        VanagonLogger.error "Directory '#{File.expand_path('..', @configdir)}' cannot be versioned by git. Maybe it hasn't been tagged yet?"
       end
 
       # Get the version string from a git branch name. This will look for a '.'
@@ -268,7 +269,7 @@ class Vanagon
       #
       # @param name [String] name of component to add. must be present in configdir/components and named $name.rb currently
       def component(name)
-        warn "Loading #{name}" if @project.settings[:verbose]
+        VanagonLogger.info "Loading #{name}" if @project.settings[:verbose]
         if @include_components.empty? or @include_components.include?(name)
           component = Vanagon::Component.load_component(name, File.join(@configdir, "components"), @project.settings, @project.platform)
           @project.components << component

--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -9,6 +9,7 @@ require 'timeout'
 # but it provides a wealth of useful constants
 require 'English'
 require 'vanagon/extensions/string'
+require 'vanagon/logger'
 
 class Vanagon
   module Utilities
@@ -165,7 +166,7 @@ class Vanagon
             yield
             return true
           rescue StandardError => e
-            warn 'An error was encountered evaluating block. Retrying..'
+            VanagonLogger.error 'An error was encountered evaluating block. Retrying..'
             error = e
           end
         end
@@ -238,7 +239,7 @@ class Vanagon
     #                        output of the command if return_command_output is true
     # @raise [RuntimeError] If there is no target given or the command fails an exception is raised
     def remote_ssh_command(target, command, port = 22, return_command_output: false)
-      warn "Executing '#{command}' on '#{target}'"
+      VanagonLogger.info "Executing '#{command}' on '#{target}'"
       if return_command_output
         ret = %x(#{ssh_command(port)} -T #{target} '#{command.gsub("'", "'\\\\''")}').chomp
         if $CHILD_STATUS.success?
@@ -261,7 +262,7 @@ class Vanagon
     # @raise [RuntimeError] If the command fails an exception is raised
     def local_command(command, return_command_output: false)
       clean_environment do
-        warn "Executing '#{command}' locally"
+        VanagonLogger.info "Executing '#{command}' locally"
         if return_command_output
           ret = %x(#{command}).chomp
           if $CHILD_STATUS.success?
@@ -305,7 +306,7 @@ class Vanagon
       outfile ||= File.join(Dir.mktmpdir, File.basename(erbfile).sub(File.extname(erbfile), ""))
       output = erb_string(erbfile, opts[:binding])
       File.open(outfile, 'w') { |f| f.write output }
-      warn "Generated: #{outfile}"
+      VanagonLogger.info "Generated: #{outfile}"
       FileUtils.rm_rf erbfile if remove_orig
       outfile
     end

--- a/spec/lib/vanagon/cli_spec.rb
+++ b/spec/lib/vanagon/cli_spec.rb
@@ -164,7 +164,7 @@ foo bar baz
 - Platforms
 1 2 3
 "
-  }
+}
       it "outputs projects and platforms space separated" do 
         expect do
           cli.run(options_space_only)
@@ -221,6 +221,3 @@ baz
     end
   end
 end
-
-      
-

--- a/spec/lib/vanagon/component_spec.rb
+++ b/spec/lib/vanagon/component_spec.rb
@@ -5,8 +5,9 @@ describe "Vanagon::Component" do
   describe "#get_environment" do
     subject { Vanagon::Component.new('env-test', {}, {}) }
 
-    it "prints a deprecation warning to STDERR" do
-      expect { subject.get_environment }.to output(/deprecated/).to_stderr
+    it "logs a deprecation warning with VanagonLogger.info" do
+      expect(VanagonLogger).to receive(:info).with(/deprecated/)
+      subject.get_environment
     end
 
     it "returns a makefile compatible environment" do

--- a/spec/lib/vanagon/engine/always_be_scheduling_spec.rb
+++ b/spec/lib/vanagon/engine/always_be_scheduling_spec.rb
@@ -174,8 +174,8 @@ describe 'Vanagon::Engine::AlwaysBeScheduling' do
       hostname = 'fainter-whirlwind.puppet.com'
       stub_request(:post, "https://foobar/request").
           to_return({status: 404, body: "", headers: {}},{status: 200, body: '[{"hostname":"'+hostname+'","type":"aix-6.1-ppc","engine":"nspooler"}]', headers: {}})
-      allow_any_instance_of(Object).to receive(:warn)
-      expect_any_instance_of(Object).to receive(:warn).with("failed to request ABS with code 404")
+      allow_any_instance_of(VanagonLogger).to receive(:info)
+      expect_any_instance_of(VanagonLogger).to receive(:info).with("failed to request ABS with code 404")
       abs_service = Vanagon::Engine::AlwaysBeScheduling.new(platform, nil)
       pooler = abs_service.select_target_from("https://foobar")
       expect(pooler).to eq('')
@@ -186,8 +186,8 @@ describe 'Vanagon::Engine::AlwaysBeScheduling' do
           to_return({status: 202, body: "", headers: {}},
                     {status: 503, body: "", headers: {}},
                     {status: 200, body: '[{"hostname":"'+hostname+'","type":"aix-6.1-ppc","engine":"nspooler"}]', headers: {}})
-      allow_any_instance_of(Object).to receive(:warn)
-      expect_any_instance_of(Object).to receive(:warn).with(/Waiting 1 seconds to check if ABS request has been filled/)
+      allow_any_instance_of(VanagonLogger).to receive(:info)
+      expect_any_instance_of(VanagonLogger).to receive(:info).with(/Waiting 1 seconds to check if ABS request has been filled/)
       abs_service = Vanagon::Engine::AlwaysBeScheduling.new(platform, nil)
       abs_service.select_target_from("https://foobar")
       expect(abs_service.target).to eq(hostname)


### PR DESCRIPTION
Use VanagonLogger (inherits from Logger class) to classify output. 

Please add all notable changes to the "Unreleased" section of the CHANGELOG.