### PR TITLE
(VANAGON-193) Adds support for Fedora 36 (x86-64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+### Added
+
+- (VANAGON-193) Adds support for Fedora 36 (x86-64)
+
 ### Changed
+
 - (maint) set the Debian compat level from 7 (which is unsupported) to 10
 - (maint) Fail more gently when a platform file isn't found. Also relax requirement that
   the platform name not end with the '.rb' extension.

--- a/lib/vanagon/platform/defaults/fedora-36-x86_64.rb
+++ b/lib/vanagon/platform/defaults/fedora-36-x86_64.rb
@@ -1,0 +1,17 @@
+platform 'fedora-36-x86_64' do |plat|
+  plat.servicedir '/usr/lib/systemd/system'
+  plat.defaultdir '/etc/sysconfig'
+  plat.servicetype 'systemd'
+  plat.dist 'fc36'
+
+  packages = %w[
+    autoconf automake bzip2-devel gcc gcc-c++ libselinux-devel
+    libsepol libsepol-devel make cmake pkgconfig readline-devel
+    rpmdevtools rsync swig zlib-devel systemtap-sdt-devel
+    perl-lib perl-FindBin
+  ]
+  plat.provision_with("/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}")
+
+  plat.install_build_dependencies_with '/usr/bin/dnf install -y --best --allowerasing'
+  plat.vmpooler_template 'fedora-36-x86_64'
+end


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.