### PR TITLE
(maint) Removes optional Mac installer attribute

### DIFF
--- a/resources/osx/project-installer.xml.erb
+++ b/resources/osx/project-installer.xml.erb
@@ -5,7 +5,7 @@
     <license file="<%= @name -%>-License.rtf"/>
     <domains enable_anywhere="true" enable_currentUserHome="false" enable_localSystem="true" />
     <pkg-ref id="<%= @identifier-%>.<%= @name -%>"/>
-    <options customize="never" hostArchitectures="i386" require-scripts="false"/>
+    <options customize="never" require-scripts="false"/>
     <choices-outline>
         <line choice="default">
             <line choice="<%= @identifier-%>.<%= @name -%>"/>


### PR DESCRIPTION
`hostArchitecture` is an optional attribute and what we specify
now (i386) is outdated and causes our arm64/M1 packages to not
properly install.