### PR TITLE
(RE-14154) Exit if `VANAGON_FORCE_SIGNING` is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ### Added
 - (PA-3709) Add Debian 11 64-bit support
 - (PA-3755) add `--extended-attributes` on mac OS
+- (RE-14154) Exit if `VANAGON_FORCE_SIGNING` is set
 
 ## [0.21.1] - released 2021-06-07
 ### Added

--- a/README.md
+++ b/README.md
@@ -230,6 +230,13 @@ time. The default value is *7200* seconds(120 minutes) but setting to any
 integer value these components to fail after the `VANAGON_TIMEOUT` count is reached.
 Note that this value is expected to be in seconds.
 
+##### `VANAGON_FORCE_SIGNING`
+By default, Vanagon does not fail if extra files signing fails, it just logs an
+error and continues building the package. This is unwanted behavior in
+environments where we expect a hard failure when signing cannot proceed. To
+force Vanagon to fail if extra files signing fails, ensure this variable is set
+before starting a build.
+
 #### Example usage
 `vanagon build --preserve puppet-agent el-6-i386` will build the puppet-agent project
 on the el-6-i386 platform and leave the host intact afterward.

--- a/lib/vanagon/utilities/extra_files_signer.rb
+++ b/lib/vanagon/utilities/extra_files_signer.rb
@@ -33,6 +33,7 @@ class Vanagon
         rescue RuntimeError
           require 'vanagon/logger'
           VanagonLogger.error "Unable to connect to #{project.signing_username}@#{project.signing_hostname}, skipping signing extra files: #{project.extra_files_to_sign.join(',')}"
+          raise if ENV['VANAGON_FORCE_SIGNING']
           []
         end
       end

--- a/spec/lib/vanagon/utilities/extra_files_signer_spec.rb
+++ b/spec/lib/vanagon/utilities/extra_files_signer_spec.rb
@@ -68,6 +68,13 @@ describe Vanagon::Utilities::ExtraFilesSigner do
           Vanagon::Utilities::ExtraFilesSigner.commands(project._project, mktemp, source_dir)
           expect(VanagonLogger).to have_received(:error).with(/Unable to connect to test@abc/)
         end
+
+        it 'fails the build if VANAGON_FORCE_SIGNING is set' do
+          allow(ENV).to receive(:[]).with('VANAGON_FORCE_SIGNING').and_return('true')
+          expect {
+            Vanagon::Utilities::ExtraFilesSigner.commands(project._project, mktemp, source_dir)
+          }.to raise_error(RuntimeError)
+        end
       end
 
       context 'when success' do


### PR DESCRIPTION
By default, Vanagon does not fail if extra files signing fails, it just logs an error and continues building the package. This is unwanted behavior in environments where we expect a hard failure when signing cannot proceed.

To force Vanagon to fail if extra files signing fails, ensure the VANAGON_FORCE_SIGNING variable is set before starting a build.
