### PR TITLE
(RE-14305) Add dependencies cli command

### DIFF
--- a/lib/vanagon/cli.rb
+++ b/lib/vanagon/cli.rb
@@ -14,7 +14,7 @@ require 'vanagon/cli/list'
 require 'vanagon/cli/render'
 require 'vanagon/cli/ship'
 require 'vanagon/cli/sign'
-require 'vanagon/cli/lock'
+require 'vanagon/cli/dependencies'
 
 require 'vanagon/logger'
 
@@ -38,7 +38,7 @@ class Vanagon
           render              create local versions of packaging artifacts for project
           sign                sign a package
           ship                upload a package to a distribution server
-          lock                create a package gemlock file for a given project and platform
+          dependencies        create a json file that shows all required gems for a given project and platform
           help                print this help
     DOCOPT
 
@@ -66,8 +66,8 @@ class Vanagon
         @sub_parser = Vanagon::CLI::Sign.new
       when 'ship'
         @sub_parser = Vanagon::CLI::Ship.new
-      when 'lock'
-        @sub_parser = Vanagon::CLI::Lock.new
+      when 'dependencies'
+        @sub_parser = Vanagon::CLI::Dependencies.new
       when 'help'
         puts DOCUMENTATION
         exit 0

--- a/lib/vanagon/cli.rb
+++ b/lib/vanagon/cli.rb
@@ -14,6 +14,7 @@ require 'vanagon/cli/list'
 require 'vanagon/cli/render'
 require 'vanagon/cli/ship'
 require 'vanagon/cli/sign'
+require 'vanagon/cli/lock'
 
 require 'vanagon/logger'
 
@@ -37,6 +38,7 @@ class Vanagon
           render              create local versions of packaging artifacts for project
           sign                sign a package
           ship                upload a package to a distribution server
+          lock                create a package gemlock file for a given project and platform
           help                print this help
     DOCOPT
 
@@ -64,6 +66,8 @@ class Vanagon
         @sub_parser = Vanagon::CLI::Sign.new
       when 'ship'
         @sub_parser = Vanagon::CLI::Ship.new
+      when 'lock'
+        @sub_parser = Vanagon::CLI::Lock.new
       when 'help'
         puts DOCUMENTATION
         exit 0

--- a/lib/vanagon/cli/dependencies.rb
+++ b/lib/vanagon/cli/dependencies.rb
@@ -12,17 +12,15 @@ class Vanagon
         Options:
           -h, --help                       Display help
           -c, --configdir DIRECTORY        Configuration directory [default: #{Dir.pwd}/configs]
-          -e, --engine ENGINE              Custom engine to use [default: always_be_scheduling]
           -w, --workdir DIRECTORY          Working directory on the local host
           -v, --verbose                    Only here for backwards compatibility. Does nothing.
 
-        Engines:
-          always_be_scheduling: default engine using Puppet's ABS infrastructure
-          docker: a docker container on the local host
-          ec2: an Amazon EC2 instance
-          hardware: a dedicated hardware device
-          local: the local machine, cannot be used with a target
-          pooler: [deprecated] Puppet's vmpooler
+        Project-Name:
+          May be a project name of a project from the configs/projects directory or 'all' to generate dependencies for all projects.
+
+        Platforms:
+          May be a platform name of a platform from the configs/platforms directory or 'all' to generate dependencies for all platforms.
+
       DOCOPT
 
       def parse(argv)
@@ -83,9 +81,8 @@ class Vanagon
           '--verbose' => :verbose,
           '--workdir' => :workdir,
           '--configdir' => :configdir,
-          '--engine' => :engine,
           '<project-name>' => :project_name,
-          '<platforms>' => :platforms,
+          '<platforms>' => :platforms
         }
         return docopt_options.map { |k, v| [translations[k], v] }.to_h
       end

--- a/lib/vanagon/cli/lock.rb
+++ b/lib/vanagon/cli/lock.rb
@@ -33,14 +33,32 @@ class Vanagon
       end
 
       def run(options)
-        platforms = options[:platforms].split(',')
-        project = options[:project_name]
-        target_list = []
+        if Dir.exist?(File.join(options[:configdir], 'platforms')) == false ||
+           Dir.exist?(File.join(options[:configdir], 'projects')) == false
 
