### PR TITLE
(maint) keep `init_system` in OpenStruct

### DIFF
--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -228,7 +228,8 @@ class Vanagon
         end
 
         # Register the service for use in packaging
-        @component.service << OpenStruct.new(:name => service_name, :service_file => target_service_file, :type => options[:service_type])
+        @component.service << OpenStruct.new(:name => service_name, :service_file => target_service_file,
+                                             :type => options[:service_type], :init_system => init_system)
       end
 
       # Copies a file from source to target during the install phase of the component

--- a/resources/deb/postinst.erb
+++ b/resources/deb/postinst.erb
@@ -2,7 +2,7 @@
 <%- get_services.each do |service| -%>
   # switch based on systemd vs systemv
   #
-  <%- if service.init_system.nil? || service.init_system.eq?('systemd') -%>
+  <%- if service.init_system.nil? || service.init_system.eql?('systemd') -%>
 if [ -f '/proc/1/comm' ]; then
   init_comm=`cat /proc/1/comm`
   if [ "$init_comm" = "systemd" ]; then
@@ -14,7 +14,7 @@ if [ -f '/proc/1/comm' ]; then
   fi
 fi
   <%- end -%>
-  <%- if service.init_system.nil? || service.init_system.eq?('sysv') -%>
+  <%- if service.init_system.nil? || service.init_system.eql?('sysv') -%>
 if [ -f '/proc/1/comm' ]; then
   init_comm=`cat /proc/1/comm`
   if [ "$init_comm" = "init" ]; then

--- a/resources/deb/prerm.erb
+++ b/resources/deb/prerm.erb
@@ -13,7 +13,7 @@ fi
 <%- get_services.each do |service| -%>
   # switch based on systemd vs systemv
   #
-  <%- if service.init_system.nil? || service.init_system.eq?('systemd') -%>
+  <%- if service.init_system.nil? || service.init_system.eql?('systemd') -%>
 if [ -f '/proc/1/comm' ]; then
   init_comm=`cat /proc/1/comm`
   if [ "$init_comm" = "systemd" ]; then
@@ -24,7 +24,7 @@ if [ -f '/proc/1/comm' ]; then
   fi
 fi
   <%- end -%>
-  <%- if service.init_system.nil? || service.init_system.eq?('sysv') -%>
+  <%- if service.init_system.nil? || service.init_system.eql?('sysv') -%>
 if [ -f '/proc/1/comm' ]; then
   init_comm=`cat /proc/1/comm`
   if [ "$init_comm" = "init" ]; then


### PR DESCRIPTION
 save `init_system` in OpenStruct since it is used later in scripts templates

 without this change, postinstall actions are executed twice, ignoring init_system

Please add all notable changes to the "Unreleased" section of the CHANGELOG.