### PR TITLE
(VANAGON-211) Run cygpath before find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+- (VANAGON-221) Speed up file listings on Windows
+
 ## [0.34.0] - release 2023-01-16
 
 ### Changed

--- a/resources/Makefile.erb
+++ b/resources/Makefile.erb
@@ -15,15 +15,19 @@ all: file-list-before-build <%= package_name %>
 file-list-before-build:
 <%- if dirnames.empty? -%>
 	touch file-list-before-build
+<%- elsif @platform.is_windows? -%>
+	(<%= @platform.find %> -H "<%= dirnames.map do |f| "$(shell cygpath -ml '#{f}')" end.join('" "') %>" 2>/dev/null || <%= @platform.find %> "<%= dirnames.map do |f| "$(shell cygpath -ml '#{f}')" end.join('" "') %>" 2>/dev/null) | <%= @platform.sort %> | uniq > file-list-before-build
 <%- else -%>
-	(<%= @platform.find %> -H "<%= dirnames.join('" "') %>" 2>/dev/null || <%= @platform.find %> "<%= dirnames.join('" "') %>" 2>/dev/null) | <%= "xargs -I[] cygpath --mixed --long-name --absolute [] |" if @platform.is_windows? %> <%= @platform.sort %> | uniq > file-list-before-build
+	(<%= @platform.find %> -H "<%= dirnames.join('" "') %>" 2>/dev/null || <%= @platform.find %> "<%= dirnames.join('" "') %>" 2>/dev/null) | <%= @platform.sort %> | uniq > file-list-before-build
 <%- end -%>
 
 file-list-after-build: <%= @components.map {|comp| comp.name }.join(" ") %>
 <%- if dirnames.empty? -%>
 	touch file-list-after-build
+<%- elsif @platform.is_windows? -%>
+	(<%= @platform.find %> -H "<%= dirnames.map do |f| "$(shell cygpath -ml '#{f}')" end.join('" "') %>" 2>/dev/null || <%= @platform.find %> "<%= dirnames.map do |f| "$(shell cygpath -ml '#{f}')" end.join('" "') %>" 2>/dev/null) | <%= @platform.sort %> | uniq > file-list-after-build
 <%- else -%>
-	(<%= @platform.find %> -H "<%= dirnames.join('" "') %>" 2>/dev/null || <%= @platform.find %> "<%= dirnames.join('" "') %>" 2>/dev/null) | <%= "xargs -I[] cygpath --mixed --long-name --absolute [] |" if @platform.is_windows? %> <%= @platform.sort %> | uniq > file-list-after-build
+	(<%= @platform.find %> -H "<%= dirnames.join('" "') %>" 2>/dev/null || <%= @platform.find %> "<%= dirnames.join('" "') %>" 2>/dev/null) | <%= @platform.sort %> | uniq > file-list-after-build
 <%- end -%>
 
 <%= @name %>-<%= @version %>.tar.gz: file-list <%= @cleanup ? 'cleanup-components' : '' %>


### PR DESCRIPTION
Cygwin supports four different forms of Windows paths:

* short: C:/PROGRA\~1 or C:\\PROGRA~1
* windows: "C:\\Program Files"
* unix: /cygdrive/c/Program\ Files
* mixed: "C:/Program Files"

Previously, we ran `find` across a set of root paths and then converted each file using `cygpath` to its "mixed" form. This is surprising slow on Windows, taking 10 minutes.

This commit switches the order so that we normalize the root paths first and then run `find`. The `find` command preserves the "mixed" form, so it doesn't need to be normalized again. This change reduces the time to generate the list from 10 minutes to 2-3 seconds:

Before https://jenkins-platform.delivery.puppetlabs.net/view/puppet-runtime/view/agent-runtime-7.x/job/platform_agent-runtime_runtime-vanagon-packaging_7.x/BUILD_TARGET=windows-2012r2-x64,SLAVE_LABEL=k8s-worker/42/console

```
16:42:41 (/usr/bin/find -H "C:/ProgramFiles64Folder/PuppetLabs/Puppet" "C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet" "C:/CommonAppDataFolder/PuppetLabs" "C:/ProgramFiles64Folder/PuppetLabs/Puppet/bin" "C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet/bin" "C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet/lib/ruby/2.7.0/rubygems/defaults" "C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet/lib/ruby/2.7.0/rubygems/ssl_certs/puppetlabs.net" 2>/dev/null || /usr/bin/find "C:/ProgramFiles64Folder/PuppetLabs/Puppet" "C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet" "C:/CommonAppDataFolder/PuppetLabs" "C:/ProgramFiles64Folder/PuppetLabs/Puppet/bin" "C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet/bin" "C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet/lib/ruby/2.7.0/rubygems/defaults" "C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet/lib/ruby/2.7.0/rubygems/ssl_certs/puppetlabs.net" 2>/dev/null) | xargs -I[] cygpath --mixed --long-name --absolute [] | /usr/bin/sort | uniq > file-list-after-build
16:51:10 touch agent-runtime-7.x-project
```

After https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1930/BUILD_TARGET=windows-2012r2-x64,SLAVE_LABEL=k8s-worker/console

```
15:43:20 (/usr/bin/find -H "C:/ProgramFiles64Folder/PuppetLabs/Puppet" "C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet" "C:/CommonAppDataFolder/PuppetLabs" "C:/ProgramFiles64Folder/PuppetLabs/Puppet/bin" "C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet/bin" "C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet/lib/ruby/3.2.0/rubygems/defaults" "C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet/lib/ruby/3.2.0/rubygems/ssl_certs/puppetlabs.net" 2>/dev/null || /usr/bin/find "C:/ProgramFiles64Folder/PuppetLabs/Puppet" "C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet" "C:/CommonAppDataFolder/PuppetLabs" "C:/ProgramFiles64Folder/PuppetLabs/Puppet/bin" "C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet/bin" "C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet/lib/ruby/3.2.0/rubygems/defaults" "C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet/lib/ruby/3.2.0/rubygems/ssl_certs/puppetlabs.net" 2>/dev/null) | /usr/bin/sort | uniq > file-list-after-build
15:43:23 touch agent-runtime-main-project
```

Note, some of the roots are prefixes of other roots, so we're finding the same set of files multiple times, for example:

    "C:/ProgramFiles64Folder/PuppetLabs/Puppet"
    "C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet"

This commit doesn't change that behavior.

Also `find` is executed twice, once not following symlinks (-H) and again following symlinks (default). This commit also doesn't change that behavior, since it's possible to create symlinks on Windows.

- [x] windows x86 https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1930/BUILD_TARGET=windows-2012r2-x86,SLAVE_LABEL=k8s-worker/
- [x] windows x64 https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1930/BUILD_TARGET=windows-2012r2-x64,SLAVE_LABEL=k8s-worker/
- [x] redhat 7 https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1930/BUILD_TARGET=el-7-x86_64,SLAVE_LABEL=k8s-worker/ 