### PR TITLE
(VANAGON-192) Add allow net connect in #force_version spec test to fix failing tests with https.

### DIFF
--- a/spec/lib/vanagon/component/source/git_spec.rb
+++ b/spec/lib/vanagon/component/source/git_spec.rb
@@ -5,7 +5,7 @@ describe "Vanagon::Component::Source::Git" do
   before :all do
     @klass = Vanagon::Component::Source::Git
     # This repo will not be cloned over the network
-    @url = 'git://github.com/puppetlabs/facter.git'
+    @url = 'https://github.com/puppetlabs/facter.git'
     # This path will not be created on disk
     @local_url = "file://#{Dir.tmpdir}/puppet-agent"
     @ref_tag = 'refs/tags/2.2.0'

--- a/spec/lib/vanagon/component/source_spec.rb
+++ b/spec/lib/vanagon/component/source_spec.rb
@@ -8,7 +8,6 @@ describe "Vanagon::Component::Source" do
     let(:unrecognized_scheme) { "abcd" }
     let(:invalid_scheme) { "abcd|things" }
 
-    let(:public_git) { "git://github.com/abcd/things" }
     let(:private_git) { "git@github.com:abcd/things" }
     let(:http_git) { "http://github.com/abcd/things" }
     let(:https_git) { "https://github.com/abcd/things" }
@@ -53,12 +52,6 @@ describe "Vanagon::Component::Source" do
           .to eq Vanagon::Component::Source::Git
       end
 
-      it "returns a Git object for git:// repositories" do
-        component_source = klass.source(public_git, ref: ref, workdir: workdir)
-        expect(component_source.url.to_s).to eq public_git
-        expect(component_source.class).to eq Vanagon::Component::Source::Git
-      end
-
       it "returns a Git object for http:// repositories" do
         expect(klass.source(http_git, ref: ref, workdir: workdir).class)
           .to eq Vanagon::Component::Source::Git
@@ -74,7 +67,6 @@ describe "Vanagon::Component::Source" do
         expect(component_source.url.to_s).to eq 'http://github.com/abcd/things'
         expect(component_source.class).to eq Vanagon::Component::Source::Git
       end
-
     end
 
     context "takes a HTTP/HTTPS file" do

--- a/spec/lib/vanagon/component_spec.rb
+++ b/spec/lib/vanagon/component_spec.rb
@@ -258,12 +258,13 @@ describe "Vanagon::Component" do
   describe '#force_version' do
     let(:source) {
       allow(File).to receive(:realpath).and_return('/this/is/a/test')
-      Vanagon::Component::Source::Git.new('git://github.com/puppetlabs/facter', workdir: '/this/is/a/test')
+      WebMock.allow_net_connect!
+      Vanagon::Component::Source::Git.new('https://github.com/puppetlabs/facter', workdir: '/this/is/a/test')
     }
 
     let(:component) {
       Vanagon::Component.new('force-version-test', {}, {}).tap do |comp|
-        comp.url = 'git://github.com/puppetlabs/facter'
+        comp.url = 'https://github.com/puppetlabs/facter'
         comp.source = source
       end
     }


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.