### PR TITLE
(RE-13837) Hack around Git.ls_remote failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- (RE-13837) Workaround a parsing bug in ruby git where Git.ls-remote was mis-parsing
+  unexpected output from ssh.
 
 ## [0.19.1] - released 2021-1-13
 ### Fixed
@@ -18,8 +21,8 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
   the rpm and deb packages.
 
 ### Fixed
-- (VANAGON-164) Fix bugs for Solaris templates - process the OpenStruct returned 
-  by `get_requires` 
+- (VANAGON-164) Fix bugs for Solaris templates - process the OpenStruct returned
+  by `get_requires`
 - (maint) Fix bugs in pick_engine
 - (maint) Fix pristine config files clobbering (Solaris 10)
 

--- a/lib/vanagon/component/source/git.rb
+++ b/lib/vanagon/component/source/git.rb
@@ -54,7 +54,8 @@ class Vanagon
               return false unless $?.exitstatus.zero?
               return true
             end
-          rescue RuntimeError
+          rescue RuntimeError # rubocop:disable Lint/ShadowedException
+            ## rubocop is right by flagging this but I think we need it in this case.
             return false
           rescue Timeout::Error
             return false

--- a/lib/vanagon/component/source/git.rb
+++ b/lib/vanagon/component/source/git.rb
@@ -26,14 +26,38 @@ class Vanagon
           #        git command has failed. Useful in instances where a URL
           #        prompts for credentials despite not being a git remote
           # @return [Boolean] whether #url is a valid Git repo or not
+
+          # [RE-13837] This ought to be the way to do this. Unfortunately,
+          # there's a bug in Git.ls_remote that when ssh prints something like
+          #  Warning: Permanently added 'github.com,192.30.255.113' (RSA)
+          # Git.ls_remote attempts to parse it as actual git output and fails
+          # with: NoMethodError: undefined method `split' for nil:NilClass
+          #
+          # We'll work around that case by calling 'git ls-remote' directly ourselves.
+          #
+          # I'm leaving in the broken version here for a time when the ruby-git library
+          # is fixed.
+
+          #def valid_remote?(url, timeout = 0)
+          #  Timeout.timeout(timeout) do
+          #    !!::Git.ls_remote(url)
+          #  end
+          #rescue ::Git::GitExecuteError
+          #  false
+          #rescue Timeout::Error
+          #  false
+          #end
+
           def valid_remote?(url, timeout = 0)
             Timeout.timeout(timeout) do
-              !!::Git.ls_remote(url)
+              Vanagon::Utilities.local_command("git ls-remote #{url} > /dev/null 2>&1")
+              return false unless $?.exitstatus.zero?
+              return true
             end
-          rescue ::Git::GitExecuteError
-            false
+          rescue RuntimeError
+            return false
           rescue Timeout::Error
-            false
+            return false
           end
         end
 

--- a/lib/vanagon/component/source/git.rb
+++ b/lib/vanagon/component/source/git.rb
@@ -54,10 +54,9 @@ class Vanagon
               return false unless $?.exitstatus.zero?
               return true
             end
-          rescue RuntimeError # rubocop:disable Lint/ShadowedException
-            ## rubocop is right by flagging this but I think we need it in this case.
-            return false
           rescue Timeout::Error
+            return false
+          rescue RuntimeError
             return false
           end
         end

--- a/spec/lib/vanagon/component/source/git_spec.rb
+++ b/spec/lib/vanagon/component/source/git_spec.rb
@@ -14,8 +14,8 @@ describe "Vanagon::Component::Source::Git" do
 
   # before(:each) blocks are run before each example
   before :each do
-    allow(Git)
-      .to receive(:ls_remote)
+    allow(Vanagon::Component::Source::Git)
+      .to receive(:valid_remote?)
             .and_return(true)
 
     allow(File).to receive(:realpath).and_return(@workdir)
@@ -24,8 +24,8 @@ describe "Vanagon::Component::Source::Git" do
   describe "#initialize" do
     it "raises error on initialization with an invalid repo" do
       # Ensure initializing a repo fails without calling over the network
-      allow(Git)
-        .to receive(:ls_remote)
+      allow(Vanagon::Component::Source::Git)
+        .to receive(:valid_remote?)
               .and_return(false)
 
       expect { @klass.new(@url, ref: @ref_tag, workdir: @workdir) }

--- a/spec/lib/vanagon/utilities_spec.rb
+++ b/spec/lib/vanagon/utilities_spec.rb
@@ -72,11 +72,14 @@ describe "Vanagon::Utilities" do
   describe '#local_command' do
     it 'runs commands in an unpolluted environment' do
       cmd = lambda { |arg| %(echo 'if [ "$#{arg}" = "" ]; then exit 0; else exit 1; fi' | /bin/sh) }
-      vars = %w(BUNDLE_BIN_PATH BUNDLE_GEMFILE)
+      vars = %w[BUNDLE_BIN_PATH BUNDLE_GEMFILE]
       vars.each do |var|
         Vanagon::Utilities.local_command(cmd.call(var))
         expect($?.exitstatus).to eq(0)
       end
+    end
+    it 'raises a RuntimeError when given a bad thing' do
+      expect { Vanagon::Utilities.local_command('__bogus__comand__') }.to raise_error(RuntimeError)
     end
   end
 

--- a/vanagon.gemspec
+++ b/vanagon.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('docopt')
   # Handle git repos responsibly
   # - MIT licensed: https://rubygems.org/gems/git
-  gem.add_runtime_dependency('git', '~> 1.3.0')
+  gem.add_runtime_dependency('git', '~> 1.8.0')
   # Parse scp-style triplets like URIs; used for Git source handling.
   # - MIT licensed: https://rubygems.org/gems/fustigit
   gem.add_runtime_dependency('fustigit', '~> 0.1.3')


### PR DESCRIPTION
Create a slightly sloppy workaround for a failure in Git.ls_remote

When Git.ls_remote calls the git command-line, under moderately common circumstances, ssh can be involved and it can print something like:

    Warning: Permanently added 'github.com,192.30.255.113' (RSA) ...

Git.ls_remote, does not anticipate this and attempts to parse it as actual `git ls-remote` output.

This results in a `NoMethodError: undefined method 'split' for nil:NilClass` because the [#split](https://github.com/ruby-git/ruby-git/blob/bd026d39b17e192e8a710744153ed28139cc64a7/lib/git/lib.rb#L502) fails on the unexpected message.

I think that leaves us with 3 possible solutions.

1. Not use ruby-git for this operation (which was my choice).
1. monkey-patch the Git.ls_remote method (which was my 2nd choice)
1. catch the 'NoMethodError' exception and try to sort it out (yuck!)

It would be good citizenry to submit a PR to ruby-git which I might do to correctly fix this problem. I may endeavor to do so.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.