### PR TITLE
(MAINT) Fix invalid invocation of VanagonLogger in Component class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- (maint) Fixed an issue invoking VanagonLogger in the error handling for the
+  `Vanagon::Component.load_component` method
 
 ## [0.19.0] - released 2021-1-12
 ### Added

--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -141,7 +141,7 @@ class Vanagon
       dsl._component
     rescue StandardError => e
       VanagonLogger.error "Error loading project '#{name}' using '#{compfile}':"
-      VanagonLogger(e)
+      VanagonLogger.error e
       VanagonLogger.error e.backtrace.join("\n")
       raise e
     end


### PR DESCRIPTION
Resolves the following failure, allowing the actual underlying exception to be seen instead:

```
13:54:24 /var/lib/jenkins/workspace/platform_pdk_adhoc_pdk-van-init-manual-parameters_adhoc/pdk-vanagon/.bundle/gems/ruby/2.4.0/gems/vanagon-0.19.0/lib/vanagon/component.rb:144:in `rescue in load_component': undefined method `VanagonLogger' for Vanagon::Component:Class (NoMethodError)
13:54:24 	from /var/lib/jenkins/workspace/platform_pdk_adhoc_pdk-van-init-manual-parameters_adhoc/pdk-vanagon/.bundle/gems/ruby/2.4.0/gems/vanagon-0.19.0/lib/vanagon/component.rb:138:in `load_component'
13:54:24 	from /var/lib/jenkins/workspace/platform_pdk_adhoc_pdk-van-init-manual-parameters_adhoc/pdk-vanagon/.bundle/gems/ruby/2.4.0/gems/vanagon-0.19.0/lib/vanagon/project/dsl.rb:274:in `component'
13:54:24 	from /var/lib/jenkins/workspace/platform_pdk_adhoc_pdk-van-init-manual-parameters_adhoc/pdk-vanagon/configs/projects/pdk.rb:185:in `block in load_project'
13:54:24 	from /var/lib/jenkins/workspace/platform_pdk_adhoc_pdk-van-init-manual-parameters_adhoc/pdk-vanagon/.bundle/gems/ruby/2.4.0/gems/vanagon-0.19.0/lib/vanagon/project/dsl.rb:32:in `project'
13:54:24 	from /var/lib/jenkins/workspace/platform_pdk_adhoc_pdk-van-init-manual-parameters_adhoc/pdk-vanagon/configs/projects/pdk.rb:1:in `load_project'
13:54:24 	from /var/lib/jenkins/workspace/platform_pdk_adhoc_pdk-van-init-manual-parameters_adhoc/pdk-vanagon/.bundle/gems/ruby/2.4.0/gems/vanagon-0.19.0/lib/vanagon/project.rb:131:in `instance_eval'
13:54:24 	from /var/lib/jenkins/workspace/platform_pdk_adhoc_pdk-van-init-manual-parameters_adhoc/pdk-vanagon/.bundle/gems/ruby/2.4.0/gems/vanagon-0.19.0/lib/vanagon/project.rb:131:in `load_project'
13:54:24 	from /var/lib/jenkins/workspace/platform_pdk_adhoc_pdk-van-init-manual-parameters_adhoc/pdk-vanagon/.bundle/gems/ruby/2.4.0/gems/vanagon-0.19.0/lib/vanagon/driver.rb:35:in `initialize'
13:54:24 	from /var/lib/jenkins/workspace/platform_pdk_adhoc_pdk-van-init-manual-parameters_adhoc/pdk-vanagon/.bundle/gems/ruby/2.4.0/gems/vanagon-0.19.0/lib/vanagon/cli/build_host_info.rb:39:in `new'
13:54:24 	from /var/lib/jenkins/workspace/platform_pdk_adhoc_pdk-van-init-manual-parameters_adhoc/pdk-vanagon/.bundle/gems/ruby/2.4.0/gems/vanagon-0.19.0/lib/vanagon/cli/build_host_info.rb:39:in `block in run'
13:54:24 	from /var/lib/jenkins/workspace/platform_pdk_adhoc_pdk-van-init-manual-parameters_adhoc/pdk-vanagon/.bundle/gems/ruby/2.4.0/gems/vanagon-0.19.0/lib/vanagon/cli/build_host_info.rb:38:in `each'
13:54:24 	from /var/lib/jenkins/workspace/platform_pdk_adhoc_pdk-van-init-manual-parameters_adhoc/pdk-vanagon/.bundle/gems/ruby/2.4.0/gems/vanagon-0.19.0/lib/vanagon/cli/build_host_info.rb:38:in `run'
13:54:24 	from /var/lib/jenkins/workspace/platform_pdk_adhoc_pdk-van-init-manual-parameters_adhoc/pdk-vanagon/.bundle/gems/ruby/2.4.0/gems/vanagon-0.19.0/lib/vanagon/cli.rb:82:in `run'
13:54:24 	from /var/lib/jenkins/workspace/platform_pdk_adhoc_pdk-van-init-manual-parameters_adhoc/pdk-vanagon/.bundle/gems/ruby/2.4.0/gems/vanagon-0.19.0/bin/vanagon:7:in `<top (required)>'
13:54:24 	from /var/lib/jenkins/workspace/platform_pdk_adhoc_pdk-van-init-manual-parameters_adhoc/pdk-vanagon/.bundle/gems/ruby/2.4.0/bin/vanagon:23:in `load'
13:54:24 	from /var/lib/jenkins/workspace/platform_pdk_adhoc_pdk-van-init-manual-parameters_adhoc/pdk-vanagon/.bundle/gems/ruby/2.4.0/bin/vanagon:23:in `<main>'
```