### PR TITLE
(VANAGON-179) Support ruby 3 for vanagon localhost

### DIFF
--- a/.github/workflows/ruby3.yml
+++ b/.github/workflows/ruby3.yml
@@ -1,0 +1,20 @@
+name: Ruby3
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Ruby 3.0
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 3.0.x
+    - name: Build and test with Rake
+      run: |
+        gem install bundler
+        bundle install --jobs 4 --retry 3
+        bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ notifications:
 rvm:
   - 2.4
   - 2.6
+  - 3.0
 
 env:
   - "CHECK='rake test:spec'"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 ### Added
+- (VANAGON-179) Addition of ruby 3 support for vanagon
 
 ### Changed
 

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gemspec
 
 # Confine EC2 engine dependencies
 group "ec2-engine" do
-  gem "aws-sdk", "~> 2.2.0", require: false
+  gem "aws-sdk", "~> 3.1.0", require: false
 end
 
 # "lock_manager" is specified in development dependencies, to allow

--- a/lib/git/basic_submodules.rb
+++ b/lib/git/basic_submodules.rb
@@ -36,7 +36,7 @@ module BasicSubmodules
   # @option options [Boolean] :recursive recurse into nested submodules
   # @return options [String] any output produced by `git` when submodules are initialized
   def update_submodules(**options)
-    self.lib.update_submodules(options)
+    self.lib.update_submodules(**options)
   end
 end
 

--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -258,7 +258,7 @@ class Vanagon
       mirrors.to_a.shuffle.each do |mirror|
         begin
           VanagonLogger.info %(Attempting to fetch from mirror URL "#{mirror}")
-          @source = Vanagon::Component::Source.source(mirror, options)
+          @source = Vanagon::Component::Source.source(mirror, **options)
           return true if source.fetch
         rescue SocketError
           # SocketError means that there was no DNS/name resolution
@@ -281,7 +281,7 @@ class Vanagon
     #   or False otherwise
     def fetch_url(options)
       VanagonLogger.info %(Attempting to fetch from canonical URL "#{url}")
-      @source = Vanagon::Component::Source.source(url, options)
+      @source = Vanagon::Component::Source.source(url, **options)
       # Explicitly coerce the return value of #source.fetch,
       # because each subclass of Vanagon::Component::Source returns
       # an inconsistent value if #fetch is successful.

--- a/spec/lib/vanagon/engine/ec2_spec.rb
+++ b/spec/lib/vanagon/engine/ec2_spec.rb
@@ -29,6 +29,16 @@ if defined? ::Aws
     it 'returns "ec2" name' do
       stub_request(:get, "http://169.254.169.254/latest/meta-data/iam/security-credentials/").
           to_return(status: 200, body: "", headers: {})
+      stub_request(:put, "http://169.254.169.254/latest/api/token").
+          with(
+              headers: {
+                 'Accept'=>'*/*',
+                 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                 'User-Agent'=>'aws-sdk-ruby3/3.124.0',
+                 'X-Aws-Ec2-Metadata-Token-Ttl-Seconds'=>'21600'
+              }).
+              to_return(status: 200, body: "", headers: {})
+
       expect(Vanagon::Engine::Ec2.new(platform_ec2).name).to eq('ec2')
     end
   end

--- a/spec/lib/vanagon/engine/ec2_spec.rb
+++ b/spec/lib/vanagon/engine/ec2_spec.rb
@@ -1,5 +1,4 @@
-begin
-  require 'aws-sdk'
+begin require 'aws-sdk'
 rescue LoadError
   $stderr.puts "Unable to load AWS SDK; skipping optional EC2 engine spec tests"
 end
@@ -28,16 +27,9 @@ if defined? ::Aws
 
     it 'returns "ec2" name' do
       stub_request(:get, "http://169.254.169.254/latest/meta-data/iam/security-credentials/").
-          to_return(status: 200, body: "", headers: {})
+        to_return(status: 200, body: "", headers: {})
       stub_request(:put, "http://169.254.169.254/latest/api/token").
-          with(
-              headers: {
-                 'Accept'=>'*/*',
-                 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-                 'User-Agent'=>'aws-sdk-ruby3/3.124.0',
-                 'X-Aws-Ec2-Metadata-Token-Ttl-Seconds'=>'21600'
-              }).
-              to_return(status: 200, body: "", headers: {})
+          to_return(status: 200, body: "", headers: {})
 
       expect(Vanagon::Engine::Ec2.new(platform_ec2).name).to eq('ec2')
     end

--- a/vanagon.gemspec
+++ b/vanagon.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.email    = 'info@puppet.com'
   gem.homepage = 'http://github.com/puppetlabs/vanagon'
   gem.specification_version = 3
-  gem.required_ruby_version = '~> 2.3'
+  gem.required_ruby_version = '>=2.3', '<4'
 
   gem.add_runtime_dependency('docopt')
   # Handle git repos responsibly


### PR DESCRIPTION
Allow vanagon to be run with ruby 3. In particular CentOS stream 9
is ruby 3.0.2p107.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.

Closes #722 