### PR TITLE
(maint) install `libarchive` on el-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 the provisioning command array. 
 - (PA-3570) add the posibility to clone into a custom dirname
 - (PA-3604) add Fedora 34 support
+- (maint) install `libarchive` on el-8
 
 
 ## [0.21.0] - released 2021-04-15

--- a/lib/vanagon/platform/defaults/el-8-aarch64.rb
+++ b/lib/vanagon/platform/defaults/el-8-aarch64.rb
@@ -3,7 +3,7 @@ platform "el-8-aarch64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
-  packages = %w(autoconf automake createrepo gcc gcc-c++ rsync cmake make rpm-libs rpm-build)
+  packages = %w(autoconf automake createrepo gcc gcc-c++ rsync cmake make rpm-libs rpm-build libarchive)
   plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
   plat.install_build_dependencies_with "dnf install -y --allowerasing "
   plat.vmpooler_template "redhat-8-arm64"

--- a/lib/vanagon/platform/defaults/el-8-x86_64.rb
+++ b/lib/vanagon/platform/defaults/el-8-x86_64.rb
@@ -3,7 +3,7 @@ platform "el-8-x86_64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
-  packages = %w(gcc gcc-c++ autoconf automake createrepo rsync cmake make rpm-libs rpm-build rpm-sign libtool)
+  packages = %w(gcc gcc-c++ autoconf automake createrepo rsync cmake make rpm-libs rpm-build rpm-sign libtool libarchive)
   plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
   plat.install_build_dependencies_with "dnf install -y --allowerasing "
   plat.vmpooler_template "redhat-8-x86_64"


### PR DESCRIPTION
RedHat recently updated their repos and the cmake
version pulled is newer (3.18.2). This uses a
libarchive method that is not available on
3.3.2 which is the one that comes with the box.

Installing a newer version of libarchive fixes the
compliation issues with cmake 3.18.2

Please add all notable changes to the "Unreleased" section of the CHANGELOG.