### PR TITLE
(VANAGON-177) Remove EL8 __debug_package workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 - (VANAGON-171) Add Ubuntu 18.04 aarch64 defaults
 - (VANAGON-166) Add RedHat 8 FIPS defaults
 - (VANAGON-166) Do not undefine `__debug_package` on EL 8 FIPS
+- (VANAGON-177) Remove `__debug_package` workaround for EL 8
 
 ## [0.22.0] - released 2021-07-06
 ### Added

--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -33,16 +33,10 @@
 <%= var %>
 <% end -%>
 
-# This breaks on el8. This is a hack to unblock development.
 <%- if @platform.is_el8? %>
-<%- if !@platform.is_fips? %>
-%undefine __debug_package
-<%- end -%>
-
 # Build el-8 packages without build-id files to prevent collision
 %define _build_id_links none
 <% end -%>
-
 
 # To avoid files installed but not packaged errors
 %global __os_install_post %{__os_install_post} \


### PR DESCRIPTION
I was able to build puppet-agent and pe-r10k-vanagon RPMs on el-8-x86_64 without this workaround. Without more context it's hard to see how/why this might have failed. Remove the workaround and see what happens.

I rummaged through Slack and was able to locate the initial failure, which appeared during the pe-r10k RPM creation:

```
10:40:08 extracting debug info from /var/tmp/tmp.bkOcmruabx/rpmbuild/BUILDROOT/pe-r10k-3.4.1.1.14.gf7f4800-1.el8.x86_64/opt/puppetlabs/puppet/lib/ruby/gems/2.5.0/extensions/x86_64-linux/2.5.0/ffi-1.11.1/ffi_c.so
10:40:08 extracting debug info from /var/tmp/tmp.bkOcmruabx/rpmbuild/BUILDROOT/pe-r10k-3.4.1.1.14.gf7f4800-1.el8.x86_64/opt/puppetlabs/puppet/lib/ruby/gems/2.5.0/extensions/x86_64-linux/2.5.0/rugged-0.27.7/rugged/rugged.so
10:40:08 /usr/lib/rpm/debugedit: /var/tmp/tmp.bkOcmruabx/rpmbuild/BUILDROOT/pe-r10k-3.4.1.1.14.gf7f4800-1.el8.x86_64/opt/puppetlabs/puppet/lib/ruby/gems/2.5.0/extensions/x86_64-linux/2.5.0/rugged-0.27.7/rugged/rugged.so: DWARF version 0 unhandled
10:40:08 Failed to update file: invalid section alignment
10:40:08 gdb-add-index: No index was created for /var/tmp/tmp.bkOcmruabx/rpmbuild/BUILDROOT/pe-r10k-3.4.1.1.14.gf7f4800-1.el8.x86_64/opt/puppetlabs/puppet/lib/ruby/gems/2.5.0/extensions/x86_64-linux/2.5.0/ffi-1.11.1/ffi_c.so
10:40:08 gdb-add-index: [Was there no debuginfo? Was there already an index?]
10:40:08 extracting debug info from /var/tmp/tmp.bkOcmruabx/rpmbuild/BUILDROOT/pe-r10k-3.4.1.1.14.gf7f4800-1.el8.x86_64/opt/puppetlabs/puppet/lib/ruby/gems/2.5.0/gems/ffi-1.11.1/ext/ffi_c/ffi_c.so
10:40:08 gdb-add-index: No index was created for /var/tmp/tmp.bkOcmruabx/rpmbuild/BUILDROOT/pe-r10k-3.4.1.1.14.gf7f4800-1.el8.x86_64/opt/puppetlabs/puppet/lib/ruby/gems/2.5.0/gems/ffi-1.11.1/ext/ffi_c/ffi_c.so
10:40:08 gdb-add-index: [Was there no debuginfo? Was there already an index?]
10:40:08 extracting debug info from /var/tmp/tmp.bkOcmruabx/rpmbuild/BUILDROOT/pe-r10k-3.4.1.1.14.gf7f4800-1.el8.x86_64/opt/puppetlabs/puppet/lib/ruby/gems/2.5.0/gems/ffi-1.11.1/ext/ffi_c/libffi-x86_64-linux/.libs/libffi.so.7.1.0
10:40:08 gdb-add-index: No index was created for /var/tmp/tmp.bkOcmruabx/rpmbuild/BUILDROOT/pe-r10k-3.4.1.1.14.gf7f4800-1.el8.x86_64/opt/puppetlabs/puppet/lib/ruby/gems/2.5.0/gems/ffi-1.11.1/ext/ffi_c/libffi-x86_64-linux/.libs/libffi.so.7.1.0
10:40:08 gdb-add-index: [Was there no debuginfo? Was there already an index?]
10:40:08 extracting debug info from /var/tmp/tmp.bkOcmruabx/rpmbuild/BUILDROOT/pe-r10k-3.4.1.1.14.gf7f4800-1.el8.x86_64/opt/puppetlabs/puppet/lib/ruby/gems/2.5.0/gems/ffi-1.11.1/ext/ffi_c/libffi-x86_64-linux/a.out
10:40:08 gdb-add-index: No index was created for /var/tmp/tmp.bkOcmruabx/rpmbuild/BUILDROOT/pe-r10k-3.4.1.1.14.gf7f4800-1.el8.x86_64/opt/puppetlabs/puppet/lib/ruby/gems/2.5.0/gems/ffi-1.11.1/ext/ffi_c/libffi-x86_64-linux/a.out
10:40:08 gdb-add-index: [Was there no debuginfo? Was there already an index?]
10:40:08 extracting debug info from /var/tmp/tmp.bkOcmruabx/rpmbuild/BUILDROOT/pe-r10k-3.4.1.1.14.gf7f4800-1.el8.x86_64/opt/puppetlabs/puppet/lib/ruby/gems/2.5.0/gems/ffi-1.11.1/lib/ffi_c.so
10:40:08 gdb-add-index: No index was created for /var/tmp/tmp.bkOcmruabx/rpmbuild/BUILDROOT/pe-r10k-3.4.1.1.14.gf7f4800-1.el8.x86_64/opt/puppetlabs/puppet/lib/ruby/gems/2.5.0/gems/ffi-1.11.1/lib/ffi_c.so
10:40:08 gdb-add-index: [Was there no debuginfo? Was there already an index?]
10:40:08 extracting debug info from /var/tmp/tmp.bkOcmruabx/rpmbuild/BUILDROOT/pe-r10k-3.4.1.1.14.gf7f4800-1.el8.x86_64/opt/puppetlabs/puppet/lib/ruby/gems/2.5.0/gems/rugged-0.27.7/ext/rugged/rugged.so
10:40:08 /usr/lib/rpm/debugedit: /var/tmp/tmp.bkOcmruabx/rpmbuild/BUILDROOT/pe-r10k-3.4.1.1.14.gf7f4800-1.el8.x86_64/opt/puppetlabs/puppet/lib/ruby/gems/2.5.0/gems/rugged-0.27.7/ext/rugged/rugged.so: DWARF version 0 unhandled
10:40:08 Failed to update file: invalid section alignment
10:40:08 /usr/lib/rpm/find-debuginfo.sh: line 500: /tmp/find-debuginfo.vNQOHA/res.*: No such file or directory
10:40:08 
10:40:08 
10:40:08 RPM build errors:
10:40:08 error: Bad exit status from /var/tmp/rpm-tmp.cPopgC (%install)
10:40:08     Bad exit status from /var/tmp/rpm-tmp.cPopgC (%install)
10:40:08 make: *** [Makefile:13: pe-r10k-3.4.1.1.14.gf7f4800-1.x86_64.rpm] Error 1
10:40:08 Remote ssh command ((cd /var/tmp/tmp.0HWYLgklif; /usr/bin/make )) failed on 'root@rapt-heroism.delivery.puppetlabs.net'.
10:40:08 /tmp/jenkins/workspace/enterprise_pe-r10k-vanagon_pkg-van-ship_daily-master/BUILD_TARGET/el-8-x86_64/SLAVE_LABEL/beaker/.bundle/gems/ruby/2.4.0/gems/vanagon-0.15.35/lib/vanagon/utilities.rb:229:in `remote_ssh_command'
```

I can confirm this does not happen anymore for pe-r10k-vanagon on el-8-x86_64. I was able to build the project from both 2019.8.x and main.

I'm not sure what could have caused this, probably some dependent library/gem which was updated since?