### PR TITLE
(PA-4838) Update platform defaults for RHEL 8 ppc64le, RHEL 7 & 8 FIPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+- (PA-4838) Update platform defaults for RHEL 8 ppc64le, RHEL 7 & 8 FIPS (x86-64)
+
 ## [0.32.0] - release 2023-01-11
 ### Changed
 - (RE-15209) Exempt github URLs from being checked as valid git repositories in order to avoid

--- a/lib/vanagon/platform/defaults/el-8-ppc64le.rb
+++ b/lib/vanagon/platform/defaults/el-8-ppc64le.rb
@@ -1,0 +1,29 @@
+platform 'el-8-ppc64le' do |plat|
+  plat.servicedir '/usr/lib/systemd/system'
+  plat.defaultdir '/etc/sysconfig'
+  plat.servicetype 'systemd'
+
+  # Workaround for an issue with RedHat subscription metadata, see ITSYS-2543
+  plat.provision_with('subscription-manager repos --disable rhel-8-for-ppc64le-baseos-rpms && subscription-manager repos --enable rhel-8-for-ppc64le-baseos-rpms')
+
+  packages = %w(
+    autoconf
+    automake
+    cmake
+    gcc-c++
+    java-1.8.0-openjdk-devel
+    libarchive
+    libselinux-devel
+    make
+    patch
+    perl-Getopt-Long
+    readline-devel
+    swig
+    systemtap-sdt-devel
+    zlib-devel
+  )
+
+  plat.provision_with("dnf install -y --allowerasing  #{packages.join(' ')}")
+  plat.install_build_dependencies_with 'dnf install -y --allowerasing'
+  plat.vmpooler_template 'redhat-8-power8'
+end

--- a/lib/vanagon/platform/defaults/redhatfips-7-x86_64.rb
+++ b/lib/vanagon/platform/defaults/redhatfips-7-x86_64.rb
@@ -4,7 +4,18 @@ platform "redhatfips-7-x86_64" do |plat|
   plat.servicetype "systemd"
 
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-el-7.noarch.rpm"
-  packages = %w(autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign)
+  packages = %w(
+    autoconf
+    automake
+    createrepo
+    gcc
+    make
+    rpmdevtools
+    rpm-libs
+    rpm-sign
+    rsync
+    yum-utils
+  )
   plat.provision_with "yum install --assumeyes #{packages.join(' ')}"
   plat.install_build_dependencies_with "yum install --assumeyes"
   plat.vmpooler_template "redhat-fips-7-x86_64"

--- a/lib/vanagon/platform/defaults/redhatfips-7-x86_64.rb
+++ b/lib/vanagon/platform/defaults/redhatfips-7-x86_64.rb
@@ -9,12 +9,22 @@ platform "redhatfips-7-x86_64" do |plat|
     automake
     createrepo
     gcc
+    java-1.8.0-openjdk-devel
+    libsepol
+    libsepol-devel
+    libselinux-devel
     make
+    openssl-devel
+    pkgconfig
+    readline-devel
     rpmdevtools
+    rpm-build
     rpm-libs
     rpm-sign
     rsync
+    swig
     yum-utils
+    zlib-devel
   )
   plat.provision_with "yum install --assumeyes #{packages.join(' ')}"
   plat.install_build_dependencies_with "yum install --assumeyes"

--- a/lib/vanagon/platform/defaults/redhatfips-8-x86_64.rb
+++ b/lib/vanagon/platform/defaults/redhatfips-8-x86_64.rb
@@ -4,6 +4,8 @@ platform "redhatfips-8-x86_64" do |plat|
   plat.servicetype "systemd"
 
   packages = %w(
+    autoconf
+    automake
     cmake
     gcc-c++
     java-1.8.0-openjdk-devel
@@ -13,8 +15,8 @@ platform "redhatfips-8-x86_64" do |plat|
     openssl-devel
     pkgconfig
     readline-devel
-    rpm-build
     rpmdevtools
+    rpm-build
     rsync
     swig
     systemtap-sdt-devel


### PR DESCRIPTION
I was able to build puppet-runtime packages containing Ruby 3.2 on these platforms:

- [x] el-8-ppc64le
- [x] redhatfips-7-x86_64
- [x] redhatfips-8-x86_64