### PR TITLE
(VANAGON-192) Github no longer supports git://

### DIFF
--- a/spec/lib/vanagon/component/source/git_spec.rb
+++ b/spec/lib/vanagon/component/source/git_spec.rb
@@ -5,7 +5,7 @@ describe "Vanagon::Component::Source::Git" do
   before :all do
     @klass = Vanagon::Component::Source::Git
     # This repo will not be cloned over the network
-    @url = 'git://github.com/puppetlabs/facter.git'
+    @url = 'https://github.com/puppetlabs/facter.git'
     # This path will not be created on disk
     @local_url = "file://#{Dir.tmpdir}/puppet-agent"
     @ref_tag = 'refs/tags/2.2.0'

--- a/spec/lib/vanagon/component/source_spec.rb
+++ b/spec/lib/vanagon/component/source_spec.rb
@@ -8,7 +8,6 @@ describe "Vanagon::Component::Source" do
     let(:unrecognized_scheme) { "abcd" }
     let(:invalid_scheme) { "abcd|things" }
 
-    let(:public_git) { "git://github.com/abcd/things" }
     let(:private_git) { "git@github.com:abcd/things" }
     let(:http_git) { "http://github.com/abcd/things" }
     let(:https_git) { "https://github.com/abcd/things" }
@@ -51,12 +50,6 @@ describe "Vanagon::Component::Source" do
       it "returns a Git object for git@ triplet repositories" do
         expect(klass.source(private_git, ref: ref, workdir: workdir).class)
           .to eq Vanagon::Component::Source::Git
-      end
-
-      it "returns a Git object for git:// repositories" do
-        component_source = klass.source(public_git, ref: ref, workdir: workdir)
-        expect(component_source.url.to_s).to eq public_git
-        expect(component_source.class).to eq Vanagon::Component::Source::Git
       end
 
       it "returns a Git object for http:// repositories" do

--- a/spec/lib/vanagon/component_spec.rb
+++ b/spec/lib/vanagon/component_spec.rb
@@ -258,12 +258,12 @@ describe "Vanagon::Component" do
   describe '#force_version' do
     let(:source) {
       allow(File).to receive(:realpath).and_return('/this/is/a/test')
-      Vanagon::Component::Source::Git.new('git://github.com/puppetlabs/facter', workdir: '/this/is/a/test')
+      Vanagon::Component::Source::Git.new('https://github.com/puppetlabs/facter', workdir: '/this/is/a/test')
     }
 
     let(:component) {
       Vanagon::Component.new('force-version-test', {}, {}).tap do |comp|
-        comp.url = 'git://github.com/puppetlabs/facter'
+        comp.url = 'https://github.com/puppetlabs/facter'
         comp.source = source
       end
     }


### PR DESCRIPTION
Tests are broken as of March 15, 2022 due to Github dropping support for non-encrypted connections