### PR TITLE
(VANAGON-214) Create `test` home directory before installing brew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 
-- (VANAGON-221) Speed up file listings on Windows
+- (VANAGON-211) Speed up file listings on Windows
+- (VANAGON-214) Create home directory on macOS before installing brew, add
+  macOS 11 & 12 ARM definitions, and opt-out from homebrew analytics.
 
 ## [0.34.0] - release 2023-01-16
 

--- a/lib/vanagon/platform/defaults/osx-10.15-x86_64.rb
+++ b/lib/vanagon/platform/defaults/osx-10.15-x86_64.rb
@@ -5,6 +5,8 @@ platform "osx-10.15-x86_64" do |plat|
 
   plat.provision_with "export HOMEBREW_NO_EMOJI=true"
   plat.provision_with "export HOMEBREW_VERBOSE=true"
+  plat.provision_with "export HOMEBREW_NO_ANALYTICS=1"
+
   plat.provision_with "sudo dscl . -create /Users/test"
   plat.provision_with "sudo dscl . -create /Users/test UserShell /bin/bash"
   plat.provision_with "sudo dscl . -create /Users/test UniqueID 1001"

--- a/lib/vanagon/platform/defaults/osx-10.15-x86_64.rb
+++ b/lib/vanagon/platform/defaults/osx-10.15-x86_64.rb
@@ -15,7 +15,7 @@ platform "osx-10.15-x86_64" do |plat|
   plat.provision_with "echo 'test ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/username"
   plat.provision_with "mkdir -p /etc/homebrew"
   plat.provision_with "cd /etc/homebrew"
+  plat.provision_with "createhomedir -c -u test"
   plat.provision_with %Q(su test -c 'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"')
-  plat.provision_with "sudo chown -R test:admin /Users/test/"
   plat.vmpooler_template "osx-1015-x86_64"
 end

--- a/lib/vanagon/platform/defaults/osx-11-arm64.rb
+++ b/lib/vanagon/platform/defaults/osx-11-arm64.rb
@@ -2,8 +2,11 @@ platform "osx-11-arm64" do |plat|
   plat.servicetype "launchd"
   plat.servicedir "/Library/LaunchDaemons"
   plat.codename "bigsur"
+
   plat.provision_with "export HOMEBREW_NO_EMOJI=true"
   plat.provision_with "export HOMEBREW_VERBOSE=true"
+  plat.provision_with "export HOMEBREW_NO_ANALYTICS=1"
+
   plat.provision_with "sudo dscl . -create /Users/test"
   plat.provision_with "sudo dscl . -create /Users/test UserShell /bin/bash"
   plat.provision_with "sudo dscl . -create /Users/test UniqueID 1001"

--- a/lib/vanagon/platform/defaults/osx-11-arm64.rb
+++ b/lib/vanagon/platform/defaults/osx-11-arm64.rb
@@ -1,0 +1,21 @@
+platform "osx-11-arm64" do |plat|
+  plat.servicetype "launchd"
+  plat.servicedir "/Library/LaunchDaemons"
+  plat.codename "bigsur"
+  plat.provision_with "export HOMEBREW_NO_EMOJI=true"
+  plat.provision_with "export HOMEBREW_VERBOSE=true"
+  plat.provision_with "sudo dscl . -create /Users/test"
+  plat.provision_with "sudo dscl . -create /Users/test UserShell /bin/bash"
+  plat.provision_with "sudo dscl . -create /Users/test UniqueID 1001"
+  plat.provision_with "sudo dscl . -create /Users/test PrimaryGroupID 1000"
+  plat.provision_with "sudo dscl . -create /Users/test NFSHomeDirectory /Users/test"
+  plat.provision_with "sudo dscl . -passwd /Users/test password"
+  plat.provision_with "sudo dscl . -merge /Groups/admin GroupMembership test"
+  plat.provision_with "echo 'test ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/username"
+  plat.provision_with "mkdir -p /etc/homebrew"
+  plat.provision_with "cd /etc/homebrew"
+  plat.provision_with %(su test -c 'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"')
+  plat.provision_with "sudo chown -R test:admin /Users/test/"
+  plat.vmpooler_template "macos-112-x86_64"
+  plat.cross_compiled true
+end

--- a/lib/vanagon/platform/defaults/osx-11-arm64.rb
+++ b/lib/vanagon/platform/defaults/osx-11-arm64.rb
@@ -14,8 +14,8 @@ platform "osx-11-arm64" do |plat|
   plat.provision_with "echo 'test ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/username"
   plat.provision_with "mkdir -p /etc/homebrew"
   plat.provision_with "cd /etc/homebrew"
+  plat.provision_with "createhomedir -c -u test"
   plat.provision_with %(su test -c 'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"')
-  plat.provision_with "sudo chown -R test:admin /Users/test/"
   plat.vmpooler_template "macos-112-x86_64"
   plat.cross_compiled true
 end

--- a/lib/vanagon/platform/defaults/osx-11-x86_64.rb
+++ b/lib/vanagon/platform/defaults/osx-11-x86_64.rb
@@ -14,7 +14,7 @@ platform "osx-11-x86_64" do |plat|
   plat.provision_with "echo 'test ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/username"
   plat.provision_with "mkdir -p /etc/homebrew"
   plat.provision_with "cd /etc/homebrew"
+  plat.provision_with "createhomedir -c -u test"
   plat.provision_with %Q(su test -c 'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"')
-  plat.provision_with "sudo chown -R test:admin /Users/test/"
   plat.vmpooler_template "macos-112-x86_64"
 end

