### PR TITLE
(maint) Revert extra file signing to use rsync again instead of scp due to issues with macos.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ## [Unreleased]
 ### Changed
 
+## [0.30.0] - release 2022-08-18
+### Changed
+- (maint) Update extra file signer to use rsync for extra file signing due to scp causing issues with osx.
+
 ## [0.29.0] - release 2022-08-15
 ### Changed
 - (maint) Update extra file signer to use scp and sign using a script rather than a direct ssh command.
@@ -1058,7 +1062,8 @@ on Debian < 8 and needs more work and testing.
 
 ## Versions <= 0.3.9 do not have a change log entry
 
-[Unreleased]: https://github.com/puppetlabs/vanagon/compare/0.29.0...HEAD
+[Unreleased]: https://github.com/puppetlabs/vanagon/compare/0.30.0...HEAD
+[0.30.0]: https://github.com/puppetlabs/vanagon/compare/0.29.0...0.30.0
 [0.29.0]: https://github.com/puppetlabs/vanagon/compare/0.28.0...0.29.0
 [0.28.0]: https://github.com/puppetlabs/vanagon/compare/0.27.0...0.28.0
 [0.27.0]: https://github.com/puppetlabs/vanagon/compare/0.26.3...0.27.0

--- a/lib/vanagon/utilities/extra_files_signer.rb
+++ b/lib/vanagon/utilities/extra_files_signer.rb
@@ -33,6 +33,9 @@ class Vanagon
             ]
           end
 
+          puts "COMMANDSSS"
+          puts commands
+
           commands
         rescue RuntimeError
           require 'vanagon/logger'

--- a/lib/vanagon/utilities/extra_files_signer.rb
+++ b/lib/vanagon/utilities/extra_files_signer.rb
@@ -33,8 +33,8 @@ class Vanagon
             ]
           end
 
-          puts "COMMANDSSS"
-          puts commands
+          VanagonLogger.info "COMMANDSSS"
+          VanagonLogger.info commands
 
           commands
         rescue RuntimeError

--- a/lib/vanagon/utilities/extra_files_signer.rb
+++ b/lib/vanagon/utilities/extra_files_signer.rb
@@ -33,6 +33,9 @@ class Vanagon
             ]
           end
 
+          VanagonLogger.info "COMMANDSSS"
+          VanagonLogger.info commands
+
           commands
         rescue RuntimeError
           require 'vanagon/logger'

--- a/lib/vanagon/utilities/extra_files_signer.rb
+++ b/lib/vanagon/utilities/extra_files_signer.rb
@@ -16,6 +16,8 @@ class Vanagon
           remote_host = "#{project.signing_username}@#{project.signing_hostname}"
           remote_destination_directory = "#{remote_host}:#{tempdir}"
           remote_signing_script_path = File.join(tempdir, File.basename('sign_extra_file'))
+          extra_flags = ''
+          extra_flags = '--extended-attributes' if project.platform.is_macos?
 
           project.extra_files_to_sign.each do |file|
             remote_file_to_sign_path = File.join(tempdir, File.basename(file))
@@ -25,9 +27,9 @@ class Vanagon
 
             commands += [
               "#{Vanagon::Utilities.ssh_command} #{remote_host} \"echo '#{project.signing_command} #{remote_file_to_sign_path}' > #{remote_signing_script_path}\"",
-              "scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no #{local_source_path} #{remote_destination_directory}",
+              "rsync -e '#{Vanagon::Utilities.ssh_command}' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group #{extra_flags} #{local_source_path} #{remote_destination_directory}",
               "#{Vanagon::Utilities.ssh_command} #{remote_host} /bin/bash #{remote_signing_script_path}",
-              "scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no #{remote_source_path} #{local_destination_path}"
+              "rsync -e '#{Vanagon::Utilities.ssh_command}' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group #{extra_flags} #{remote_source_path} #{local_destination_path}"
             ]
           end
 

--- a/lib/vanagon/utilities/extra_files_signer.rb
+++ b/lib/vanagon/utilities/extra_files_signer.rb
@@ -33,9 +33,6 @@ class Vanagon
             ]
           end
 
-          VanagonLogger.info "COMMANDSSS"
-          VanagonLogger.info commands
-
           commands
         rescue RuntimeError
           require 'vanagon/logger'

--- a/spec/lib/vanagon/utilities/extra_files_signer_spec.rb
+++ b/spec/lib/vanagon/utilities/extra_files_signer_spec.rb
@@ -83,7 +83,7 @@ describe Vanagon::Utilities::ExtraFilesSigner do
             commands = Vanagon::Utilities::ExtraFilesSigner.commands(project._project, mktemp, source_dir)
             expect(commands).to match(
               [
-                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc \"echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file\"),
+                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc \"echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file"),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes $(tempdir)/dir/source_dir/test1/a.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes test@abc:/tmp/xyz/a.rb $(tempdir)/dir/source_dir/test1/a.rb),

