### PR TITLE
(VANAGON-174) Add el-9 definitions to vanagon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 - (VANAGON-168) Remove Fedora 30 x86_64
 - (VANAGON-169) Remove Fedora 31 x86_64
 - (VANAGON-170) Remove OSX 10.14 x86_64
+- (VANAGON-174) Addition 'el-9' platform
 - (RE-14305) Add 'vanagon dependencies' command to generate gem dependencies as a json file
 - (VANAGON-162) Added new instance variable 'log_url' to use in logs rather than the full git url
 - (maint) Check environment for the X-RPROXY-PASS variable and add it to the http request header in the download method if it exists

--- a/lib/vanagon/platform/defaults/el-9-aarch64.rb
+++ b/lib/vanagon/platform/defaults/el-9-aarch64.rb
@@ -1,0 +1,10 @@
+platform "el-9-aarch64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  packages = %w(autoconf automake createrepo gcc gcc-c++ rsync cmake make rpm-libs rpm-build libarchive)
+  plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
+  plat.install_build_dependencies_with "dnf install -y --allowerasing "
+  plat.vmpooler_template "redhat-9-arm64"
+end

--- a/lib/vanagon/platform/defaults/el-9-x86_64.rb
+++ b/lib/vanagon/platform/defaults/el-9-x86_64.rb
@@ -1,0 +1,10 @@
+platform "el-9-x86_64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  packages = %w(gcc gcc-c++ autoconf automake createrepo rsync cmake make rpm-libs rpm-build rpm-sign libtool libarchive)
+  plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
+  plat.install_build_dependencies_with "dnf install -y --allowerasing "
+  plat.vmpooler_template "redhat-9-x86_64"
+end

--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -81,7 +81,7 @@ Requires:  <%= requires.requirement %><%= requires.version ? " #{requires.versio
 # did not specify a dependency on these.
 # In the future, we will supress pre/post scripts completely if there's nothing
 # specified by the project or the components.
-<%- if @platform.is_fedora? && @platform.os_version.to_i >= 29 -%>
+<%- if @platform.is_fedora? || (@platform.is_el? && @platform.os_version.to_i >= 9) -%>
 Requires(pre): /usr/bin/mkdir
 Requires(pre): /usr/bin/touch
 Requires(post): /usr/bin/mkdir


### PR DESCRIPTION
Add platforms to support building on el-9 based systems

In CentOS Stream 9

```
dnf install '/bin/mkdir'
Last metadata expiration check: 0:00:09 ago on Thu 02 Dec 2021 12:25:13 PM CET.
No match for argument: /bin/mkdir
Error: Unable to find a match: /bin/mkdir
```

where as

```
dnf install '/usr/bin/mkdir'
```

does install `coreutils-single`

Note that Fedora < 26 has already been deprecated and that case can be
ignored.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.