### PR TITLE
(PA-4841) Combine Ubuntu 18.04 aarch64 packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+- (PA-4841) Update platform default for Ubuntu 18.04 aarch64/ARM64
+
 ## [0.33.0] - release 2023-01-13
 
 ### Changed

--- a/lib/vanagon/platform/defaults/ubuntu-18.04-aarch64.rb
+++ b/lib/vanagon/platform/defaults/ubuntu-18.04-aarch64.rb
@@ -4,7 +4,24 @@ platform "ubuntu-18.04-aarch64" do |plat|
   plat.servicetype "systemd"
   plat.codename "bionic"
 
-  packages = %w(build-essential devscripts make quilt pkg-config debhelper rsync fakeroot cmake)
+  packages = %w(
+    autoconf
+    build-essential
+    cmake
+    debhelper
+    devscripts
+    fakeroot
+    libbz2-dev
+    libreadline-dev
+    libselinux1-dev
+    openjdk-8-jre-headless
+    pkg-config
+    quilt
+    rsync
+    swig
+    systemtap-sdt-dev
+    zlib1g-dev
+  )
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1804-arm64"


### PR DESCRIPTION
This commit merges the packages formerly from the Ubuntu 18.04 aarch64/ARM64 platform definition in puppet-runtime with the Vanagon defaults and adds autoconf to enable building Ruby 3.2.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.