--- a/spec/lib/vanagon/utilities/extra_files_signer_spec.rb
+++ b/spec/lib/vanagon/utilities/extra_files_signer_spec.rb
@@ -83,11 +83,11 @@ describe Vanagon::Utilities::ExtraFilesSigner do
             commands = Vanagon::Utilities::ExtraFilesSigner.commands(project._project, mktemp, source_dir)
             expect(commands).to match(
               [
-                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc \"echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file"),
+                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc \"echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file\"),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes $(tempdir)/dir/source_dir/test1/a.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes test@abc:/tmp/xyz/a.rb $(tempdir)/dir/source_dir/test1/a.rb),
-                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc "echo 'codesign /tmp/xyz/b.rb' > /tmp/xyz/sign_extra_file"),
+                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc \"echo 'codesign /tmp/xyz/b.rb' > /tmp/xyz/sign_extra_file\"),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes $(tempdir)/dir/source_dir/test2/b.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes test@abc:/tmp/xyz/b.rb $(tempdir)/dir/source_dir/test2/b.rb)
@@ -109,11 +109,11 @@ describe Vanagon::Utilities::ExtraFilesSigner do
             commands = Vanagon::Utilities::ExtraFilesSigner.commands(project._project, mktemp, source_dir)
             expect(commands).to match(
               [
-                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc "echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file"),
-                %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group $(tempdir)/dir/source_dir/test1/a.rb test@abc:/tmp/xyz),
+                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc \"echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file\"),
+                %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group  $(tempdir)/dir/source_dir/test1/a.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group test@abc:/tmp/xyz/a.rb $(tempdir)/dir/source_dir/test1/a.rb),
-                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc "echo 'codesign /tmp/xyz/b.rb' > /tmp/xyz/sign_extra_file"),
+                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc \"echo 'codesign /tmp/xyz/b.rb' > /tmp/xyz/sign_extra_file\"),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group $(tempdir)/dir/source_dir/test2/b.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group test@abc:/tmp/xyz/b.rb $(tempdir)/dir/source_dir/test2/b.rb)

--- a/spec/lib/vanagon/utilities/extra_files_signer_spec.rb
+++ b/spec/lib/vanagon/utilities/extra_files_signer_spec.rb
@@ -83,11 +83,11 @@ describe Vanagon::Utilities::ExtraFilesSigner do
             commands = Vanagon::Utilities::ExtraFilesSigner.commands(project._project, mktemp, source_dir)
             expect(commands).to match(
               [
-                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc "echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file"),
+                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc \"echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file\"),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes $(tempdir)/dir/source_dir/test1/a.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes test@abc:/tmp/xyz/a.rb $(tempdir)/dir/source_dir/test1/a.rb),
-                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc "echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file"),
+                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc \"echo 'codesign /tmp/xyz/b.rb' > /tmp/xyz/sign_extra_file\"),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes $(tempdir)/dir/source_dir/test2/b.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes test@abc:/tmp/xyz/b.rb $(tempdir)/dir/source_dir/test2/b.rb)
@@ -109,11 +109,11 @@ describe Vanagon::Utilities::ExtraFilesSigner do
             commands = Vanagon::Utilities::ExtraFilesSigner.commands(project._project, mktemp, source_dir)
             expect(commands).to match(
               [
-                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc "echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file"),
-                %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group  $(tempdir)/dir/source_dir/test1/a.rb test@abc:/tmp/xyz),
+                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc \"echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file\"),
+                %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group $(tempdir)/dir/source_dir/test1/a.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group test@abc:/tmp/xyz/a.rb $(tempdir)/dir/source_dir/test1/a.rb),
-                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc "echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file"),
+                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc \"echo 'codesign /tmp/xyz/b.rb' > /tmp/xyz/sign_extra_file\"),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group $(tempdir)/dir/source_dir/test2/b.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group test@abc:/tmp/xyz/b.rb $(tempdir)/dir/source_dir/test2/b.rb)

