### PR TITLE
(maint) force dh_builddeb to use -Zgzip for reprepro compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ### Added
 - (VANAGON-182) Add Ubuntu 22.04
 
+### Changed
+- (maint) Force dh_builddeb to use -Zgzip for compatibility with reprepro
+
 ## [0.26.3] - released 2022-05-11
 ### Changed
 - (RE-14660) Update git gem dependency

--- a/resources/deb/rules.erb
+++ b/resources/deb/rules.erb
@@ -27,5 +27,10 @@ override_dh_shlibdeps:
 
 override_dh_usrlocal:
 
+override_dh_builddeb:
+	# Force builddeb to use gzip for its internal compression. reprepro can get
+	# confused if something newer is used.
+	dh_builddeb -- -Zgzip
+
 %:
 	dh $@


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.