### PR TITLE
(maint) Allow target on CLI to set user and port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 - (RE-14305) Add 'vanagon dependencies' command to generate gem dependencies as a json file
 - (VANAGON-162) Added new instance variable 'log_url' to use in logs rather than the full git url
 - (maint) Check environment for the X-RPROXY-PASS variable and add it to the http request header in the download method if it exists
+- (maint) Allow target on CLI to set user and port
 
 ## [0.23.0] - released 2021-09-23
 ### Added

--- a/lib/vanagon/engine/docker.rb
+++ b/lib/vanagon/engine/docker.rb
@@ -36,11 +36,11 @@ class Vanagon
       # a docker container.
       # @raise [Vanagon::Error] if a target cannot be obtained
       def select_target
-        ssh_args = @platform.use_docker_exec ? '' : "-p #{@platform.ssh_port}:22"
+        ssh_args = @platform.use_docker_exec ? '' : "-p #{@target_port}:22"
         extra_args = @platform.docker_run_args.nil? ? [] : @platform.docker_run_args
 
         Vanagon::Utilities.ex("#{@docker_cmd} run -d --name #{build_host_name}-builder #{ssh_args} #{extra_args.join(' ')} #{@platform.docker_image}")
-        @target = 'localhost'
+        @target = URI.new('localhost')
 
         wait_for_ssh unless @platform.use_docker_exec
       rescue StandardError => e
@@ -141,7 +141,7 @@ class Vanagon
       def wait_for_ssh
         Vanagon::Utilities.retry_with_timeout(5, 5) do
           begin
-            Vanagon::Utilities.remote_ssh_command("#{@target_user}@#{@target}", 'exit', @platform.ssh_port)
+            Vanagon::Utilities.remote_ssh_command("#{@target_user}@#{@target}", 'exit', @target_port)
           rescue StandardError => e
             sleep(1) # Give SSHD some time to start.
             raise e

--- a/spec/lib/vanagon/engine/pooler_spec.rb
+++ b/spec/lib/vanagon/engine/pooler_spec.rb
@@ -2,7 +2,7 @@ require 'vanagon/engine/pooler'
 require 'vanagon/platform'
 
 describe 'Vanagon::Engine::Pooler' do
-  let (:platform) { double(Vanagon::Platform, :target_user => 'root') }
+  let (:platform) { double(Vanagon::Platform, :target_user => 'root', :ssh_port => 22) }
   let (:platform_with_vcloud_name) {
     plat = Vanagon::Platform::DSL.new('debian-6-i386')
     plat.instance_eval("platform 'debian-6-i386' do |plat|


### PR DESCRIPTION
This allows the CLI target argument to override the target user and port
specified in the platform config. This is useful for local dev
environments that don't match the enviroment used in the real build
pipeline. Previously, this required temporarily modifying the platform
config, which is more onerous than simply passing the argument on the
CLI.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.