--- a/spec/lib/vanagon/utilities/extra_files_signer_spec.rb
+++ b/spec/lib/vanagon/utilities/extra_files_signer_spec.rb
@@ -84,13 +84,13 @@ describe Vanagon::Utilities::ExtraFilesSigner do
             expect(commands).to match(
               [
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc "echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file"),
-                %q(scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $(tempdir)/dir/source_dir/test1/a.rb test@abc:/tmp/xyz),
+                %q(rsync -e /usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes $(tempdir)/dir/source_dir/test1/a.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
-                %q(scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc:/tmp/xyz/a.rb $(tempdir)/dir/source_dir/test1/a.rb),
+                %q(rsync -e /usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes test@abc:/tmp/xyz/a.rb $(tempdir)/dir/source_dir/test1/a.rb),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc "echo 'codesign /tmp/xyz/b.rb' > /tmp/xyz/sign_extra_file"),
-                %q(scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $(tempdir)/dir/source_dir/test2/b.rb test@abc:/tmp/xyz),
+                %q(rsync -e /usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes $(tempdir)/dir/source_dir/test2/b.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
-                %q(scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc:/tmp/xyz/b.rb $(tempdir)/dir/source_dir/test2/b.rb)
+                %q(rsync -e /usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes test@abc:/tmp/xyz/b.rb $(tempdir)/dir/source_dir/test2/b.rb)
               ]
             )
           end
@@ -110,13 +110,13 @@ describe Vanagon::Utilities::ExtraFilesSigner do
             expect(commands).to match(
               [
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc "echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file"),
-                %q(scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $(tempdir)/dir/source_dir/test1/a.rb test@abc:/tmp/xyz),
+                %q(rsync -e /usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no --verbose --recursive --hard-links --links --no-perms --no-owner --no-group $(tempdir)/dir/source_dir/test1/a.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
-                %q(scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc:/tmp/xyz/a.rb $(tempdir)/dir/source_dir/test1/a.rb),
+                %q(rsync -e /usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no --verbose --recursive --hard-links --links --no-perms --no-owner --no-group test@abc:/tmp/xyz/a.rb $(tempdir)/dir/source_dir/test1/a.rb),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc "echo 'codesign /tmp/xyz/b.rb' > /tmp/xyz/sign_extra_file"),
-                %q(scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $(tempdir)/dir/source_dir/test2/b.rb test@abc:/tmp/xyz),
+                %q(rsync -e /usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no --verbose --recursive --hard-links --links --no-perms --no-owner --no-group $(tempdir)/dir/source_dir/test2/b.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
-                %q(scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc:/tmp/xyz/b.rb $(tempdir)/dir/source_dir/test2/b.rb)
+                %q(rsync -e /usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no --verbose --recursive --hard-links --links --no-perms --no-owner --no-group test@abc:/tmp/xyz/b.rb $(tempdir)/dir/source_dir/test2/b.rb)
               ]
             )
           end

--- a/spec/lib/vanagon/utilities/extra_files_signer_spec.rb
+++ b/spec/lib/vanagon/utilities/extra_files_signer_spec.rb
@@ -83,14 +83,14 @@ describe Vanagon::Utilities::ExtraFilesSigner do
             commands = Vanagon::Utilities::ExtraFilesSigner.commands(project._project, mktemp, source_dir)
             expect(commands).to match(
               [
-                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc "echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file"),
-                %q(rsync -e /usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes $(tempdir)/dir/source_dir/test1/a.rb test@abc:/tmp/xyz),
+                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc \"echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file\"),
+                %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes $(tempdir)/dir/source_dir/test1/a.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
-                %q(rsync -e /usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes test@abc:/tmp/xyz/a.rb $(tempdir)/dir/source_dir/test1/a.rb),
+                %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes test@abc:/tmp/xyz/a.rb $(tempdir)/dir/source_dir/test1/a.rb),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc "echo 'codesign /tmp/xyz/b.rb' > /tmp/xyz/sign_extra_file"),
-                %q(rsync -e /usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes $(tempdir)/dir/source_dir/test2/b.rb test@abc:/tmp/xyz),
+                %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes $(tempdir)/dir/source_dir/test2/b.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
-                %q(rsync -e /usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes test@abc:/tmp/xyz/b.rb $(tempdir)/dir/source_dir/test2/b.rb)
+                %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes test@abc:/tmp/xyz/b.rb $(tempdir)/dir/source_dir/test2/b.rb)
               ]
             )
           end
@@ -110,13 +110,13 @@ describe Vanagon::Utilities::ExtraFilesSigner do
             expect(commands).to match(
               [
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc "echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file"),
-                %q(rsync -e /usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no --verbose --recursive --hard-links --links --no-perms --no-owner --no-group $(tempdir)/dir/source_dir/test1/a.rb test@abc:/tmp/xyz),
+                %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group $(tempdir)/dir/source_dir/test1/a.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
-                %q(rsync -e /usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no --verbose --recursive --hard-links --links --no-perms --no-owner --no-group test@abc:/tmp/xyz/a.rb $(tempdir)/dir/source_dir/test1/a.rb),
+                %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group test@abc:/tmp/xyz/a.rb $(tempdir)/dir/source_dir/test1/a.rb),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc "echo 'codesign /tmp/xyz/b.rb' > /tmp/xyz/sign_extra_file"),
-                %q(rsync -e /usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no --verbose --recursive --hard-links --links --no-perms --no-owner --no-group $(tempdir)/dir/source_dir/test2/b.rb test@abc:/tmp/xyz),
+                %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group $(tempdir)/dir/source_dir/test2/b.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
-                %q(rsync -e /usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no --verbose --recursive --hard-links --links --no-perms --no-owner --no-group test@abc:/tmp/xyz/b.rb $(tempdir)/dir/source_dir/test2/b.rb)
+                %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group test@abc:/tmp/xyz/b.rb $(tempdir)/dir/source_dir/test2/b.rb)
               ]
             )
           end

