### PR TITLE
(PA-3755) Add support for mac OS code signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 the provisioning command array. 
 - (PA-3570) add the posibility to clone into a custom dirname
 - (PA-3604) add Fedora 34 support
+- (PA-3755) Add support for mac OS code signing
+
 
 
 ## [0.21.0] - released 2021-04-15

--- a/lib/vanagon/platform/osx.rb
+++ b/lib/vanagon/platform/osx.rb
@@ -35,6 +35,11 @@ class Vanagon
           bom_install = []
         end
 
+        if project.extra_files_to_sign.any?
+          sign_commands = Vanagon::Utilities::ExtraFilesSigner.commands(project, @mktemp, "/osx/build/root/#{project.name}-#{project.version}")
+        else
+          sign_commands = []
+        end
 
          # Setup build directories
         ["bash -c 'mkdir -p $(tempdir)/osx/build/{dmg,pkg,scripts,resources,root,payload,plugins}'",
@@ -50,6 +55,9 @@ class Vanagon
          "gunzip -c #{project.name}-#{project.version}.tar.gz | '#{@tar}' -C '$(tempdir)/osx/build/root/#{project.name}-#{project.version}' --strip-components 1 -xf -",
 
          bom_install,
+
+         # Sign extra files
+         sign_commands,
 
          # Package the project
          "(cd $(tempdir)/osx/build/; #{@pkgbuild} --root root/#{project.name}-#{project.version} \

--- a/lib/vanagon/platform/windows.rb
+++ b/lib/vanagon/platform/windows.rb
@@ -214,28 +214,10 @@ class Vanagon
           "gunzip -c #{project.name}-#{project.version}.tar.gz | '#{@tar}' -C '$(tempdir)/SourceDir' --strip-components 1 -xf -"
         ]
 
-        unless project.extra_files_to_sign.empty?
-          begin
-            tempdir = nil
-            # Skip signing extra files if logging into the signing_host fails
-            # This enables things like CI being able to sign the additional files,
-            # but locally triggered builds by developers who don't have access to
-            # the signing host just print a message and skip the signing.
-            Vanagon::Utilities.retry_with_timeout(3, 5) do
-              tempdir = Vanagon::Utilities::remote_ssh_command("#{project.signing_username}@#{project.signing_hostname}", "#{@mktemp} 2>/dev/null", return_command_output: true)
-            end
-            project.extra_files_to_sign.each do |file|
-              file_location = File.join(tempdir, File.basename(file))
-              make_commands << [
-                "rsync -e '#{Vanagon::Utilities.ssh_command}' -rHlv --no-perms --no-owner --no-group #{File.join('$(tempdir)', 'SourceDir', file)} #{project.signing_username}@#{project.signing_hostname}:#{tempdir}",
-                "#{Vanagon::Utilities.ssh_command} #{project.signing_username}@#{project.signing_hostname} #{project.signing_command} #{file_location}",
-                "rsync -e '#{Vanagon::Utilities.ssh_command}' -rHlv -O --no-perms --no-owner --no-group #{project.signing_username}@#{project.signing_hostname}:#{file_location} #{File.join('$(tempdir)', 'SourceDir', file)}"
-              ]
-            end
-          rescue RuntimeError
-            VanagonLogger.error "Unable to connect to #{project.signing_username}@#{project.signing_hostname}, skipping signing extra files: #{project.extra_files_to_sign.join(',')}"
-          end
+        if project.extra_files_to_sign.any?
+          make_commands << Vanagon::Utilities::ExtraFilesSigner.commands(project, @mktemp, 'SourceDir')
         end
