### PR TITLE
(maint) osx-10.15 installs Homebrew via the bash method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 - (VANAGON-197) Remove support for Debian 9 (x86 and x86-64)
 
 ### Changed
+- (maint) osx-10-15.x86-64 installs homebrew via bash rather then ruby
 
 ## [0.30.0] - release 2022-08-18
 ### Changed

--- a/lib/vanagon/platform/defaults/osx-10.15-x86_64.rb
+++ b/lib/vanagon/platform/defaults/osx-10.15-x86_64.rb
@@ -15,7 +15,7 @@ platform "osx-10.15-x86_64" do |plat|
   plat.provision_with "echo 'test ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/username"
   plat.provision_with "mkdir -p /etc/homebrew"
   plat.provision_with "cd /etc/homebrew"
-  plat.provision_with %Q(su test -c 'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"')
+  plat.provision_with %Q(su test -c 'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"')
   plat.provision_with "sudo chown -R test:admin /Users/test/"
   plat.vmpooler_template "osx-1015-x86_64"
 end


### PR DESCRIPTION
Homebrew has removed the ability to be installed via ruby, so this PR changes to the bash method the other newer versions of MacOS use.
