### PR TITLE
(maint) Fix pristine configfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ### Fixed
 - (maint) Fix bugs in pick_engine
+- (maint) Fix pristine config files clobbering (Solaris 10)
 
 
 ## [0.18.1] - released 2020-12-09

--- a/resources/osx/postinstall.erb
+++ b/resources/osx/postinstall.erb
@@ -5,8 +5,12 @@
 <%- get_configfiles.each do |config|
 dest_file = config.path.gsub(/\.pristine$/, '') -%>
 
-if [ -f "<%= dest_file %>" ] && ! diff "<%= config.path %>" "<%= dest_file %>" > /dev/null; then
-  echo "Detected file at '<%= dest_file %>'; updated file at '<%= config.path %>'."
+if [ -f "<%= dest_file %>" ]; then
+  if diff "<%= config.path %>" "<%= dest_file %>" > /dev/null; then
+    rm -f "<%= config.path %>"
+  else
+    echo "Detected file at '<%= dest_file %>'; updated file at '<%= config.path %>'."
+  fi
 else
   mv '<%= config.path %>' '<%= dest_file %>'
 fi

--- a/resources/solaris/10/postinstall.erb
+++ b/resources/solaris/10/postinstall.erb
@@ -23,7 +23,11 @@ fi
 
 # Set up any specific permissions needed...
 <%- (get_directories + get_configfiles + get_files).select { |pathname| pathname.has_overrides? }.uniq.each do |file_or_directory| -%>
-  <%= "chmod '#{file_or_directory.mode}' '#{file_or_directory.path}'" if file_or_directory.mode %>
+  <%- if file_or_directory.mode -%>
+  if [ -f "<%= file_or_directory.path %>" ] || [ -d "<%= file_or_directory.path %>" ]; then
+    chmod '<%= file_or_directory.mode %>' '<%= file_or_directory.path %>'
+  fi
+  <%- end -%>
   <%- if file_or_directory.owner -%>
     if getent passwd '<%= file_or_directory.owner %>' &> /dev/null; then
       chown '<%= file_or_directory.owner %>' '<%= file_or_directory.path %>'

--- a/resources/solaris/10/postinstall.erb
+++ b/resources/solaris/10/postinstall.erb
@@ -9,8 +9,12 @@
 <%- get_configfiles.each do |config|
 dest_file = config.path.gsub(/\.pristine$/, '') -%>
 
-if [ -f "<%= dest_file %>" ] && ! diff "<%= config.path %>" "<%= dest_file %>" > /dev/null; then
-  echo "Detected file at '<%= dest_file %>'; updated file at '<%= config.path %>'."
+if [ -f "<%= dest_file %>" ]; then
+  if diff "<%= config.path %>" "<%= dest_file %>" > /dev/null; then
+    rm -f "<%= config.path %>"
+  else
+    echo "Detected file at '<%= dest_file %>'; updated file at '<%= config.path %>'."
+  fi
 else
   cp -pr '<%= config.path %>' '<%= dest_file %>'
 fi


### PR DESCRIPTION
On Solaris 10, postinstall scripts are executed by the `sh` interpreter,
as the package manager does not seem to respect the shebang line at the
top of the file.

This causes the `!` sign to not be recognized, and the configfiles are
clobbered regardless of the differences between the installed config
file and the pristine config file.

Sample output after upgrading puppet-agent on Solaris 10:

```
/var/sadm/pkg/puppet-agent/install/postinstall: !: not found
/var/sadm/pkg/puppet-agent/install/postinstall: !: not found
/var/sadm/pkg/puppet-agent/install/postinstall: !: not found
/var/sadm/pkg/puppet-agent/install/postinstall: !: not found
/var/sadm/pkg/puppet-agent/install/postinstall: !: not found
/var/sadm/pkg/puppet-agent/install/postinstall: !: not found
/var/sadm/pkg/puppet-agent/install/postinstall: !: not found
/var/sadm/pkg/puppet-agent/install/postinstall: !: not found
/var/sadm/pkg/puppet-agent/install/postinstall: !: not found
/var/sadm/pkg/puppet-agent/install/postinstall: !: not found
rootx0:0:Super-User:/:/usr/bin/bash
root::0:
Installation of <puppet-agent> was successful.
```

To avoid these types of errors, do not use `!` in the script, and remove
the pristine files instead of tampering with the non-pristine ones.

This also takes care of the case when `diff` is not present on the
system, causing the check to noop instead of clobbering.

Also, check if a file or directory exists before running `chmod` on it on Solaris 10.