### PR TITLE
(RE-13838) Do not mask critical upload failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.20.1] - released 2021-03-15
+### Changed
+- (RE-13838) Remove the rescue from the ship cli code that masked Artifactory
+  upload failures. Make it easier to diagnose when artifacts fail to ship.
+
 ## [0.20.0] - released 2021-2-2
 ### Added
 - (VANAGON-123) Re-add support for multiple service types for a single platform.
@@ -948,7 +953,8 @@ on Debian < 8 and needs more work and testing.
 
 ## Versions <= 0.3.9 do not have a change log entry
 
-[Unreleased]: https://github.com/puppetlabs/vanagon/compare/0.20.0...HEAD
+[Unreleased]: https://github.com/puppetlabs/vanagon/compare/0.20.1...HEAD
+[0.20.1]: https://github.com/puppetlabs/vanagon/compare/0.20.0...0.20.1
 [0.20.0]: https://github.com/puppetlabs/vanagon/compare/0.19.1...0.20.0
 [0.19.1]: https://github.com/puppetlabs/vanagon/compare/0.19.0...0.19.1
 [0.19.0]: https://github.com/puppetlabs/vanagon/compare/0.18.1...0.19.0

--- a/lib/vanagon/cli/ship.rb
+++ b/lib/vanagon/cli/ship.rb
@@ -22,16 +22,6 @@ class Vanagon
       def run(_)
         ENV['PROJECT_ROOT'] = Dir.pwd
 
-        artifactory_warning = <<-DOC
-          Unable to ship packages to artifactory. Please make sure you are pointing to a
-          recent version of packaging in your Gemfile. Please also make sure you include
-          the artifactory gem in your Gemfile.
-
-          Examples:
-            gem 'packaging', :github => 'puppetlabs/packaging', branch: '1.0.x'
-            gem 'artifactory'
-        DOC
-
         if Dir['output/**/*'].select { |entry| File.file?(entry) }.empty?
           VanagonLogger.error 'vanagon: Error: No packages to ship in the "output" directory. Maybe build some first?'
           exit 1
@@ -40,13 +30,7 @@ class Vanagon
         require 'packaging'
         Pkg::Util::RakeUtils.load_packaging_tasks
         Pkg::Util::RakeUtils.invoke_task('pl:jenkins:ship', 'artifacts', 'output')
-        begin
-          Pkg::Util::RakeUtils.invoke_task('pl:jenkins:ship_to_artifactory', 'output')
-        rescue LoadError
-          VanagonLogger.error artifactory_warning
-        rescue StandardError
-          VanagonLogger.error artifactory_warning
-        end
+        Pkg::Util::RakeUtils.invoke_task('pl:jenkins:ship_to_artifactory', 'output')
       end
     end
   end


### PR DESCRIPTION
When an artifact upload/ship fails, we want to see all the gory details so
that we can diagnose it.

This removes the polite message that masks the failures.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.