### PR TITLE
(VANAGON-187) Change valid remote repository check to use 'git ls-remote --heads'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 - (VANAGON-179) Addition of ruby 3 support for vanagon
 
 ### Changed
+- (VANAGON-187) Change valid remote repository check to use 'git ls-remote --heads' rather than 'git ls-remote'
 
 ### Removed
 

--- a/lib/vanagon/component/source/git.rb
+++ b/lib/vanagon/component/source/git.rb
@@ -50,7 +50,7 @@ class Vanagon
 
           def valid_remote?(url, timeout = 0)
             Timeout.timeout(timeout) do
-              Vanagon::Utilities.local_command("git ls-remote #{url} > /dev/null 2>&1")
+              Vanagon::Utilities.local_command("git ls-remote --heads #{url} > /dev/null 2>&1")
               return false unless $?.exitstatus.zero?
               return true
             end


### PR DESCRIPTION

Please add all notable changes to the "Unreleased" section of the CHANGELOG.