### PR TITLE
(maint) fix target argument handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+- (maint) When target argument is specified, do not load the engine
 
 ## [0.18.0] - released 2020-12-08
 ### Added

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -74,6 +74,8 @@ class Vanagon
     end
 
     def load_engine_object(engine_type, platform, target)
+      engine_type = 'base' if target
+
       require "vanagon/engine/#{engine_type}"
       @engine = Object::const_get("Vanagon::Engine::#{camelize(engine_type)}")
         .new(platform, target, remote_workdir: remote_workdir)


### PR DESCRIPTION
After default engine was changed to 'always_be_scheduling' target
argument was ignored

