### PR TITLE
(VANAGON-166) Do not undefine __debug_package on EL 8 FIPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 - (VANAGON-167) Update tests to remove redhat 5 
 - (VANAGON-171) Add Ubuntu 18.04 aarch64 defaults
 - (VANAGON-166) Add RedHat 8 FIPS defaults
+- (VANAGON-166) Do not undefine `__debug_package` on EL 8 FIPS
 
 ## [0.22.0] - released 2021-07-06
 ### Added

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -339,8 +339,18 @@ class Vanagon
       return !!@name.match(/^(el|redhat|redhatfips)-.*$/)
     end
 
+    # Utility matcher to determine if the platform is of an EL 8 variety
+    #
+    # @return [true, false] true if it is an EL 8 variety, false otherwise
     def is_el8?
       return !!@name.match(/^(el|redhat|redhatfips)-8.*$/)
+    end
+
+    # Utility matcher to determine if the platform is a FIPS platform
+    #
+    # @return [true, false] true if it is a FIPS platform, false otherwise
+    def is_fips?
+      return @name.include?('fips')
     end
 
     # Utility matcher to determine is the platform is a sles variety

--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -35,7 +35,9 @@
 
 # This breaks on el8. This is a hack to unblock development.
 <%- if @platform.is_el8? %>
+<%- if !@platform.is_fips? %>
 %undefine __debug_package
+<%- end -%>
 
 # Build el-8 packages without build-id files to prevent collision
 %define _build_id_links none


### PR DESCRIPTION
Because of the undefine statement openssl fails to start on RedHat 8
FIPS:

```
[root@nonacid-gel ~]# /opt/puppetlabs/puppet/bin/openssl
crypto/fips/fips.c:154: OpenSSL internal error: FATAL FIPS SELFTEST FAILURE
Aborted (core dumped)
```

After removing the statement openssl works:

```
[root@nonacid-gel ~]# /opt/puppetlabs/puppet/bin/openssl
OpenSSL>
```

I'm not sure what the statement does, I assume something related to
stripping libs/binaries, but whatever it is FIPS doesn't like it.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.