### PR TITLE
(maint) update deprecated Bundler call

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,9 +10,9 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: '2.7'
     - name: Build and test with Rake
       run: |
         gem install bundler

--- a/.github/workflows/ruby3.yml
+++ b/.github/workflows/ruby3.yml
@@ -10,9 +10,9 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Set up Ruby 3.0
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.0.x
+        ruby-version: '3.0'
     - name: Build and test with Rake
       run: |
         gem install bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ### Changed
 - (RE-15209) Exempt github URLs from being checked as valid git repositories in order to avoid
   rate-limiting from excessive traffic.
+- (maint) use `Bundler.with_unbundled_env` instead of `with_clean_env`. The latter usage is
+  deprecated.
 
 ### Fixed
 - `only-build` option is now converted to an array so it can be used.

--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -279,7 +279,7 @@ class Vanagon
     end
 
     def clean_environment(&block)
-      return Bundler.with_clean_env { yield } if defined?(Bundler)
+      return Bundler.with_unbundled_env { yield } if defined?(Bundler)
       yield
     end
     private :clean_environment


### PR DESCRIPTION
It's now `with_unbundled_env` rather than `with_clean_env`


Please add all notable changes to the "Unreleased" section of the CHANGELOG.