### PR TITLE
(PUP-11786) Ruby 3.1 compatibility updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ### Changed
 - (PUP-11786) Update fustigit gem to version 0.3.0.
+- (PUP-11786) Use keyword arguments in method calls.
 
 ## [0.35.1] - release 2023-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+- (PUP-11786) Update fustigit gem to version 0.3.0.
+
 ## [0.35.1] - release 2023-03-21
 
 ### Changed

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -857,7 +857,7 @@ class Vanagon
         if source_type == :http
           yaml_path = File.join(working_directory, source.file)
         end
-        @settings.merge!(YAML.safe_load(File.read(yaml_path), [Symbol]))
+        @settings.merge!(YAML.safe_load(File.read(yaml_path), permitted_classes: [Symbol]))
       end
     end
 

--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -291,7 +291,7 @@ class Vanagon
     # @return [String] the evaluated template
     def erb_string(erbfile, b = binding)
       template = File.read(erbfile)
-      message  = ERB.new(template, nil, "-")
+      message  = ERB.new(template, trim_mode: "-")
       message.result(b)
         .gsub(/[\n]+{3,}/, "\n\n")
         .squeeze("\s")

--- a/vanagon.gemspec
+++ b/vanagon.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('git', '~> 1.13.0')
   # Parse scp-style triplets like URIs; used for Git source handling.
   # - MIT licensed: https://rubygems.org/gems/fustigit
-  gem.add_runtime_dependency('fustigit', '~> 0.2.0')
+  gem.add_runtime_dependency('fustigit', '~> 0.3.0')
   # Handle locking hardware resources
   # - ASL v2 licensed: https://rubygems.org/gems/lock_manager
   gem.add_runtime_dependency('lock_manager', '>= 0')


### PR DESCRIPTION
This PR:

- Updates fusitgit to enable compatibility with newer version of the URI module included in Ruby >= 3.1.
- Updates method calls to explicitly use keyword arguments instead of implicitly assuming that the last positional argument is a keyword argument.

More details in the commit messages.