### PR TITLE
(VANAGON-85) Add method to clear the provisioning command array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Added
+- (VANAGON-85) Added the `clear_provisioning` method to the platform dsl to clear 
+the provisioning command array. 
 
 ## [0.21.0] - released 2021-04-15
 ### Added

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -214,6 +214,11 @@ class Vanagon
         @platform.provision_with(command)
       end
 
+      # Clears the provisioning commands array
+      def clear_provisioning
+        @platform.provisioning.clear
+      end
+
       # Set the command to install any needed build dependencies for the target machine
       #
       # @param command [String] Command to install build dependencies for the target machine


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.