-        platforms.zip(target_list).each do |pair|
-          platform, target = pair
-          artifact = Vanagon::Driver.new(platform, project, options.merge({ :target => target }))
-          artifact.lock
+          VanagonLogger.error "Path to #{File.join(options[:configdir], 'platforms')} or #{File.join(options[:configdir], 'projects')} not found."
+          exit 1
+        end
+
+        projects = [options[:project_name]]
+        if options[:project_name] == 'all'
+          projects = Dir.children(File.join(options[:configdir], 'projects')).map do |project|
+            File.basename(project, File.extname(project))
+          end
+        end
+
+        platforms = options[:platforms].split(',')
+        if options[:platforms] == 'all'
+          platforms = Dir.children(File.join(options[:configdir], 'platforms')).map do |platform|
+            File.basename(platform, File.extname(platform))
+          end
+        end
+
+        projects.each do |project|
+          platforms.each do |platform|
+            artifact = Vanagon::Driver.new(platform, project, options)
+            artifact.lock
+          end
         end
       end
 

--- a/lib/vanagon/cli/lock.rb
+++ b/lib/vanagon/cli/lock.rb
@@ -1,0 +1,60 @@
+require 'docopt'
+require 'json'
+require 'vanagon/logger'
+
+class Vanagon
+  class CLI
+    class Lock < Vanagon::CLI
+      DOCUMENTATION = <<~DOCOPT.freeze
+        Usage:
+        lock [options] <project-name> <platforms>
+
+        Options:
+          -h, --help                       Display help
+          -c, --configdir DIRECTORY        Configuration directory [default: #{Dir.pwd}/configs]
+          -e, --engine ENGINE              Custom engine to use [default: always_be_scheduling]
+          -w, --workdir DIRECTORY          Working directory on the local host
+          -v, --verbose                    Only here for backwards compatibility. Does nothing.
+
+        Engines:
+          always_be_scheduling: default engine using Puppet's ABS infrastructure
+          docker: a docker container on the local host
+          ec2: an Amazon EC2 instance
+          hardware: a dedicated hardware device
+          local: the local machine, cannot be used with a target
+          pooler: [deprecated] Puppet's vmpooler
+      DOCOPT
+
+      def parse(argv)
+        Docopt.docopt(DOCUMENTATION, { argv: argv })
+      rescue Docopt::Exit => e
+        VanagonLogger.error e.message
+        exit 1
+      end
+
+      def run(options)
+        platforms = options[:platforms].split(',')
+        project = options[:project_name]
+        target_list = []
+
+        platforms.zip(target_list).each do |pair|
+          platform, target = pair
+          artifact = Vanagon::Driver.new(platform, project, options.merge({ :target => target }))
+          artifact.lock
+        end
+      end
+
+      def options_translate(docopt_options)
+        translations = {
+          '--verbose' => :verbose,
+          '--workdir' => :workdir,
+          '--configdir' => :configdir,
+          '--engine' => :engine,
+          '<project-name>' => :project_name,
+          '<platforms>' => :platforms,
+        }
+        return docopt_options.map { |k, v| [translations[k], v] }.to_h
+      end
+    end
+  end
+end

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -182,6 +182,19 @@ class Vanagon
       @project.make_makefile(workdir)
     end
 
+    def lock # rubocop:disable Metrics/AbcSize
+      # Simple sanity check for the project
+      if @project.version.nil? or @project.version.empty?
+        raise Vanagon::Error, "Project requires a version set, all is lost."
+      end
+
+      VanagonLogger.info "creating Gemfile.lock"
+      @project.fetch_sources(workdir, retry_count, timeout)
+      @project.make_bill_of_materials(workdir)
+      @project.generate_packaging_artifacts(workdir)
+      @project.save_manifest_json(@platform, workdir)
+    end
+
     # Initialize the logging instance
     def loginit(logfile)
       @@logger = Logger.new(logfile)

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -182,15 +182,15 @@ class Vanagon
       @project.make_makefile(workdir)
     end
 
-    def lock # rubocop:disable Metrics/AbcSize
+    def dependencies(temp_dir) # rubocop:disable Metrics/AbcSize
       # Simple sanity check for the project
       if @project.version.nil? or @project.version.empty?
         raise Vanagon::Error, "Project requires a version set, all is lost."
       end
 
-      VanagonLogger.info "creating Gemfile.lock"
+      VanagonLogger.info "creating dependencies list"
       @project.fetch_sources(workdir, retry_count, timeout)
-      @project.cli_save_manifest_json(@platform)
+      @project.cli_save_manifest_json(@platform, temp_dir)
     end
 
     # Initialize the logging instance

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -190,9 +190,7 @@ class Vanagon
 
       VanagonLogger.info "creating Gemfile.lock"
       @project.fetch_sources(workdir, retry_count, timeout)
-      @project.make_bill_of_materials(workdir)
-      @project.generate_packaging_artifacts(workdir)
-      @project.save_manifest_json(@platform, workdir)
+      @project.cli_save_manifest_json(@platform)
     end
 
     # Initialize the logging instance

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -171,7 +171,7 @@ class Vanagon
 
     def render # rubocop:disable Metrics/AbcSize
       # Simple sanity check for the project
-      if @project.version.nil? or @project.version.empty?
+      if @project.version.nil? || @project.version.empty?
         raise Vanagon::Error, "Project requires a version set, all is lost."
       end
 
@@ -182,15 +182,15 @@ class Vanagon
       @project.make_makefile(workdir)
     end
 
-    def dependencies(temp_dir) # rubocop:disable Metrics/AbcSize
+    def dependencies(temporary_directory) # rubocop:disable Metrics/AbcSize
       # Simple sanity check for the project
-      if @project.version.nil? or @project.version.empty?
+      if @project.version.nil? || @project.version.empty?
         raise Vanagon::Error, "Project requires a version set, all is lost."
       end
 
       VanagonLogger.info "creating dependencies list"
       @project.fetch_sources(workdir, retry_count, timeout)
-      @project.cli_save_manifest_json(@platform, temp_dir)
+      @project.cli_save_manifest_json(@platform, temporary_directory)
     end
 
     # Initialize the logging instance

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -762,10 +762,11 @@ class Vanagon
       end
     end
 
-    # Writes a json file at `/tmp/*/build_metadata.<project>.<platform>.json` containing information
+    # Writes a json file at `temp_dir/build_metadata.<project>.<platform>.json` containing information
     # about what will go into an artifact
     #
     # @param platform [String] platform we're writing metadata for
+    # @param temp_dir [String] directory metadata is written to
     def cli_save_manifest_json(platform, temp_dir) # rubocop:disable Metrics/AbcSize
       manifest = build_manifest_json
       metadata = metadata_merge(manifest, @upstream_metadata)

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -762,6 +762,21 @@ class Vanagon
       end
     end
 
+    # Writes a json file at `/tmp/*/build_metadata.<project>.<platform>.json` containing information
+    # about what will go into an artifact
+    #
+    # @param platform [String] platform we're writing metadata for
+    def cli_save_manifest_json(platform) # rubocop:disable Metrics/AbcSize
+      manifest = build_manifest_json
+      metadata = metadata_merge(manifest, @upstream_metadata)
+
+      metadata_file_name = "build_metadata.#{name}.#{platform.name}.json"
+      outfile = File.join(Dir.mktmpdir, metadata_file_name)
+      File.open(outfile, 'w') { |f| f.write(JSON.pretty_generate(metadata)) }
+
+      VanagonLogger.info "Generated: #{outfile}"
+    end
+
     # Writes a yaml file at `output/<name>-<version>.<platform>.settings.yaml`
     # containing settings used to build the current project on the platform
     # provided (and a corresponding sha1sum file) if `yaml_settings` has been

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -766,12 +766,12 @@ class Vanagon
     # about what will go into an artifact
     #
     # @param platform [String] platform we're writing metadata for
-    def cli_save_manifest_json(platform) # rubocop:disable Metrics/AbcSize
+    def cli_save_manifest_json(platform, temp_dir) # rubocop:disable Metrics/AbcSize
       manifest = build_manifest_json
       metadata = metadata_merge(manifest, @upstream_metadata)
 
       metadata_file_name = "build_metadata.#{name}.#{platform.name}.json"
-      outfile = File.join(Dir.mktmpdir, metadata_file_name)
+      outfile = File.join(temp_dir, metadata_file_name)
       File.open(outfile, 'w') { |f| f.write(JSON.pretty_generate(metadata)) }
 
       VanagonLogger.info "Generated: #{outfile}"

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -766,13 +766,13 @@ class Vanagon
     # about what will go into an artifact
     #
     # @param platform [String] platform we're writing metadata for
-    # @param temp_dir [String] directory metadata is written to
-    def cli_save_manifest_json(platform, temp_dir) # rubocop:disable Metrics/AbcSize
+    # @param temporary_directory [String] directory metadata is written to
+    def cli_save_manifest_json(platform, temporary_directory) # rubocop:disable Metrics/AbcSize
       manifest = build_manifest_json
       metadata = metadata_merge(manifest, @upstream_metadata)
 
       metadata_file_name = "build_metadata.#{name}.#{platform.name}.json"
-      outfile = File.join(temp_dir, metadata_file_name)
+      outfile = File.join(temporary_directory, metadata_file_name)
       File.open(outfile, 'w') { |f| f.write(JSON.pretty_generate(metadata)) }
 
       VanagonLogger.info "Generated: #{outfile}"


### PR DESCRIPTION
The dependencies command generates a json file which lists all required gems and gem versions in a json file for a given project and platform.