--- a/spec/lib/vanagon/utilities/extra_files_signer_spec.rb
+++ b/spec/lib/vanagon/utilities/extra_files_signer_spec.rb
@@ -83,11 +83,11 @@ describe Vanagon::Utilities::ExtraFilesSigner do
             commands = Vanagon::Utilities::ExtraFilesSigner.commands(project._project, mktemp, source_dir)
             expect(commands).to match(
               [
-                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc \"echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file\"),
+                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc "echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file"),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes $(tempdir)/dir/source_dir/test1/a.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes test@abc:/tmp/xyz/a.rb $(tempdir)/dir/source_dir/test1/a.rb),
-                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc \"echo 'codesign /tmp/xyz/b.rb' > /tmp/xyz/sign_extra_file\"),
+                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc "echo 'codesign /tmp/xyz/b.rb' > /tmp/xyz/sign_extra_file"),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes $(tempdir)/dir/source_dir/test2/b.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes test@abc:/tmp/xyz/b.rb $(tempdir)/dir/source_dir/test2/b.rb)
@@ -109,11 +109,11 @@ describe Vanagon::Utilities::ExtraFilesSigner do
             commands = Vanagon::Utilities::ExtraFilesSigner.commands(project._project, mktemp, source_dir)
             expect(commands).to match(
               [
-                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc \"echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file\"),
+                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc "echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file"),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group $(tempdir)/dir/source_dir/test1/a.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group test@abc:/tmp/xyz/a.rb $(tempdir)/dir/source_dir/test1/a.rb),
-                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc \"echo 'codesign /tmp/xyz/b.rb' > /tmp/xyz/sign_extra_file\"),
+                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc "echo 'codesign /tmp/xyz/b.rb' > /tmp/xyz/sign_extra_file"),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group $(tempdir)/dir/source_dir/test2/b.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group test@abc:/tmp/xyz/b.rb $(tempdir)/dir/source_dir/test2/b.rb)

--- a/spec/lib/vanagon/utilities/extra_files_signer_spec.rb
+++ b/spec/lib/vanagon/utilities/extra_files_signer_spec.rb
@@ -83,11 +83,11 @@ describe Vanagon::Utilities::ExtraFilesSigner do
             commands = Vanagon::Utilities::ExtraFilesSigner.commands(project._project, mktemp, source_dir)
             expect(commands).to match(
               [
-                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc \"echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file\"),
+                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc "echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file"),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes $(tempdir)/dir/source_dir/test1/a.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes test@abc:/tmp/xyz/a.rb $(tempdir)/dir/source_dir/test1/a.rb),
-                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc \"echo 'codesign /tmp/xyz/b.rb' > /tmp/xyz/sign_extra_file\"),
+                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc "echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file"),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes $(tempdir)/dir/source_dir/test2/b.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group --extended-attributes test@abc:/tmp/xyz/b.rb $(tempdir)/dir/source_dir/test2/b.rb)
@@ -109,11 +109,11 @@ describe Vanagon::Utilities::ExtraFilesSigner do
             commands = Vanagon::Utilities::ExtraFilesSigner.commands(project._project, mktemp, source_dir)
             expect(commands).to match(
               [
-                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc \"echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file\"),
+                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc "echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file"),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group  $(tempdir)/dir/source_dir/test1/a.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group test@abc:/tmp/xyz/a.rb $(tempdir)/dir/source_dir/test1/a.rb),
-                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc \"echo 'codesign /tmp/xyz/b.rb' > /tmp/xyz/sign_extra_file\"),
+                %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc "echo 'codesign /tmp/xyz/a.rb' > /tmp/xyz/sign_extra_file"),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group $(tempdir)/dir/source_dir/test2/b.rb test@abc:/tmp/xyz),
                 %q(/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no test@abc /bin/bash /tmp/xyz/sign_extra_file),
                 %q(rsync -e '/usr/bin/ssh -p 22  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --verbose --recursive --hard-links --links --no-perms --no-owner --no-group test@abc:/tmp/xyz/b.rb $(tempdir)/dir/source_dir/test2/b.rb)


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.