### PR TITLE
(VANAGON-123) deb systemv and systemd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Added
+- (VANAGON-123) Re-add support for multiple service types for a single platform.
+  This is intended primarily for Debian packages supporting both systemd and
+  sysv init systems. The systemd/init check was updated.
+
 ### Fixed
 - (RE-13837) Workaround a parsing bug in ruby git where Git.ls-remote was mis-parsing
   unexpected output from ssh.

--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -180,6 +180,7 @@ class Vanagon
       @preremove_actions = []
       @postremove_actions = []
       @install_only = false
+      @service = []
     end
 
     # Adds the given file to the list of files and returns @files.

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -167,8 +167,8 @@ class Vanagon
       #
       # @param service_file [String] path to the service file relative to the source
       # @param default_file [String] path to the default file relative to the source
+      # @param service_name [String] name of the service
       # @param options optional extra parameters
-      #        service_name [String] name of the service
       #        service_type [String] type of the service (network, application, system, etc)
       #        init_system [String] the init system on which to install service (sysv, systemd)
       #        link_target [String] executable service file should be linked to

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -167,38 +167,43 @@ class Vanagon
       #
       # @param service_file [String] path to the service file relative to the source
       # @param default_file [String] path to the default file relative to the source
-      # @param service_name [String] name of the service
-      # @param service_type [String] type of the service (network, application, system, etc)
-      # @param link_target [String] executable service file should be linked to
-      def install_service(service_file, default_file = nil, service_name = @component.name, service_type: nil, link_target: nil) # rubocop:disable Metrics/AbcSize
-        case @component.platform.servicetype
+      # @param options optional extra parameters
+      #        service_name [String] name of the service
+      #        service_type [String] type of the service (network, application, system, etc)
+      #        init_system [String] the init system on which to install service (sysv, systemd)
+      #        link_target [String] executable service file should be linked to
+      def install_service(service_file, default_file = nil, service_name = @component.name, **options) # rubocop:disable Metrics/AbcSize
+        init_system = options[:init_system] || @component.platform.servicetype
+        servicedir = @component.platform.get_service_dir(init_system)
+
+        case init_system
         when "sysv"
-          target_service_file = File.join(@component.platform.servicedir, service_name)
+          target_service_file = File.join(servicedir, service_name)
           target_default_file = File.join(@component.platform.defaultdir, service_name)
           target_mode = '0755'
           default_mode = '0644'
         when "systemd"
-          target_service_file = File.join(@component.platform.servicedir, "#{service_name}.service")
+          target_service_file = File.join(servicedir, "#{service_name}.service")
           target_default_file = File.join(@component.platform.defaultdir, service_name)
           target_mode = '0644'
           default_mode = '0644'
         when "launchd"
