### PR TITLE
(maint) Cleanup #pick_engine method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+- (maint) When target argument is specified, do not load the engine
 
 ## [0.18.0] - released 2020-12-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [0.18.0] - released 2020-12-08
 ### Added
 - (maint) Added `vanagon list` subcommand with options to list `--projects`,
   and / or `--platforms`. By default, the list is spaced with new-line
@@ -910,7 +912,8 @@ on Debian < 8 and needs more work and testing.
 
 ## Versions <= 0.3.9 do not have a change log entry
 
-[Unreleased]: https://github.com/puppetlabs/vanagon/compare/0.17.0...HEAD
+[Unreleased]: https://github.com/puppetlabs/vanagon/compare/0.18.0...HEAD
+[0.18.0]: https://github.com/puppetlabs/vanagon/compare/0.17.0...0.18.0
 [0.17.0]: https://github.com/puppetlabs/vanagon/compare/0.16.1...0.17.0
 [0.16.1]: https://github.com/puppetlabs/vanagon/compare/0.16.0...0.16.1
 [0.16.0]: https://github.com/puppetlabs/vanagon/compare/0.15.38...0.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ## [0.18.1] - released 2020-12-09
 ### Fixed
 - (maint) Patch bug in engine-selection method where target argument is getting ignored
-  ABS engine is loaded.
+  when ABS engine is loaded.
 
 ## [0.18.0] - released 2020-12-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
-- (maint) When target argument is specified, do not load the engine
+
+## [0.18.1] - released 2020-12-09
+### Fixed
+- (maint) Patch bug in engine-selection method where target argument is getting ignored
+  ABS engine is loaded.
 
 ## [0.18.0] - released 2020-12-08
 ### Added
@@ -913,7 +917,8 @@ on Debian < 8 and needs more work and testing.
 
 ## Versions <= 0.3.9 do not have a change log entry
 
-[Unreleased]: https://github.com/puppetlabs/vanagon/compare/0.18.0...HEAD
+[Unreleased]: https://github.com/puppetlabs/vanagon/compare/0.18.1...HEAD
+[0.18.1]: https://github.com/puppetlabs/vanagon/compare/0.18.0...0.18.1
 [0.18.0]: https://github.com/puppetlabs/vanagon/compare/0.17.0...0.18.0
 [0.17.0]: https://github.com/puppetlabs/vanagon/compare/0.16.1...0.17.0
 [0.16.1]: https://github.com/puppetlabs/vanagon/compare/0.16.0...0.16.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- (maint) Cleanup #pick_engine method.
 
 ## [0.18.1] - released 2020-12-09
 ### Fixed

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -56,26 +56,22 @@ class Vanagon
     end
 
     def pick_engine(options) # rubocop:disable Metrics/PerceivedComplexity
-      default_engine = 'always_be_scheduling'
-
-      # Use the explicitly configured engine if no target was provided.
-      return options[:engine] if options[:engine] && !options[:target]
-
-      # If the configured engine matches the default engine, use it
-      return options[:engine] if options[:engine] == default_engine
-
-      # Make some guesses about which engine to use
-      return 'hardware' if @platform.build_hosts
-      return 'ec2' if @platform.aws_ami
-      return 'docker' if @platform.docker_image
-      return 'base' if @options[:target]
-
-      return default_engine
+      if options[:engine] && !options[:target]
+        options[:engine]
+      elsif @platform.build_hosts
+        'hardware'
+      elsif @platform.aws_ami
+        'ec2'
+      elsif @platform.docker_image
+        'docker'
+      elsif options[:target]
+        'base'
+      else
+        'always_be_scheduling'
+      end
     end
 
     def load_engine_object(engine_type, platform, target)
-      engine_type = 'base' if target
-
       require "vanagon/engine/#{engine_type}"
       @engine = Object::const_get("Vanagon::Engine::#{camelize(engine_type)}")
         .new(platform, target, remote_workdir: remote_workdir)

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -74,6 +74,8 @@ class Vanagon
     end
 
     def load_engine_object(engine_type, platform, target)
+      engine_type = 'base' if target
+
       require "vanagon/engine/#{engine_type}"
       @engine = Object::const_get("Vanagon::Engine::#{camelize(engine_type)}")
         .new(platform, target, remote_workdir: remote_workdir)


### PR DESCRIPTION
My first try at isolating the pick_engine method was buggy. Cas provided
us a better one.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.