### PR TITLE
(maint) Add brew method for macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This changelog adheres to [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
 
+### Added
+- (maint) Adds `brew` attribute to specify the path of Homebrew on macOS on different architectures.
+
 ## [0.37.1] - release 2023-06-21
 ### Changed
 - (maint) Add TLS 1.2 to the platform add command for Windows

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -54,6 +54,7 @@ class Vanagon
     attr_accessor :sort
     attr_accessor :tar
     attr_accessor :shasum
+    attr_accessor :brew # This is macOS specific
 
     # Hold a string containing the values that a given platform
     # should use when a Makefile is run - resolves to the CFLAGS

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -159,6 +159,13 @@ class Vanagon
         @platform.copy = copy_cmd
       end
 
+      # Set the path to Homebrew for the platform
+      #
+      # @param brew_cmd [String] Absolute path to Homebrew for the platform
+      def brew(brew_cmd)
+        @platform.brew = brew_cmd
+      end
+
       # Set the cross_compiled flag for the platform
       #
       # @param xcc [Boolean] True if this is a cross-compiled platform

--- a/lib/vanagon/platform/osx.rb
+++ b/lib/vanagon/platform/osx.rb
@@ -10,7 +10,7 @@ class Vanagon
         <<-HERE.undent
           mkdir -p /etc/homebrew
           cd /etc/homebrew
-          su test -c '/usr/local/bin/brew install #{list_build_dependencies.join(' ')}'
+          su test -c '#{@brew} install #{list_build_dependencies.join(' ')}'
         HERE
       end
 
@@ -135,6 +135,7 @@ class Vanagon
         @patch = "/usr/bin/patch"
         @num_cores = "/usr/sbin/sysctl -n hw.physicalcpu"
         @mktemp = "mktemp -d -t 'tmp'"
+        @brew = '/usr/local/bin/brew'
         super(name)
       end
     end


### PR DESCRIPTION
In 2020, Apple began releasing machines that used new ARM-based  processors, as opposed to the x86 processors it had used for many years prior.

Homebrew, a macOS package manager, changes its path depending on whether it's running on x86-64 or ARM64.

This commit adds a new `brew` method to Vanagon that defaults to the x86 path (/usr/local/bin/brew) but can be overriden to the ARM path (/opt/homebrew/bin/brew).