### PR TITLE
Revert "(RE-13380) Support Apple Notarization for Puppet Packages."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 - (RE-14305) Add 'vanagon dependencies' command to generate gem dependencies as a json file
 - (VANAGON-162) Added new instance variable 'log_url' to use in logs rather than the full git url
 - (maint) Check environment for the X-RPROXY-PASS variable and add it to the http request header in the download method if it exists
-- (RE-13380) Added support for Apple Notarization. 
 
 ### Removed
 - (VANAGON-168) Remove Fedora 30 x86_64

--- a/lib/vanagon/platform/osx.rb
+++ b/lib/vanagon/platform/osx.rb
@@ -41,8 +41,6 @@ class Vanagon
           sign_commands = []
         end
 
-        signing_host = "jenkins@osx-signer-prod-2.delivery.puppetlabs.net"
-
          # Setup build directories
         ["bash -c 'mkdir -p $(tempdir)/osx/build/{dmg,pkg,scripts,resources,root,payload,plugins}'",
          "mkdir -p $(tempdir)/osx/build/root/#{project.name}-#{project.version}",
@@ -58,26 +56,8 @@ class Vanagon
 
          bom_install,
 
-         #  The signing commands below should not cause `vanagon build` to fail. Many devs need to run `vanagon build`
-         #  locally and do not necessarily need signed packages. The `|| :` will rescue failures by evaluating as successful.
-         #  /Users/binaries will be a list of all binaries that need to be signed
-         "touch /Users/binaries || :",
-         #  Find all of the executables (Mach-O files), and put the in /Users/binaries
-         "for item in `find $(tempdir)/osx/build/ -perm -0100 -type f` ; do file $$item | grep 'Mach-O' ; done | awk '{print $$1}' | sed 's/\:$$//' > /Users/binaries || :",
-         #  A tmpdir is created on the signing_host, all of the executables will be rsyncd there to be signed
-         "#{Vanagon::Utilities.ssh_command}  #{signing_host} mkdir -p /tmp/$(binaries_dir) || :",
-         "rsync -e '#{Vanagon::Utilities.ssh_command}' --no-perms --no-owner --no-group --files-from=/Users/binaries / #{signing_host}:/tmp/$(binaries_dir) || :",
-         "rsync -e '#{Vanagon::Utilities.ssh_command}' --no-perms --no-owner --no-group /Users/binaries #{signing_host}:/tmp/$(binaries_dir)/binaries_list || :",
-         #  The binaries are signed, and then rsynced back
-         "#{Vanagon::Utilities.ssh_command}  #{signing_host} /usr/local/bin/sign.sh $(binaries_dir) || :",
-         "rsync -e '#{Vanagon::Utilities.ssh_command}' --no-perms --no-owner --no-group -r #{signing_host}:/tmp/$(binaries_dir)/var/ /var || :",
-
          # Sign extra files
          sign_commands,
-         # Some extra files are created during the signing process that are not needed, so we delete them! Otherwise
-         # notarization gets confused by these extra files.
-          "for item in `find $(tempdir)/osx/build -type d -name Resources` ; do rm -rf $$item ; done || :",
-
 
          # Package the project
          "(cd $(tempdir)/osx/build/; #{@pkgbuild} --root root/#{project.name}-#{project.version} \

--- a/resources/Makefile.erb
+++ b/resources/Makefile.erb
@@ -9,10 +9,6 @@ workdir := $(PWD)
 
 all: file-list-before-build <%= package_name %>
 
-<%- if @platform.is_macos? -%>
-binaries_dir := $(shell <%= @platform.mktemp %> 2>/dev/null)
-<%- end -%>
-
 <%= package_name %>: <%= @name %>-<%= @version %>.tar.gz
 	<%= generate_package.join("\n\t") %>
 


### PR DESCRIPTION
This reverts commit 5919ba23749dbc5fa4674dac75ef418687ebd882.

The Phoenix team has had issues with the new Apple signing/notarization process and have had to pin to f0f43db (the commit prior to notarization being added).

To move forward with other Vanagon changes (e.g. adding macOS 12 support) we'll need to revert notarization changes.