### PR TITLE
(maint) Alphabetize vanagon list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+- (maint) `vanagon list` now returns results in alphabetical order.
+- (maint) Added the current vanagon commands to the README.md
 - (PA-3613) Added vanagon support for MacOS 11 Big Sur
-
 - (VANAGON-85) Added the `clear_provisioning` method to the platform dsl to clear 
 the provisioning command array. 
 - (PA-3570) add the posibility to clone into a custom dirname

--- a/README.md
+++ b/README.md
@@ -85,6 +85,24 @@ wheezy and build my project against it.
 For more detailed examples of the DSLs available, please see the
 [examples](examples) directory and the YARD documentation for Vanagon.
 
+### CLI commands
+
+The vanagon command line tool contains these commands: 
+
+* `build`               build a package given a project and platform
+* `build_host_info`     print information about build hosts
+* `build_requirements`  print external packages required to build project
+* `completion`          outputs path to tab completion script
+* `inspect`             a build dry-run, printing lots of information about the build
+* `list`                shows a list of available projects and platforms
+* `render`              create local versions of packaging artifacts for project
+* `sign`                sign a package
+* `ship`                upload a package to a distribution server
+* `help`                print this help
+
+Commands are called with a git-like pattern of `vanagon <subcommand>`. 
+For example: `vanagon list`
+
 ### CLI changes and deprecations (from version 0.16.0)
 
 Prior to 0.16.0, the vanagon command line contained these commands

--- a/lib/vanagon/cli/list.rb
+++ b/lib/vanagon/cli/list.rb
@@ -39,15 +39,15 @@ class Vanagon
 
         default_list = Dir.children(File.join(File.dirname(__FILE__), '..', 'platform', 'defaults')).map do |platform|
           File.basename(platform, File.extname(platform))
-        end
+        end.sort
 
         platform_list = Dir.children(File.join(options[:configdir], 'platforms')).map do |platform|
           File.basename(platform, File.extname(platform))
-        end
+        end.sort
 
         project_list = Dir.children(File.join(options[:configdir], 'projects')).map do |project|
           File.basename(project, File.extname(project))
-        end
+        end.sort
 
         if options[:defaults]
           puts "- Defaults", output(default_list, options[:use_spaces])

--- a/spec/lib/vanagon/cli_spec.rb
+++ b/spec/lib/vanagon/cli_spec.rb
@@ -98,9 +98,9 @@ describe Vanagon::CLI::List do
     let(:platforms){ ['1', '2', '3'] }
     let(:output_both){
 "- Projects
-foo
 bar
 baz
+foo
 
 - Platforms
 1
@@ -167,7 +167,7 @@ baz
       
       let(:output_both_space){
 "- Projects
-foo bar baz
+bar baz foo
 
 - Platforms
 1 2 3
@@ -194,9 +194,9 @@ foo bar baz
 
       let(:output_projects){
 "- Projects
-foo
 bar
 baz
+foo
 "
 }
       it "outputs only projects when projects is passed" do 


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.