### PR TITLE
(maint) Allow VANAGON_USE_MIRROR to recognize `false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ Port of the system where redis is running. Defaults to *6379*.
 ##### `VANAGON_USE_MIRRORS`
 Controls whether component sources are downloaded directly from upstream URLs
 or from configured mirrors. Most Puppet projects using Vanagon default to
-fetching components from internal mirrors. Set this variable to `n` when
-building outside of the Puppet private network to download directly from
+fetching components from internal mirrors. Set this variable to `n` or `false`
+when building outside of the Puppet private network to download directly from
 upstream sources.
 
 ##### `VANAGON_RETRY_COUNT`

--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -305,7 +305,7 @@ class Vanagon
     def get_source(workdir) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
       opts = options.merge({ workdir: workdir })
       if url || !mirrors.empty?
-        if ENV['VANAGON_USE_MIRRORS'] == 'n'
+        if ENV['VANAGON_USE_MIRRORS'] == 'n' or ENV['VANAGON_USE_MIRRORS'] == 'false'
           fetch_url(opts)
         else
           fetch_mirrors(opts) || fetch_url(opts)

--- a/spec/lib/vanagon/component_spec.rb
+++ b/spec/lib/vanagon/component_spec.rb
@@ -108,6 +108,18 @@ describe "Vanagon::Component" do
       expect(subject).to receive(:fetch_url)
       subject.get_source(@workdir)
     end
+
+    it 'retrieves from a canonical URI if VANAGON_USE_MIRRORS is set to "false"' do
+      allow(ENV).to receive(:[]).with('VANAGON_USE_MIRRORS').and_return('false')
+      allow(subject)
+        .to receive(:fetch_url)
+        .and_return(true)
+
+      # We expect #get_source to skip mirrors
+      expect(subject).not_to receive(:fetch_mirrors)
+      expect(subject).to receive(:fetch_url)
+      subject.get_source(@workdir)
+    end
   end
 
   describe "#get_sources" do


### PR DESCRIPTION
Previous the VANAGON_USE_MIRROR env variable only recoginzied `n`. This
seems counter intuitive, so I've added a small adjustment to have it
also recognize `false`.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.