### PR TITLE
(maint) compat levels below 10 are deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- (maint) set the Debian compat level from 7 (which is unsupported) to 10
 
 ## [0.27.0] - released 2022-06-06
 ### Added

--- a/lib/vanagon/platform/deb.rb
+++ b/lib/vanagon/platform/deb.rb
@@ -46,7 +46,7 @@ class Vanagon
         end
 
         # These could be templates, but their content is static, so that seems weird.
-        File.open(File.join(deb_dir, "compat"), "w") { |f| f.puts("7") }
+        File.open(File.join(deb_dir, 'compat'), 'w') { |f| f.puts('10') }
         FileUtils.mkdir_p(File.join(deb_dir, "source"))
         File.open(File.join(deb_dir, "source", "format"), "w") { |f| f.puts("3.0 (quilt)") }
       end


### PR DESCRIPTION
Set compat to '10' which is the lowest still supported.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.