+
         make_commands << [
           "mkdir -p $(tempdir)/#{misc_dir}",
           # Need to use awk here to convert to DOS format so that notepad can display file correctly.

--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -10,6 +10,7 @@ require 'timeout'
 require 'English'
 require 'vanagon/extensions/string'
 require 'vanagon/logger'
+require 'vanagon/utilities/extra_files_signer'
 
 class Vanagon
   module Utilities

--- a/lib/vanagon/utilities/extra_files_signer.rb
+++ b/lib/vanagon/utilities/extra_files_signer.rb
@@ -1,0 +1,39 @@
+class Vanagon
+  module Utilities
+    module ExtraFilesSigner
+      class << self
+        def commands(project, mktemp, source_dir) # rubocop:disable Metrics/AbcSize
+          tempdir = nil
+          commands = []
+          # Skip signing extra files if logging into the signing_host fails
+          # This enables things like CI being able to sign the additional files,
+          # but locally triggered builds by developers who don't have access to
+          # the signing host just print a message and skip the signing.
+          Vanagon::Utilities.retry_with_timeout(3, 5) do
+            tempdir = Vanagon::Utilities::remote_ssh_command("#{project.signing_username}@#{project.signing_hostname}", "#{mktemp} 2>/dev/null", return_command_output: true)
+          end
+
+          project.extra_files_to_sign.each do |file|
+            file_location = File.join(tempdir, File.basename(file))
+            local_source_path = File.join('$(tempdir)', source_dir, file)
+            remote_host = "#{project.signing_username}@#{project.signing_hostname}"
+            remote_destination_path = "#{remote_host}:#{tempdir}"
+            remote_file_location = "#{remote_host}:#{file_location}"
+
+            commands += [
+              "rsync -e '#{Vanagon::Utilities.ssh_command}' --verbose --recursive --hard-links --links  --no-perms --no-owner --no-group #{local_source_path} #{remote_destination_path}",
+              "#{Vanagon::Utilities.ssh_command} #{remote_host} #{project.signing_command} #{file_location}",
+              "rsync -e '#{Vanagon::Utilities.ssh_command}' --verbose --recursive --hard-links --links  --no-perms --no-owner --no-group #{remote_file_location} #{local_source_path}"
+            ]
+          end
+
+          commands
+        rescue RuntimeError
+          require 'vanagon/logger'
+          VanagonLogger.error "Unable to connect to #{project.signing_username}@#{project.signing_hostname}, skipping signing extra files: #{project.extra_files_to_sign.join(',')}"
+          []
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/vanagon/utilities/extra_files_signer_spec.rb
+++ b/spec/lib/vanagon/utilities/extra_files_signer_spec.rb
@@ -1,0 +1,90 @@
+require 'vanagon/platform'
+require 'vanagon/project'
+require 'vanagon/utilities/extra_files_signer'
+
+describe Vanagon::Utilities::ExtraFilesSigner do
+  let(:platform_block) do
+    %( platform "osx-11-x86_64" do |plat|
+    end
+    )
+  end
+  let (:project_block) do
+    <<-HERE.undent
+      project 'test-fixture' do |proj|
+        proj.version '0.0.0'
+      end
+    HERE
+  end
+  let(:configdir) { '/a/b/c' }
+  let(:platform) { Vanagon::Platform::DSL.new('osx-11-x86_64') }
+  let(:project) do
+    Vanagon::Project::DSL.new('test-fixture', configdir, platform._platform, [])
+  end
+  let(:mktemp) { '/tmp/xyz' }
+  let(:source_dir) { '/dir/source_dir' }
+
+  before do
+    allow(VanagonLogger).to receive(:error)
+    platform.instance_eval(platform_block)
+    project.instance_eval(project_block)
+    allow(Vanagon::Utilities).to receive(:remote_ssh_command).and_return(mktemp)
+  end
+
+  describe '.commands' do
+    context 'without extra files to sign' do
+      it 'returns empty array' do
+        commands = Vanagon::Utilities::ExtraFilesSigner.commands(project._project, mktemp, source_dir)
+        expect(commands).to eql([])
+      end
+    end
+
+    context 'with extra files to sign' do
+      let (:project_block) do
+        <<-HERE.undent
+          project 'test-fixture' do |proj|
+            proj.version '0.0.0'
+            proj.extra_file_to_sign '/test1/a.rb'
+            proj.extra_file_to_sign '/test2/b.rb'
+            proj.signing_hostname('abc')
+            proj.signing_username('test')
+             proj.signing_command('codesign')
+          end
+        HERE
+      end
+
+      context 'when it cannot connect to signing hostname' do
+        before do
+          allow(Vanagon::Utilities).to receive(:remote_ssh_command)
+            .with('test@abc', '/tmp/xyz 2>/dev/null', return_command_output: true)
+            .and_raise RuntimeError
+        end
+
+        it 'returns empty array' do
+          commands = Vanagon::Utilities::ExtraFilesSigner.commands(project._project, mktemp, source_dir)
+          expect(commands).to eql([])
+        end
+
+        it 'logs error' do
+          Vanagon::Utilities::ExtraFilesSigner.commands(project._project, mktemp, source_dir)
+          expect(VanagonLogger).to have_received(:error).with(/Unable to connect to test@abc/)
+        end
+      end
+
+      context 'when success' do
+        it 'generates signing commands for each file' do
+          commands = Vanagon::Utilities::ExtraFilesSigner.commands(project._project, mktemp, source_dir)
+          expect(commands).to match(
+            [
+              "rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links  --no-perms --no-owner --no-group $(tempdir)/dir/source_dir/test1/a.rb test@abc:/tmp/xyz",
+              "/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc codesign /tmp/xyz/a.rb",
+              "rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links  --no-perms --no-owner --no-group test@abc:/tmp/xyz/a.rb $(tempdir)/dir/source_dir/test1/a.rb",
+              "rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links  --no-perms --no-owner --no-group $(tempdir)/dir/source_dir/test2/b.rb test@abc:/tmp/xyz",
+              "/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc codesign /tmp/xyz/b.rb",
+              "rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links  --no-perms --no-owner --no-group test@abc:/tmp/xyz/b.rb $(tempdir)/dir/source_dir/test2/b.rb"
+            ]
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- extract the generic code for signing extra files
- use the ExtraFilesSinger in osx and windows

Please add all notable changes to the "Unreleased" section of the CHANGELOG.