-          target_service_file = File.join(@component.platform.servicedir, "#{service_name}.plist")
+          target_service_file = File.join(servicedir, "#{service_name}.plist")
           target_mode = '0644'
           default_mode = '0644'
         when "smf"
           # modify version in smf manifest so service gets restarted after package upgrade
           @component.install << %{#{@component.platform.sed} -ri 's/(<service.*version=)(".*")/\\1"#{Time.now.to_i}"/' #{service_file}}
-          target_service_file = File.join(@component.platform.servicedir, service_type.to_s, "#{service_name}.xml")
+          target_service_file = File.join(servicedir, options[:service_type].to_s, "#{service_name}.xml")
           target_default_file = File.join(@component.platform.defaultdir, service_name)
           target_mode = '0644'
           default_mode = '0755'
         when "aix"
-          @component.service = OpenStruct.new(:name => service_name, :service_command => File.read(service_file).chomp)
+          @component.service << OpenStruct.new(:name => service_name, :service_command => File.read(service_file).chomp)
           # Return here because there is no file to install, just a string read in
           return
         when "windows"
-          @component.service = OpenStruct.new(\
+          @component.service << OpenStruct.new(\
             :bindir_id => "#{service_name.gsub(/[^A-Za-z0-9]/, '').upcase}BINDIR", \
             :service_file => service_file, \
             :component_group_id => "#{service_name.gsub(/[^A-Za-z0-9]/, '')}Component"\
@@ -206,13 +211,13 @@ class Vanagon
           # return here as we are just collecting the name of the service file to put into the harvest filter list.
           return
         else
-          fail "Don't know how to install the #{@component.platform.servicetype}. Please teach #install_service how to do this."
+          fail "Don't know how to install the #{init_system}. Please teach #install_service how to do this."
         end
 
         # Install the service and default files
-        if link_target
-          install_file(service_file, link_target, mode: target_mode)
-          link link_target, target_service_file
+        if options[:link_target]
+          install_file(service_file, options[:link_target], mode: target_mode)
+          link options[:link_target], target_service_file
         else
           install_file(service_file, target_service_file, mode: target_mode)
         end
@@ -223,7 +228,7 @@ class Vanagon
         end
 
         # Register the service for use in packaging
-        @component.service = OpenStruct.new(:name => service_name, :service_file => target_service_file, :type => service_type)
+        @component.service << OpenStruct.new(:name => service_name, :service_file => target_service_file, :type => options[:service_type])
       end
 
       # Copies a file from source to target during the install phase of the component

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -33,6 +33,9 @@ class Vanagon
     # Where does a given platform expect to find init scripts/service files?
     # e.g. /etc/init.d, /usr/lib/systemd/system
     attr_accessor :servicedir
+    # Array of OpenStructs containing the servicetype and the corresponding
+    # servicedir
+    attr_accessor :servicetypes
     # Where does a given platform's init system expect to find
     # something resembling 'defaults' files. Most likely to apply
     # to Linux systems that use SysV-ish, upstart, or systemd init systems.
@@ -245,6 +248,7 @@ class Vanagon
       # Our first attempt at defining metadata about a platform
       @cross_compiled ||= false
       @valid_operators ||= ['<', '>', '<=', '>=', '=']
+      @servicetypes = []
     end
 
     def shell # rubocop:disable Lint/DuplicateMethods
@@ -552,6 +556,34 @@ class Vanagon
 
     def validate_operator(operator_string)
       valid_operators.include?(operator_string)
+    end
+
+    # Get all configured service types (added through plat.servicetype)
+    # @return array of service types, empty array if none have been configured
+    def get_service_types
+      if @servicetypes.any?
+        @servicetypes.flat_map(&:servicetype).compact
+      elsif @servicetype
+        [@servicetype]
+      else
+        []
+      end
+    end
+
+    # Get configured service dir (added through plat.servicedir, or plat.servicetype 'foo', servicedir: 'bar')
+    # @param servicetype the service type you want the service dir for (optional)
+    # @raises VanagonError if more than one service dir is found
+    def get_service_dir(servicetype = '')
+      if @servicetypes.empty?
+        return @servicedir
+      end
+      servicedir = @servicetypes.select { |s| s.servicetype.include?(servicetype) }.flat_map(&:servicedir).compact
+
+      if servicedir.size > 1
+        raise Vanagon::Error, "You can only have one service dir for each service type. Found '#{servicedir.join(',')}' for service type #{servicetype}"
+      end
+
+      servicedir.first
     end
   end
 end

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -10,6 +10,7 @@ require 'vanagon/platform/solaris_11'
 require 'vanagon/platform/windows'
 require 'vanagon/logger'
 require 'securerandom'
+require 'ostruct'
 require 'uri'
 
 class Vanagon
@@ -219,6 +220,11 @@ class Vanagon
       # @param dir [String] Directory where service files live on the platform
       def servicedir(dir)
         @platform.servicedir = dir
+
+        # Add to the servicetypes array if we haven't already
+        if @platform.servicetype && @platform.servicedir && @platform.servicetypes.select { |s| s.servicetype == @platform.servicetype }.empty?
+          @platform.servicetypes << OpenStruct.new(:servicetype => @platform.servicetype, :servicedir => @platform.servicedir)
+        end
       end
 
       # Set the directory where default or sysconfig files live for the platform
@@ -231,8 +237,18 @@ class Vanagon
       # Set the servicetype for the platform so that services can be installed correctly.
       #
       # @param type [String] service type for the platform ('sysv' for example)
-      def servicetype(type)
-        @platform.servicetype = type
+      # @param servicedir [String] service dir for this platform and service type ('/etc/init.d' for example). Optional.
+      def servicetype(type, servicedir: nil) # rubocop:disable Metrics/AbcSize
+        if servicedir
+          @platform.servicetypes << OpenStruct.new(:servicetype => type, :servicedir => servicedir)
+        else
+          @platform.servicetype = type
+        end
+
+        # Add to the servicetypes array if we haven't already
+        if @platform.servicetype && @platform.servicedir && @platform.servicetypes.select { |s| s.servicetype == @platform.servicetype }.empty?
+          @platform.servicetypes << OpenStruct.new(:servicetype => @platform.servicetype, :servicedir => @platform.servicedir)
+        end
       end
 
       # Set the list of possible host to perform a build on (when not using

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -351,10 +351,14 @@ class Vanagon
     # will return nil
     #
     # @param [string] name of service to grab
-    # @return [@component.service obj] specific service
+    # @return [@component.service obj] specific service, or array of services
+    #         if there's more than one
     def get_service(name)
       components.each do |component|
         if component.name == name
+          if component.service.size == 1
+            return component.service.first
+          end
           return component.service
         end
       end

--- a/resources/deb/postinst.erb
+++ b/resources/deb/postinst.erb
@@ -2,18 +2,23 @@
 <%- get_services.each do |service| -%>
   # switch based on systemd vs systemv
   #
-  <%- if @platform.servicetype == "systemd" -%>
-if [ -z "$2" ]; then
-  systemctl enable <%= service.name %>.service >/dev/null || :
-else
-  systemctl try-restart <%= service.name %>.service >/dev/null || :
+  <%- if service.init_system.nil? || service.init_system.eq?('systemd') -%>
+if [ -d '/run/systemd/system' ] ; then
+  if [ -z "$2" ]; then
+    systemctl enable <%= service.name %>.service >/dev/null || :
+  else
+    systemctl try-restart <%= service.name %>.service >/dev/null || :
+  fi
 fi
-  <%- elsif @platform.servicetype == "sysv" -%>
-if [ -x "<%= service.service_file %>" ]; then
-  update-rc.d <%= service.name %> defaults > /dev/null
+  <%- end -%>
+  <%- if service.init_system.nil? || service.init_system.eq?('sysv') -%>
+if [ ! -d '/run/systemd/system' ] ; then
+  if [ -x "<%= service.service_file %>" ]; then
+    update-rc.d <%= service.name %> defaults > /dev/null
 
-  if [ -n "$2" ]; then
-    invoke-rc.d <%= service.name %> condrestart || true
+    if [ -n "$2" ]; then
+      invoke-rc.d <%= service.name %> condrestart || true
+    fi
   fi
 fi
   <%- end -%>
@@ -27,17 +32,17 @@ fi
 
 # Set up any specific permissions needed...
 <%- (get_directories + get_configfiles + get_files).select { |pathname| pathname.has_overrides? }.uniq.each do |file_or_directory| -%>
-  <%= "chmod '#{file_or_directory.mode}' '#{file_or_directory.path}'" if file_or_directory.mode %>
+  <%= "chmod '#{file_or_directory.mode}' '#{file_or_directory.path}' &>/dev/null ||:" if file_or_directory.mode %>
   <%- if file_or_directory.owner -%>
     if getent passwd '<%= file_or_directory.owner %>' &> /dev/null; then
-      chown '<%= file_or_directory.owner %>' '<%= file_or_directory.path %>'
+      chown '<%= file_or_directory.owner %>' '<%= file_or_directory.path %>' &>/dev/null ||:
     else
       echo "Error updating '<%= file_or_directory.path %>': user '<%= file_or_directory.owner %>' does not exist."
     fi
   <%- end -%>
   <%- if file_or_directory.group -%>
     if getent group '<%= file_or_directory.group %>' &> /dev/null; then
-      chgrp '<%= file_or_directory.group %>' '<%= file_or_directory.path %>'
+      chgrp '<%= file_or_directory.group %>' '<%= file_or_directory.path %>' &>/dev/null ||:
     else
       echo "Error updating '<%= file_or_directory.path %>': group '<%= file_or_directory.group %>' does not exist."
     fi

--- a/resources/deb/postinst.erb
+++ b/resources/deb/postinst.erb
@@ -3,21 +3,27 @@
   # switch based on systemd vs systemv
   #
   <%- if service.init_system.nil? || service.init_system.eq?('systemd') -%>
-if [ -d '/run/systemd/system' ] ; then
-  if [ -z "$2" ]; then
-    systemctl enable <%= service.name %>.service >/dev/null || :
-  else
-    systemctl try-restart <%= service.name %>.service >/dev/null || :
+if [ -f '/proc/1/comm' ]; then
+  init_comm=`cat /proc/1/comm`
+  if [ "$init_comm" = "systemd" ]; then
+    if [ -z "$2" ]; then
+      systemctl enable <%= service.name %>.service >/dev/null || :
+    else
+      systemctl try-restart <%= service.name %>.service >/dev/null || :
+    fi
   fi
 fi
   <%- end -%>
   <%- if service.init_system.nil? || service.init_system.eq?('sysv') -%>
-if [ ! -d '/run/systemd/system' ] ; then
-  if [ -x "<%= service.service_file %>" ]; then
-    update-rc.d <%= service.name %> defaults > /dev/null
+if [ -f '/proc/1/comm' ]; then
+  init_comm=`cat /proc/1/comm`
+  if [ "$init_comm" = "init" ]; then
+    if [ -x "<%= service.service_file %>" ]; then
+      update-rc.d <%= service.name %> defaults > /dev/null
 
-    if [ -n "$2" ]; then
-      invoke-rc.d <%= service.name %> condrestart || true
+      if [ -n "$2" ]; then
+        invoke-rc.d <%= service.name %> condrestart || true
+      fi
     fi
   fi
 fi

--- a/resources/deb/postrm.erb
+++ b/resources/deb/postrm.erb
@@ -13,11 +13,11 @@ fi
 <%- get_services.each do |service| -%>
   # switch based on systemd vs systemv
   #
-  <%- if @platform.servicetype == "systemd" -%>
-systemctl daemon-reload >/dev/null 2>&1 || :
-  <%- elsif @platform.servicetype == "sysv" -%>
-if [ "$1" = "purge" ] ; then
-  update-rc.d <%= service.name %> remove > /dev/null
+if [ -d '/run/systemd/system' ] ; then
+  systemctl daemon-reload >/dev/null 2>&1 || :
+else
+  if [ "$1" = "purge" ] ; then
+    update-rc.d <%= service.name %> remove > /dev/null
+  fi
 fi
-  <%- end -%>
 <%- end -%>

--- a/resources/deb/postrm.erb
+++ b/resources/deb/postrm.erb
@@ -13,11 +13,14 @@ fi
 <%- get_services.each do |service| -%>
   # switch based on systemd vs systemv
   #
-if [ -d '/run/systemd/system' ] ; then
-  systemctl daemon-reload >/dev/null 2>&1 || :
-else
-  if [ "$1" = "purge" ] ; then
-    update-rc.d <%= service.name %> remove > /dev/null
+if [ -f '/proc/1/comm' ]; then
+  init_comm=`cat /proc/1/comm`
+  if [ "$init_comm" = "systemd" ]; then
+    systemctl daemon-reload >/dev/null 2>&1 || :
+  else
+    if [ "$1" = "purge" ] ; then
+      update-rc.d <%= service.name %> remove > /dev/null
+    fi
   fi
 fi
 <%- end -%>

--- a/resources/deb/prerm.erb
+++ b/resources/deb/prerm.erb
@@ -13,15 +13,19 @@ fi
 <%- get_services.each do |service| -%>
   # switch based on systemd vs systemv
   #
-  <%- if @platform.servicetype == "systemd" -%>
-if [ "$1" = remove ]; then
-  systemctl --no-reload disable <%= service.name %>.service > /dev/null 2>&1 || :
-  systemctl stop <%= service.name %>.service > /dev/null 2>&1 || :
+  <%- if service.init_system.nil? || service.init_system.eq?('systemd') -%>
+if [ -d '/run/systemd/system' ] ; then
+  if [ "$1" = remove ]; then
+    systemctl --no-reload disable <%= service.name %>.service > /dev/null 2>&1 || :
+    systemctl stop <%= service.name %>.service > /dev/null 2>&1 || :
+  fi
 fi
-
-  <%- elsif @platform.servicetype == "sysv" -%>
-if [ -x "<%= service.service_file %>" ] && [ "$1" = remove ]; then
-  invoke-rc.d <%= service.name %> stop || true
+  <%- end -%>
+  <%- if service.init_system.nil? || service.init_system.eq?('sysv') -%>
+if [ ! -d '/run/systemd/system' ] ; then
+  if [ -x "<%= service.service_file %>" ] && [ "$1" = remove ]; then
+    invoke-rc.d <%= service.name %> stop || true
+  fi
 fi
   <%- end -%>
 <%- end -%>

--- a/resources/deb/prerm.erb
+++ b/resources/deb/prerm.erb
@@ -14,17 +14,23 @@ fi
   # switch based on systemd vs systemv
   #
   <%- if service.init_system.nil? || service.init_system.eq?('systemd') -%>
-if [ -d '/run/systemd/system' ] ; then
-  if [ "$1" = remove ]; then
-    systemctl --no-reload disable <%= service.name %>.service > /dev/null 2>&1 || :
-    systemctl stop <%= service.name %>.service > /dev/null 2>&1 || :
+if [ -f '/proc/1/comm' ]; then
+  init_comm=`cat /proc/1/comm`
+  if [ "$init_comm" = "systemd" ]; then
+    if [ "$1" = remove ]; then
+      systemctl --no-reload disable <%= service.name %>.service > /dev/null 2>&1 || :
+      systemctl stop <%= service.name %>.service > /dev/null 2>&1 || :
+    fi
   fi
 fi
   <%- end -%>
   <%- if service.init_system.nil? || service.init_system.eq?('sysv') -%>
-if [ ! -d '/run/systemd/system' ] ; then
-  if [ -x "<%= service.service_file %>" ] && [ "$1" = remove ]; then
-    invoke-rc.d <%= service.name %> stop || true
+if [ -f '/proc/1/comm' ]; then
+  init_comm=`cat /proc/1/comm`
+  if [ "$init_comm" = "init" ]; then
+    if [ -x "<%= service.service_file %>" ] && [ "$1" = remove ]; then
+      invoke-rc.d <%= service.name %> stop || true
+    fi
   fi
 fi
   <%- end -%>

--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -98,7 +98,7 @@ Requires(post): /bin/touch
 <%- end -%>
 
 <%- if has_services? -%>
-  <%- if @platform.servicetype == "systemd" -%>
+  <%- if @platform.get_service_types.include?("systemd") -%>
     <%- if @platform.is_sles? -%>
 BuildRequires:    systemd
 %{?systemd_requires}
@@ -108,7 +108,7 @@ Requires(post):   systemd
 Requires(preun):  systemd
 Requires(postun): systemd
     <%- end -%>
-  <%- elsif @platform.servicetype == "sysv" -%>
+  <%- elsif @platform.get_service_types.include?("sysv") -%>
     <%- if @platform.is_sles? -%>
 Requires: aaa_base
     <%- elsif @platform.is_linux? -%>
@@ -256,15 +256,15 @@ fi
 <%- get_services.each do |service| -%>
   # switch based on systemd vs systemv vs smf vs aix
   #
-  <%- if @platform.servicetype == "systemd" -%>
+  <%- if @platform.get_service_types.include?("systemd") -%>
     <%- if @platform.is_sles? -%>
       %service_add_post <%= service.name %>.service
     <%- else -%>
       %systemd_post <%= service.name %>.service
     <%- end -%>
-  <%- elsif @platform.servicetype == "sysv" -%>
+  <%- elsif @platform.get_service_types.include?("sysv") -%>
     chkconfig --add <%= service.name %> >/dev/null 2>&1 || :
-  <%- elsif @platform.servicetype == "aix" -%>
+  <%- elsif @platform.get_service_types.include?("aix") -%>
     if /usr/bin/lssrc -s <%= service.name -%> > /dev/null 2>&1; then
       /usr/bin/chssys -s <%= service.name -%> -p <%= service.service_command -%> -w 7 -S -n 15 -f 9 > /dev/null 2>&1 || :
     else
@@ -305,17 +305,17 @@ fi
 <%- get_services.each do |service| -%>
   # switch based on systemd vs systemv vs smf vs aix
   #
-  <%- if @platform.servicetype == "systemd" -%>
+  <%- if @platform.get_service_types.include?("systemd") -%>
     <%- if @platform.is_sles? -%>
       %service_del_postun <%= service.name %>.service
     <%- else -%>
       %systemd_postun_with_restart <%= service.name %>.service
     <%- end -%>
-  <%- elsif @platform.servicetype == "sysv" -%>
+  <%- elsif @platform.get_service_types.include?("sysv") -%>
     if [ "$1" -eq 1 ]; then
       /sbin/service <%= service.name %> condrestart || :
     fi
-  <%- elsif @platform.servicetype == "aix" -%>
+  <%- elsif @platform.get_service_types.include?("aix") -%>
     if  [ "$1" -eq 0 ]; then
       /usr/bin/rmssys -s <%= service.name -%> > /dev/null 2>&1 || :
       /usr/sbin/rmitab <%= service.name -%> > /dev/null 2>&1 || :
@@ -336,18 +336,18 @@ if [ "$1" -eq 0 ] ; then
 fi
 
 <%- get_services.each do |service| -%>
-  <%- if @platform.servicetype == "systemd" -%>
+  <%- if @platform.get_service_types.include?("systemd") -%>
     <%- if @platform.is_sles? -%>
       %service_del_preun <%= service.name %>.service
     <%- else -%>
       %systemd_preun <%= service.name %>.service
     <%- end -%>
-  <%- elsif @platform.servicetype == "sysv" -%>
+  <%- elsif @platform.get_service_types.include?("sysv") -%>
     if [ "$1" -eq 0 ]; then
       /sbin/service <%= service.name %> stop >/dev/null 2>&1 || :
       chkconfig --del <%= service.name %> || :
     fi
-  <%- elsif @platform.servicetype == "aix" -%>
+  <%- elsif @platform.get_service_types.include?("aix") -%>
       # stop the service only on a real uninstall, not on upgrades
       if [ "$1" -eq 0 ] ; then
           /usr/bin/stopsrc -s <%= service.name -%> > /dev/null 2>&1 || :


### PR DESCRIPTION
Debian in particular supports running modern systems under either
systemd or sysv. This adds support for passing multiple servicetypes in
your platform definition and also installing multiple services.

This PR contains the original changes from https://github.com/puppetlabs/vanagon/pull/556 with systemd check updated
to be the same as the one used by puppet systemd service provider