### PR TITLE
(RE-13380) Support Apple Notarization for Puppet Packages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 - (RE-14305) Add 'vanagon dependencies' command to generate gem dependencies as a json file
 - (VANAGON-162) Added new instance variable 'log_url' to use in logs rather than the full git url
 - (maint) Check environment for the X-RPROXY-PASS variable and add it to the http request header in the download method if it exists
+- (RE-13380) Added support for Apple Notarization. 
 
 ## [0.23.0] - released 2021-09-23
 ### Added

--- a/resources/Makefile.erb
+++ b/resources/Makefile.erb
@@ -9,6 +9,10 @@ workdir := $(PWD)
 
 all: file-list-before-build <%= package_name %>
 
+<%- if @platform.is_macos? -%>
+binaries_dir := $(shell <%= @platform.mktemp %> 2>/dev/null)
+<%- end -%>
+
 <%= package_name %>: <%= @name %>-<%= @version %>.tar.gz
 	<%= generate_package.join("\n\t") %>
 


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.