### PR TITLE
(maint) Simplifies logic for .tar.xz archives

### DIFF
--- a/lib/vanagon/component/source/local.rb
+++ b/lib/vanagon/component/source/local.rb
@@ -97,14 +97,12 @@ class Vanagon
             %(gunzip "#{file}")
           when "rar"
             %(unrar x "#{file}")
-          when "tar"
+          when "tar", "txz"
             %(#{tar} xf "#{file}")
           when "tbz2"
             %(bunzip2 -c "#{file}" | #{tar} xf -)
           when "tgz"
             %(gunzip -c "#{file}" | #{tar} xf -)
-          when "txz"
-            %(unxz -d "#{file}" | #{tar} xvf -)
           when "xz"
             %(unxz "#{file}")
           when "zip"


### PR DESCRIPTION
Currently, the logic for decompressing .tar.xz archives uses `unxz`
which pipes to `tar`. This uses multiple tools unnecessarily and
doesn't work.

This commit simplifies the logic to only use `tar`.

Encountered issues with this while downloading the latest archive dmidecode for PA-4423.

Tested this behavior on a RedHat 7 machine:
```
[root@indirect-door ~]# cat /etc/redhat-release
Red Hat Enterprise Linux Server release 7.9 (Maipo)
[root@indirect-door test]# curl http://download.savannah.gnu.org/releases/dmidecode/dmidecode-3.3.tar.xz -JLOs; unxz -d "dmidecode-3.3.tar.xz" | tar xvf -; ls; rm -rf dmidecode*
tar: This does not look like a tar archive
tar: Exiting with failure status due to previous errors
dmidecode-3.3.tar
[root@indirect-door test]# curl http://download.savannah.gnu.org/releases/dmidecode/dmidecode-3.3.tar.xz -JLOs; tar xf "dmidecode-3.3.tar.xz"; ls; rm -rf dmidecode*
dmidecode-3.3  dmidecode-3.3.tar.xz
```