### PR TITLE
(VANAGON-129) Allow for passing version to 'requires'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Added
+- (VANAGON-129) Added support for passing a version to `requires` in components
+  and projects. Updated `get_requires` to handle the versions, and pass them to 
+  the rpm and deb packages. 
 
 ## [0.18.1] - released 2020-12-09
 ### Fixed

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -132,8 +132,8 @@ class Vanagon
       # component
       #
       # @param requirement [String] a package that is required at runtime for this component
-      def requires(requirement)
-        @component.requires << requirement
+      def requires(requirement, version = nil)
+        @component.requires << OpenStruct.new(:requirement => requirement, :version => version)
       end
 
       # Indicates that this component replaces a system level package. Replaces can be collected and used by the project and package.

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -297,10 +297,14 @@ class Vanagon
     #
     # @return [Array] array of runtime requirements for the project
     def get_requires
-      req = []
-      req << components.flat_map(&:requires)
-      req << @requires
-      req.flatten.uniq
+      requires = []
+      requires << @requires.flatten
+      requires << components.flat_map(&:requires)
+      requires.flatten!
+      requires.each do |requirement|
+        requirement.version = @platform.version_munger(requirement.version, default: '<') if requirement.version
+      end
+      requires.uniq
     end
 
     # Collects all of the replacements for the project and its components
@@ -308,8 +312,8 @@ class Vanagon
     # @return [Array] array of package level replacements for the project
     def get_replaces
       replaces = []
-      replaces.push @replaces.flatten
-      replaces.push components.flat_map(&:replaces)
+      replaces << @replaces.flatten
+      replaces << components.flat_map(&:replaces)
       replaces.flatten!
       replaces.each do |replace|
         # TODO: Make this a more reasonable default before 1.0.0
@@ -325,8 +329,9 @@ class Vanagon
 
     # Collects all of the conflicts for the project and its components
     def get_conflicts
-      conflicts = components.flat_map(&:conflicts) + @conflicts
-      # Mash the whole thing down into a flat Array
+      conflicts = []
+      conflicts << @conflicts.flatten
+      conflicts << components.flat_map(&:conflicts)
       conflicts.flatten!
       conflicts.each do |conflict|
         # TODO: Make this a more reasonable default before 1.0.0
@@ -361,8 +366,8 @@ class Vanagon
     # @return [Array] array of package level provides for the project
     def get_provides
       provides = []
-      provides.push @provides.flatten
-      provides.push components.flat_map(&:provides)
+      provides << @provides.flatten
+      provides << components.flat_map(&:provides)
       provides.flatten!
       provides.each do |provide|
         # TODO: Make this a more reasonable default before 1.0.0

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -110,8 +110,8 @@ class Vanagon
       # Sets the run time requirements for the project. Mainly for use in packaging.
       #
       # @param req [String] of requirements of the project
-      def requires(req)
-        @project.requires << req
+      def requires(requirement, version = nil)
+        @project.requires << OpenStruct.new(:requirement => requirement, :version => version)
       end
 
       # Indicates that this component replaces a system level package. Replaces can be collected and used by the project and package.

--- a/resources/deb/control.erb
+++ b/resources/deb/control.erb
@@ -18,7 +18,7 @@ Breaks: <%= get_replaces.map { |replace| "#{replace.replacement} #{replace.versi
 Conflicts: <%= get_conflicts.map { |conflict| "#{conflict.pkgname} #{conflict.version ? "(#{conflict.version})" : ""}" }.join(", ") %>
 <%- end -%>
 <%- unless get_requires.empty? -%>
-Depends: <%= get_requires.join(", ") %>
+Depends: <%= get_requires.map { |req| "#{req.requirement} #{req.version ? "(#{req.version})" : ""}" }.join(", ") %>
 <%- end -%>
 <%- unless get_provides.empty? -%>
 Provides: <%= get_provides.map { |prov| prov.provide }.join(", ") %>

--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -77,7 +77,7 @@ Source1:        file-list-for-rpm
 Autoprov: 0
 Autoreq: 0
 <%- get_requires.each do |requires| -%>
-Requires:  <%= requires %>
+Requires:  <%= requires.requirement %><%= requires.version ? " #{requires.version}" : "" %>
 <%- end -%>
 
 # All rpm packages built by vanagon have the pre-/post-install script

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -313,10 +313,17 @@ end" }
       comp = Vanagon::Component::DSL.new('requires-test', {}, {})
       comp.requires('library1')
       comp.requires('library2')
-      expect(comp._component.requires).to include('library1')
-      expect(comp._component.requires).to include('library2')
+      expect(comp._component.requires.first.requirement).to include('library1')
+      expect(comp._component.requires.last.requirement).to include('library2')
     end
   end
+
+    it 'supports versioned requires' do
+      comp = Vanagon::Component::DSL.new('requires-test', {}, {})
+      comp.requires('library1', '1.2.3')
+      expect(comp._component.requires.first.requirement).to eq('library1')
+      expect(comp._component.requires.first.version).to eq('1.2.3')
+    end
 
   describe '#provides' do
     it 'adds the package provide to the list of provides' do


### PR DESCRIPTION
Added support for passing a version to `requires` in components and projects. Updated `get_requires` to handle the versions, and pass them to the rpm and deb packages. 

Please add all notable changes to the "Unreleased" section of the CHANGELOG.