--- a/lib/vanagon/platform/defaults/osx-11-x86_64.rb
+++ b/lib/vanagon/platform/defaults/osx-11-x86_64.rb
@@ -2,8 +2,11 @@ platform "osx-11-x86_64" do |plat|
   plat.servicetype "launchd"
   plat.servicedir "/Library/LaunchDaemons"
   plat.codename "bigsur"
+
   plat.provision_with "export HOMEBREW_NO_EMOJI=true"
   plat.provision_with "export HOMEBREW_VERBOSE=true"
+  plat.provision_with "export HOMEBREW_NO_ANALYTICS=1"
+
   plat.provision_with "sudo dscl . -create /Users/test"
   plat.provision_with "sudo dscl . -create /Users/test UserShell /bin/bash"
   plat.provision_with "sudo dscl . -create /Users/test UniqueID 1001"

--- a/lib/vanagon/platform/defaults/osx-12-arm64.rb
+++ b/lib/vanagon/platform/defaults/osx-12-arm64.rb
@@ -5,6 +5,7 @@ platform 'osx-12-arm64' do |plat|
 
     plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
     plat.provision_with 'export HOMEBREW_VERBOSE=true'
+    plat.provision_with "export HOMEBREW_NO_ANALYTICS=1"
 
     plat.provision_with 'sudo dscl . -create /Users/test'
     plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'

--- a/lib/vanagon/platform/defaults/osx-12-arm64.rb
+++ b/lib/vanagon/platform/defaults/osx-12-arm64.rb
@@ -16,8 +16,8 @@ platform 'osx-12-arm64' do |plat|
     plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
     plat.provision_with 'mkdir -p /etc/homebrew'
     plat.provision_with 'cd /etc/homebrew'
+    plat.provision_with 'createhomedir -c -u test'
     plat.provision_with 'su test -c \'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"\''
-    plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'
     plat.vmpooler_template 'macos-12-x86_64'
     plat.cross_compiled true
   end

--- a/lib/vanagon/platform/defaults/osx-12-arm64.rb
+++ b/lib/vanagon/platform/defaults/osx-12-arm64.rb
@@ -1,0 +1,23 @@
+platform 'osx-12-arm64' do |plat|
+    plat.servicetype 'launchd'
+    plat.servicedir '/Library/LaunchDaemons'
+    plat.codename 'monterey'
+
+    plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
+    plat.provision_with 'export HOMEBREW_VERBOSE=true'
+
+    plat.provision_with 'sudo dscl . -create /Users/test'
+    plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'
+    plat.provision_with 'sudo dscl . -create /Users/test UniqueID 1001'
+    plat.provision_with 'sudo dscl . -create /Users/test PrimaryGroupID 1000'
+    plat.provision_with 'sudo dscl . -create /Users/test NFSHomeDirectory /Users/test'
+    plat.provision_with 'sudo dscl . -passwd /Users/test password'
+    plat.provision_with 'sudo dscl . -merge /Groups/admin GroupMembership test'
+    plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
+    plat.provision_with 'mkdir -p /etc/homebrew'
+    plat.provision_with 'cd /etc/homebrew'
+    plat.provision_with 'su test -c \'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"\''
+    plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'
+    plat.vmpooler_template 'macos-12-x86_64'
+    plat.cross_compiled true
+  end

--- a/lib/vanagon/platform/defaults/osx-12-x86_64.rb
+++ b/lib/vanagon/platform/defaults/osx-12-x86_64.rb
@@ -14,7 +14,7 @@ platform "osx-12-x86_64" do |plat|
   plat.provision_with "echo 'test ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/username"
   plat.provision_with "mkdir -p /etc/homebrew"
   plat.provision_with "cd /etc/homebrew"
+  plat.provision_with "createhomedir -c -u test"
   plat.provision_with %Q(su test -c 'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"')
-  plat.provision_with "sudo chown -R test:admin /Users/test/"
   plat.vmpooler_template "macos-12-x86_64"
 end

--- a/lib/vanagon/platform/defaults/osx-12-x86_64.rb
+++ b/lib/vanagon/platform/defaults/osx-12-x86_64.rb
@@ -2,8 +2,11 @@ platform "osx-12-x86_64" do |plat|
   plat.servicetype "launchd"
   plat.servicedir "/Library/LaunchDaemons"
   plat.codename "monterey"
+
   plat.provision_with "export HOMEBREW_NO_EMOJI=true"
   plat.provision_with "export HOMEBREW_VERBOSE=true"
+  plat.provision_with "export HOMEBREW_NO_ANALYTICS=1"
+
   plat.provision_with "sudo dscl . -create /Users/test"
   plat.provision_with "sudo dscl . -create /Users/test UserShell /bin/bash"
   plat.provision_with "sudo dscl . -create /Users/test UniqueID 1001"


### PR DESCRIPTION
* Create `test` home directory before installing brew (since brew expects the home directory to be writable, especially `~/Library/Logs`)
* Opt out of homebrew analytics (from puppet-agent)
* Add platform definition for macOS 11 & 12 ARM64 (from puppet-agent)
* Fix incorrect changelog for VANAGON-211

- [x] [puppet-runtime (agent-runtime-main)](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1937/)
- [x] [puppet-runtime (agent-runtime-7.x)](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1935/)
- [x] [puppet-runtime (agent-runtime-6.x)](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1936/)
- [x] [pxp-agent-vanagon#7.x](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1934/)
- [x] [pxp-agent-vanagon#main](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1939/)
- [x] [puppet-agent#6.x](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1933/)
- [ ] puppet-agent#7.x
- [ ] puppet-agent#main

I'm going to skip the last two because I'm pretty sure they work and we'll need to merge up puppet-agent#6.x -> 7.x -> main

I also manually tested pdk-runtime and bolt-runtime with 10.15.