### PR TITLE
(VANAGON-164) Process the OpenStruct from `get_requires` in Solaris templates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
   the rpm and deb packages.
 
 ### Fixed
+- (VANAGON-164) Fix bugs for Solaris templates - process the OpenStruct returned 
+  by `get_requires` 
 - (maint) Fix bugs in pick_engine
 - (maint) Fix pristine config files clobbering (Solaris 10)
 

--- a/resources/solaris/10/depend.erb
+++ b/resources/solaris/10/depend.erb
@@ -1,3 +1,3 @@
-<%- get_requires.each do |requirement| -%>
-P <%= requirement %>
+<%- get_requires.each do |requires| -%>
+P <%= requires.requirement %>
 <%- end -%>

--- a/resources/solaris/11/p5m.erb
+++ b/resources/solaris/11/p5m.erb
@@ -17,8 +17,8 @@ set name=variant.opensolaris.zone value=global value=nonglobal
 %>
 
 # Add any needed dependencies
-<%- get_requires.each do |requirement| -%>
-depend fmri=pkg:/<%= requirement %> type=require
+<%- get_requires.each do |requires| -%>
+depend fmri=pkg:/<%= requires.requirement %> type=require
 <%- end -%>
 
 # Always drop /etc, /usr, and /var, it will cause conflicts with other system packages


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.