### PR TITLE
(PA-3755) add --extended-attributes on mac OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ## [Unreleased]
 ### Added
 - (PA-3709) Add Debian 11 64-bit support
+- (PA-3755) add `--extended-attributes` on mac OS
 
 ## [0.21.1] - released 2021-06-07
 ### Added

--- a/lib/vanagon/platform/osx.rb
+++ b/lib/vanagon/platform/osx.rb
@@ -64,6 +64,7 @@ class Vanagon
           --scripts $(tempdir)/osx/build/scripts \
           --identifier #{project.identifier}.#{project.name} \
           --version #{project.version} \
+          --preserve-xattr \
           --install-location / \
           payload/#{project.name}-#{project.version}-#{project.release}.pkg)",
          # Create a custom installer using the pkg above

--- a/lib/vanagon/utilities/extra_files_signer.rb
+++ b/lib/vanagon/utilities/extra_files_signer.rb
@@ -19,11 +19,13 @@ class Vanagon
             remote_host = "#{project.signing_username}@#{project.signing_hostname}"
             remote_destination_path = "#{remote_host}:#{tempdir}"
             remote_file_location = "#{remote_host}:#{file_location}"
+            extra_flags = ''
+            extra_flags = '--extended-attributes' if project.platform.is_macos?
 
             commands += [
-              "rsync -e '#{Vanagon::Utilities.ssh_command}' --verbose --recursive --hard-links --links  --no-perms --no-owner --no-group #{local_source_path} #{remote_destination_path}",
+              "rsync -e '#{Vanagon::Utilities.ssh_command}' --verbose --recursive --hard-links --links  --no-perms --no-owner --no-group #{extra_flags} #{local_source_path} #{remote_destination_path}",
               "#{Vanagon::Utilities.ssh_command} #{remote_host} #{project.signing_command} #{file_location}",
-              "rsync -e '#{Vanagon::Utilities.ssh_command}' --verbose --recursive --hard-links --links  --no-perms --no-owner --no-group #{remote_file_location} #{local_source_path}"
+              "rsync -e '#{Vanagon::Utilities.ssh_command}' --verbose --recursive --hard-links --links  --no-perms --no-owner --no-group #{extra_flags} #{remote_file_location} #{local_source_path}"
             ]
           end
 

--- a/spec/lib/vanagon/utilities/extra_files_signer_spec.rb
+++ b/spec/lib/vanagon/utilities/extra_files_signer_spec.rb
@@ -71,18 +71,44 @@ describe Vanagon::Utilities::ExtraFilesSigner do
       end
 
       context 'when success' do
-        it 'generates signing commands for each file' do
-          commands = Vanagon::Utilities::ExtraFilesSigner.commands(project._project, mktemp, source_dir)
-          expect(commands).to match(
-            [
-              "rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links  --no-perms --no-owner --no-group $(tempdir)/dir/source_dir/test1/a.rb test@abc:/tmp/xyz",
-              "/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc codesign /tmp/xyz/a.rb",
-              "rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links  --no-perms --no-owner --no-group test@abc:/tmp/xyz/a.rb $(tempdir)/dir/source_dir/test1/a.rb",
-              "rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links  --no-perms --no-owner --no-group $(tempdir)/dir/source_dir/test2/b.rb test@abc:/tmp/xyz",
-              "/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc codesign /tmp/xyz/b.rb",
-              "rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links  --no-perms --no-owner --no-group test@abc:/tmp/xyz/b.rb $(tempdir)/dir/source_dir/test2/b.rb"
-            ]
-          )
+        context 'when macos' do
+          it 'generates signing commands for each file using --extended-attributes' do
+            commands = Vanagon::Utilities::ExtraFilesSigner.commands(project._project, mktemp, source_dir)
+            expect(commands).to match(
+              [
+                "rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links  --no-perms --no-owner --no-group --extended-attributes $(tempdir)/dir/source_dir/test1/a.rb test@abc:/tmp/xyz",
+                "/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc codesign /tmp/xyz/a.rb",
+                "rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links  --no-perms --no-owner --no-group --extended-attributes test@abc:/tmp/xyz/a.rb $(tempdir)/dir/source_dir/test1/a.rb",
+                "rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links  --no-perms --no-owner --no-group --extended-attributes $(tempdir)/dir/source_dir/test2/b.rb test@abc:/tmp/xyz",
+                "/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc codesign /tmp/xyz/b.rb",
+                "rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links  --no-perms --no-owner --no-group --extended-attributes test@abc:/tmp/xyz/b.rb $(tempdir)/dir/source_dir/test2/b.rb"
+              ]
+            )
+          end
+        end
+
+        context 'when other platform' do
+          let(:platform_block) do
+            %( platform "windows-2012r2-x86_64" do |plat|
+            end
+            )
+          end
+
+          let(:platform) { Vanagon::Platform::DSL.new('windows-2012r2-x86_64') }
+
+          it 'generates signing commands for each file' do
+            commands = Vanagon::Utilities::ExtraFilesSigner.commands(project._project, mktemp, source_dir)
+            expect(commands).to match(
+              [
+                "rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links  --no-perms --no-owner --no-group  $(tempdir)/dir/source_dir/test1/a.rb test@abc:/tmp/xyz",
+                "/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc codesign /tmp/xyz/a.rb",
+                "rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links  --no-perms --no-owner --no-group  test@abc:/tmp/xyz/a.rb $(tempdir)/dir/source_dir/test1/a.rb",
+                "rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links  --no-perms --no-owner --no-group  $(tempdir)/dir/source_dir/test2/b.rb test@abc:/tmp/xyz",
+                "/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc codesign /tmp/xyz/b.rb",
+                "rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links  --no-perms --no-owner --no-group  test@abc:/tmp/xyz/b.rb $(tempdir)/dir/source_dir/test2/b.rb"
+              ]
+            )
+          end
         end
       end
     end


### PR DESCRIPTION
 `-E, --extended-attributes - copy extended attributes`
 This flag is needed because the code signature is
 stored as a xattr.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.