### PR TITLE
(maint) Seeing if setting host arch to be x86_64,arm64 will work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 - (maint) set the Debian compat level from 7 (which is unsupported) to 10
 - (maint) Fail more gently when a platform file isn't found. Also relax requirement that
   the platform name not end with the '.rb' extension.
+- (maint) Update the macos hostArchitectures option to 'x86_64,arm64' in order to support the install of packages on macos M1 hardware
 
 ## [0.27.0] - released 2022-06-06
 ### Added

--- a/resources/osx/project-installer.xml.erb
+++ b/resources/osx/project-installer.xml.erb
@@ -5,7 +5,7 @@
     <license file="<%= @name -%>-License.rtf"/>
     <domains enable_anywhere="true" enable_currentUserHome="false" enable_localSystem="true" />
     <pkg-ref id="<%= @identifier-%>.<%= @name -%>"/>
-    <options customize="never" hostArchitectures="i386" require-scripts="false"/>
+    <options customize="never" hostArchitectures="x86_64,arm64" require-scripts="false"/>
     <choices-outline>
         <line choice="default">
             <line choice="<%= @identifier-%>.<%= @name -%>"/>


### PR DESCRIPTION
This change allows the install of the puppet-agent package on macos M1