### PR TITLE
(PA-3570) enable clone into a custom dirname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ### Added
 - (VANAGON-85) Added the `clear_provisioning` method to the platform dsl to clear 
 the provisioning command array. 
+- (PA-3570) add the posibility to clone into a custom dirname
+
 
 ## [0.21.0] - released 2021-04-15
 ### Added

--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -304,7 +304,7 @@ class Vanagon
     #
     # @param workdir [String] working directory to put the source into
     def get_source(workdir) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
-      opts = options.merge({ workdir: workdir })
+      opts = options.merge({ workdir: workdir, dirname: dirname })
       if url || !mirrors.empty?
         if ENV['VANAGON_USE_MIRRORS'] == 'n' or ENV['VANAGON_USE_MIRRORS'] == 'false'
           fetch_url(opts)

--- a/lib/vanagon/component/source.rb
+++ b/lib/vanagon/component/source.rb
@@ -37,6 +37,7 @@ class Vanagon
               sum: options[:sum],
               ref: options[:ref],
               workdir: options[:workdir],
+              dirname: options[:dirname],
               clone_options: options[:clone_options]
           end
 

--- a/lib/vanagon/component/source/git.rb
+++ b/lib/vanagon/component/source/git.rb
@@ -79,6 +79,7 @@ class Vanagon
           # Ensure that #url returns a URI object
           @url = URI.parse(url.to_s)
           @ref = opts[:ref]
+          @dirname = opts[:dirname]
           @workdir = File.realpath(workdir)
           @clone_options = opts[:clone_options] ||= {}
 
@@ -113,7 +114,7 @@ class Vanagon
         #
         # @return [String] the directory where the repo was cloned
         def dirname
-          File.basename(url.path, ".git")
+          @dirname || File.basename(url.path, ".git")
         end
 
         # Use `git describe` to lazy-load a version for this component

--- a/spec/lib/vanagon/component/source/git_spec.rb
+++ b/spec/lib/vanagon/component/source/git_spec.rb
@@ -60,6 +60,7 @@ describe "Vanagon::Component::Source::Git" do
       allow(::Git).to receive(:clone).and_return(clone)
       expect(File).to receive(:realpath).and_return(@file_path)
     end
+
     it "repository" do
       git_source = @klass.new(@url, ref: @ref_tag, workdir: "/tmp/foo")
       expect(::Git).to receive(:clone).with(git_source.url, git_source.dirname, path: @file_path)
@@ -70,6 +71,12 @@ describe "Vanagon::Component::Source::Git" do
       expected_clone_options = {:branch => "foo", :depth => 50 }
       git_source = @klass.new(@url, ref: @ref_tag, workdir: "/tmp/foo", :clone_options => expected_clone_options)
       expect(::Git).to receive(:clone).with(git_source.url, git_source.dirname, path: @file_path, **expected_clone_options)
+      git_source.clone
+    end
+
+    it 'uses a custom dirname' do
+      git_source = @klass.new(@url, ref: @ref_tag, workdir: "/tmp/foo", dirname: 'facter-ng')
+      expect(::Git).to receive(:clone).with(git_source.url, 'facter-ng', path: @file_path)
       git_source.clone
     end
   end
@@ -85,6 +92,12 @@ describe "Vanagon::Component::Source::Git" do
       git_source = @klass.new(@url, ref: @ref_tag, workdir: @workdir)
       expect(git_source.dirname)
         .to eq('facter')
+    end
+
+    it "returns @dirname if is set" do
+      git_source = @klass.new(@url, ref: @ref_tag, workdir: @workdir, dirname: 'facter-ng')
+      expect(git_source.dirname)
+          .to eq('facter-ng')
     end
   end
 


### PR DESCRIPTION
puppet-agent#6.x needs to ship both facter#3.x and
facter#main branches using 2 different components(
facter#3.x -> facter, facter#main -> facter-ng).
In order to do this, the component must configure
the directory where the git repository should be cloned.

This PR makes use of `dirname` attribute that can
be set at component level and exposes this to the
Git source in order to enable the ability to clone
and use a repository with a specific name.


Eg. of usage: https://github.com/puppetlabs/puppet-agent/pull/2075/files
```
pkg.load_from_json('configs/components/facter-ng.json')
pkg.dirname("facter-ng")
```