### PR TITLE
Revert "VANAGON-165"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 - (RE-14305) Add 'vanagon dependencies' command to generate gem dependencies as a json file
 - (VANAGON-162) Added new instance variable 'log_url' to use in logs rather than the full git url
 - (maint) Check environment for the X-RPROXY-PASS variable and add it to the http request header in the download method if it exists
-- (VANAGON-165) Use packaging gem methods instead of invoking rake tasks
 
 ## [0.23.0] - released 2021-09-23
 ### Added

--- a/bin/repo
+++ b/bin/repo
@@ -19,12 +19,12 @@ require 'packaging'
 Pkg::Util::RakeUtils.load_packaging_tasks
 case repo_target
 when 'rpm'
-  Pkg::Util::Repo.rpm_repos
+  Pkg::Util::RakeUtils.invoke_task('pl:jenkins:rpm_repos')
 when 'deb'
-  Pkg::Util::Repo.deb_repos
+  Pkg::Util::RakeUtils.invoke_task('pl:jenkins:deb_repos')
 when 'none'
   VanagonLogger.warn "Skipping repo generation since repo target is set to 'none'"
 else
-  Pkg::Util::Repo.rpm_repos
-  Pkg::Util::Repo.deb_repos
+  Pkg::Util::RakeUtils.invoke_task('pl:jenkins:rpm_repos')
+  Pkg::Util::RakeUtils.invoke_task('pl:jenkins:deb_repos')
 end

--- a/lib/vanagon/cli/ship.rb
+++ b/lib/vanagon/cli/ship.rb
@@ -28,8 +28,9 @@ class Vanagon
         end
 
         require 'packaging'
-        Pkg::Util::Ship.ship('artifacts', 'output')
-        Pkg::Util::Ship.ship_to_artifactory('output')
+        Pkg::Util::RakeUtils.load_packaging_tasks
+        Pkg::Util::RakeUtils.invoke_task('pl:jenkins:ship', 'artifacts', 'output')
+        Pkg::Util::RakeUtils.invoke_task('pl:jenkins:ship_to_artifactory', 'output')
       end
     end
   end

--- a/lib/vanagon/cli/sign.rb
+++ b/lib/vanagon/cli/sign.rb
@@ -28,7 +28,7 @@ class Vanagon
 
         require 'packaging'
         Pkg::Util::RakeUtils.load_packaging_tasks
-        Pkg::Util::Sign.sign_all('output')
+        Pkg::Util::RakeUtils.invoke_task('pl:jenkins:sign_all', 'output')
       end
     end
   end


### PR DESCRIPTION
Reverts puppetlabs/vanagon#725

Puppet Agent and components have packaging location pinned to 0.99.43 but pull from vanagon main branch. This depends on changes in packaging 0.105.0. Reverting this to un-break their pipelines, and the updates to those projects will be ticketed for after the upcoming releases