### PR TITLE
(RE-13380) Support Apple Notarization for Puppet Packages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 - (RE-14305) Add 'vanagon dependencies' command to generate gem dependencies as a json file
 - (VANAGON-162) Added new instance variable 'log_url' to use in logs rather than the full git url
 - (maint) Check environment for the X-RPROXY-PASS variable and add it to the http request header in the download method if it exists
+- (RE-13380) Added support for Apple Notarization. 
 
 ## [0.23.0] - released 2021-09-23
 ### Added

--- a/lib/vanagon/platform/osx.rb
+++ b/lib/vanagon/platform/osx.rb
@@ -41,6 +41,8 @@ class Vanagon
           sign_commands = []
         end
 
+        signing_host = "jenkins@osx-signer-prod-2.delivery.puppetlabs.net"
+
          # Setup build directories
         ["bash -c 'mkdir -p $(tempdir)/osx/build/{dmg,pkg,scripts,resources,root,payload,plugins}'",
          "mkdir -p $(tempdir)/osx/build/root/#{project.name}-#{project.version}",
@@ -56,8 +58,32 @@ class Vanagon
 
          bom_install,
 
+         #  The signing commands below should not cause `vanagon build` to fail. Many devs need to run `vanagon build`
+         #  locally and do not necessarily need signed packages. The `|| :` will rescue failures by evaluating as successful.
+         #  /Users/binaries will be a list of all binaries that need to be signed
+         "touch /Users/binaries || :",
+         #  Find all of the executables (Mach-O files), and put the in /Users/binaries
+         "echo bananaa",
+         "for item in `find $(tempdir)/osx/build/ -perm -0100 -type f` ; do file $$item | grep 'Mach-O' ; done | awk '{print $$1}' | sed 's/\:$$//' > /Users/binaries || :",
+         #  A tmpdir is created on the signing_host, all off the executables will be rsyncd there to be signed
+         "echo dog",
+         "#{Vanagon::Utilities.ssh_command}  #{signing_host} mkdir -p /tmp/$(binaries_dir) || :",
+         "echo apple",
+         "rsync -e '#{Vanagon::Utilities.ssh_command}' --no-perms --no-owner --no-group --files-from=/Users/binaries / #{signing_host}:/tmp/$(binaries_dir) || :",
+         "echo raisin",
+         "rsync -e '#{Vanagon::Utilities.ssh_command}' --no-perms --no-owner --no-group /Users/binaries #{signing_host}:/tmp/binaries_list || :",
+         #  The binaries are signed, and then rsynced back
+         "#{Vanagon::Utilities.ssh_command}  #{signing_host} /usr/local/bin/sign.sh $(binaries_dir) || :",
+         "echo peach",
+         "rsync -e '#{Vanagon::Utilities.ssh_command}' --no-perms --no-owner --no-group -r #{signing_host}:/tmp/$(binaries_dir)/var/ /var || :",
+         "echo parsnip",
+
          # Sign extra files
          sign_commands,
+         # Some extra files are created during the signing process that are not needed, so we delete them! Otherwise 
+         # notarization gets confused by these extra files. 
+          "for item in `find $(tempdir)/osx/build -type d -name Resources` ; do rm -rf $$item ; done || :",
+
 
          # Package the project
          "(cd $(tempdir)/osx/build/; #{@pkgbuild} --root root/#{project.name}-#{project.version} \

--- a/resources/Makefile.erb
+++ b/resources/Makefile.erb
@@ -9,6 +9,10 @@ workdir := $(PWD)
 
 all: file-list-before-build <%= package_name %>
 
+<%- if @platform.is_macos? -%>
+binaries_dir := $(shell <%= @platform.mktemp %> 2>/dev/null)
+<%- end -%>
+
 <%= package_name %>: <%= @name %>-<%= @version %>.tar.gz
 	<%= generate_package.join("\n\t") %>
 


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.