### PR TITLE
(VANAGON-227) Try to be smarter about identifying github repositories

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -443,6 +443,18 @@ RSpec/SubjectDeclaration:
 RSpec/VerifiedDoubleReference:
   Enabled: true
 
+Rspec/BeforeAfterAll:
+  Enabled: false
+
+Rspec/ExampleLength:
+  Enabled: false
+
+Rspec/HookArgument:
+  Enabled: false
+
+Rspec/MultipleMemoizedHelpers:
+  Enabled: false
+
 Security/CompoundHash:
   Enabled: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](https://semver.org).
 This changelog adheres to [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+### Fixed
+- (VANAGON-227) Be more discerning when declaring a URI starting with 'https://github.com/'
+  as a git repository for source purposes.
 
 ## [0.36.0] - release 2023-04-18
 ### Fixed

--- a/lib/vanagon/component/source.rb
+++ b/lib/vanagon/component/source.rb
@@ -68,7 +68,8 @@ class Vanagon
           timeout = 5
           if Vanagon::Component::Source::Git.valid_remote?(uri, timeout)
             if uri =~ /^http/
-              VanagonLogger.info "Passing git URLs as http(s) addresses is deprecated! Please prefix your source URL with `git:`"
+              VanagonLogger.warn "Using http(s) URIs for github is deprecated. " \
+                                 "Use `git:` URI scheme instead."
             end
             return :git
           end

--- a/lib/vanagon/component/source.rb
+++ b/lib/vanagon/component/source.rb
@@ -10,18 +10,18 @@ class Vanagon
       SUPPORTED_PROTOCOLS = %w[file http https git].freeze
 
       class << self
-        # Basic factory to hand back the correct {Vanagon::Component::Source} subtype to the component
+        # Factory to hand back the correct {Vanagon::Component::Source} subtype to the component
         #
-        # @param url [String] URI of the source file (includes git@... style links)
+        # @param uri_instance [#to_s] URI of the source file (includes git@... style links)
         # @param options [Hash] hash of the options needed for the subtype
         # @param workdir [String] working directory to fetch the source into
         # @return [Vanagon::Component::Source] the correct subtype for the given source
-        def source(uri, **options) # rubocop:disable Metrics/AbcSize
+        def source(uri_instance, **options) # rubocop:disable Metrics/AbcSize
           # Sometimes the uri comes in as a string, but sometimes it's already been
           # coerced into a URI object. The individual source providers will turn
           # the passed uri into a URI object if needed, but for this method we
           # want to work with the uri as a string.
-          uri = uri.to_s
+          uri = uri_instance.to_s
           if uri.start_with?('git')
             source_type = :git
             # when using an http(s) source for a git repo, you should prefix the

--- a/spec/lib/vanagon/component/source/git_spec.rb
+++ b/spec/lib/vanagon/component/source/git_spec.rb
@@ -1,7 +1,6 @@
 require 'vanagon/component/source/git'
 
 describe "Vanagon::Component::Source::Git" do
-  # before(:all) blocks are run once before all of the examples in a group
   before :all do
     @klass = Vanagon::Component::Source::Git
     # This repo will not be cloned over the network
@@ -12,106 +11,136 @@ describe "Vanagon::Component::Source::Git" do
     @workdir = nil
   end
 
-  # before(:each) blocks are run before each example
-  before :each do
-    allow(Vanagon::Component::Source::Git)
-      .to receive(:valid_remote?)
-            .and_return(true)
-
-    allow(File).to receive(:realpath).and_return(@workdir)
-  end
-
-  describe "#initialize" do
-    it "raises error on initialization with an invalid repo" do
-      # Ensure initializing a repo fails without calling over the network
-      allow(Vanagon::Component::Source::Git)
-        .to receive(:valid_remote?)
-              .and_return(false)
-
-      expect { @klass.new(@url, ref: @ref_tag, workdir: @workdir) }
-        .to raise_error(Vanagon::InvalidRepo)
+  context 'with a github https: URI' do
+    let(:github_archive_uri) do
+      'https://github.com/2ndQuadrant/pglogical/archive/a_file_name.tar.gz'
+    end
+    let(:github_tarball_uri) do
+      'https://github.com/Baeldung/kotlin-tutorials/tarball/main'
+    end
+    let(:github_zipball_uri) do
+      'https://github.com/Baeldung/kotlin-tutorials/zipball/master'
+    end
+    let(:github_repo_uri) do
+      'https://github.com/cameronmcnz/rock-paper-scissors'
+    end
+    let(:github_repo_dotgit_uri) do
+      'https://github.com/cameronmcnz/rock-paper-scissors.git'
     end
 
-    it "uses the realpath of the workdir if we're in a symlinked dir" do
-      expect(File).to receive(:realpath).and_return("/tmp/bar")
-      git_source = @klass.new(@local_url, ref: @ref_tag, workdir: "/tmp/foo")
-      expect(git_source.workdir)
-        .to eq('/tmp/bar')
+    it "flags github archive uris as not valid repos" do
+      expect(Vanagon::Component::Source::Git.valid_remote?(github_archive_uri)).to be false
     end
 
-    it "with no clone options should be empty" do
-      git_source = @klass.new(@local_url, ref: @ref_tag, workdir: "/tmp/foo")
-      expect(git_source.clone_options)
-          .to be {}
+    it "flags github tarball uris as not valid repos" do
+      expect(Vanagon::Component::Source::Git.valid_remote?(github_tarball_uri)).to be false
     end
 
-    it "add clone options depth and branch" do
-      expected_clone_options = {:branch => "bar", :depth => 50 }
-      git_source = @klass.new(@local_url, ref: @ref_tag, workdir: "/tmp/foo", :clone_options => expected_clone_options)
-      expect(git_source.clone_options)
-          .to  be(expected_clone_options)
+    it "flags git zipball uris as not valid repos" do
+      expect(Vanagon::Component::Source::Git.valid_remote?(github_zipball_uri)).to be false
+    end
+
+    it "identifies git generic uris as valid repos" do
+      expect(Vanagon::Component::Source::Git.valid_remote?(github_repo_uri)).to be true
+    end
+
+    it "identifies .git repo uris as valid repos" do
+      expect(Vanagon::Component::Source::Git.valid_remote?(github_repo_dotgit_uri)).to be true
     end
   end
 
-  describe "#clone" do
+  context 'with other non-github URIs' do
     before :each do
-      clone = double(Git::Base)
-      @file_path = "/tmp/foo"
-      allow(::Git).to receive(:clone).and_return(clone)
-      expect(File).to receive(:realpath).and_return(@file_path)
+      allow(Vanagon::Component::Source::Git).to receive(:valid_remote?).and_return(true)
+      allow(File).to receive(:realpath).and_return(@workdir)
     end
 
-    it "repository" do
-      git_source = @klass.new(@url, ref: @ref_tag, workdir: "/tmp/foo")
-      expect(::Git).to receive(:clone).with(git_source.url, git_source.dirname, path: @file_path)
-      git_source.clone
+    describe "#initialize" do
+      it "raises error on initialization with an invalid repo" do
+        # Ensure initializing a repo fails without calling over the network
+        allow(Vanagon::Component::Source::Git).to receive(:valid_remote?).and_return(false)
+
+        expect { @klass.new(@url, ref: @ref_tag, workdir: @workdir) }
+          .to raise_error(Vanagon::InvalidRepo)
+      end
+
+      it "uses the realpath of the workdir if we're in a symlinked dir" do
+        expect(File).to receive(:realpath).and_return("/tmp/bar")
+        git_source = @klass.new(@local_url, ref: @ref_tag, workdir: "/tmp/foo")
+        expect(git_source.workdir).to eq('/tmp/bar')
+      end
+
+      it "with no clone options should be empty" do
+        git_source = @klass.new(@local_url, ref: @ref_tag, workdir: "/tmp/foo")
+        expect(git_source.clone_options).to be {}
+      end
+
+      it "add clone options depth and branch" do
+        expected_clone_options = {branch: 'bar', depth: 50 }
+        git_source = @klass.new(@local_url, ref: @ref_tag,
+                                workdir: "/tmp/foo", clone_options: expected_clone_options)
+        expect(git_source.clone_options).to  be(expected_clone_options)
+      end
     end
 
-    it "a particular branch with a depth" do
-      expected_clone_options = {:branch => "foo", :depth => 50 }
-      git_source = @klass.new(@url, ref: @ref_tag, workdir: "/tmp/foo", :clone_options => expected_clone_options)
-      expect(::Git).to receive(:clone).with(git_source.url, git_source.dirname, path: @file_path, **expected_clone_options)
-      git_source.clone
+    describe "#clone" do
+      before :each do
+        clone = double(Git::Base)
+        @file_path = "/tmp/foo"
+        allow(Git).to receive(:clone).and_return(clone)
+        expect(File).to receive(:realpath).and_return(@file_path)
+      end
+
+      it "repository" do
+        git_source = @klass.new(@url, ref: @ref_tag, workdir: "/tmp/foo")
+        expect(Git).to receive(:clone).with(git_source.url, git_source.dirname, path: @file_path)
+        git_source.clone
+      end
+
+      it "a particular branch with a depth" do
+        expected_clone_options = {:branch => "foo", :depth => 50 }
+        git_source = @klass.new(@url, ref: @ref_tag, workdir: "/tmp/foo",
+                                clone_options: expected_clone_options)
+        expect(Git)
+          .to receive(:clone)
+          .with(git_source.url, git_source.dirname, path: @file_path, **expected_clone_options)
+        git_source.clone
+      end
+
+      it 'uses a custom dirname' do
+        git_source = @klass.new(@url, ref: @ref_tag, workdir: "/tmp/foo", dirname: 'facter-ng')
+        expect(Git).to receive(:clone).with(git_source.url, 'facter-ng', path: @file_path)
+        git_source.clone
+      end
     end
 
-    it 'uses a custom dirname' do
-      git_source = @klass.new(@url, ref: @ref_tag, workdir: "/tmp/foo", dirname: 'facter-ng')
-      expect(::Git).to receive(:clone).with(git_source.url, 'facter-ng', path: @file_path)
-      git_source.clone
-    end
-  end
+    describe "#dirname" do
+      it "returns the name of the repo" do
+        git_source = @klass.new(@local_url, ref: @ref_tag, workdir: @workdir)
+        expect(git_source.dirname).to eq('puppet-agent')
+      end
 
-  describe "#dirname" do
-    it "returns the name of the repo" do
-      git_source = @klass.new(@local_url, ref: @ref_tag, workdir: @workdir)
-      expect(git_source.dirname)
-        .to eq('puppet-agent')
-    end
+      it "returns the name of the repo and strips .git" do
+        git_source = @klass.new(@url, ref: @ref_tag, workdir: @workdir)
+        expect(git_source.dirname).to eq('facter')
+      end
 
-    it "returns the name of the repo and strips .git" do
-      git_source = @klass.new(@url, ref: @ref_tag, workdir: @workdir)
-      expect(git_source.dirname)
-        .to eq('facter')
+      it "returns @dirname if is set" do
+        git_source = @klass.new(@url, ref: @ref_tag, workdir: @workdir, dirname: 'facter-ng')
+        expect(git_source.dirname).to eq('facter-ng')
+      end
     end
 
-    it "returns @dirname if is set" do
-      git_source = @klass.new(@url, ref: @ref_tag, workdir: @workdir, dirname: 'facter-ng')
-      expect(git_source.dirname)
-          .to eq('facter-ng')
-    end
-  end
+    describe "#ref" do
+      it "returns a default value of HEAD when no explicit Git reference is provided" do
+        git_source = @klass.new(@url, workdir: @workdir)
+        expect(git_source.ref).to eq('HEAD')
+      end
 
-  describe "#ref" do
-    it "returns a default value of HEAD when no explicit Git reference is provided" do
-      git_source = @klass.new(@url, workdir: @workdir)
-      expect(git_source.ref)
-        .to eq('HEAD')
-    end
-
-    it "returns a default value of HEAD when Git reference is nil" do
-      git_source = @klass.new(@url, ref: nil, workdir: @workdir)
-      expect(git_source.ref)
-        .to eq('HEAD')
+      it "returns a default value of HEAD when Git reference is nil" do
+        git_source = @klass.new(@url, ref: nil, workdir: @workdir)
+        expect(git_source.ref).to eq('HEAD')
+      end
     end
   end
 end

--- a/spec/lib/vanagon/component/source_spec.rb
+++ b/spec/lib/vanagon/component/source_spec.rb
@@ -36,7 +36,7 @@ describe "Vanagon::Component::Source" do
         .to raise_error(URI::InvalidURIError)
     end
 
-    context "takes a Git repo" do
+    context "with a Git repo" do
       before do
         allow_any_instance_of(Vanagon::Component::Source::Git)
           .to receive(:valid_remote?)
@@ -64,12 +64,16 @@ describe "Vanagon::Component::Source" do
 
       it "returns a Git object for git:http:// repositories" do
         component_source = klass.source(git_prefixed_http, ref: ref, workdir: workdir)
-        expect(component_source.url.to_s).to eq 'http://github.com/abcd/things'
         expect(component_source.class).to eq Vanagon::Component::Source::Git
+      end
+
+      it "returns a Git url for git:http:// repositories" do
+        component_source = klass.source(git_prefixed_http, ref: ref, workdir: workdir)
+        expect(component_source.url.to_s).to eq 'http://github.com/abcd/things'
       end
     end
 
-    context "takes a HTTP/HTTPS file" do
+    context "with a HTTP/HTTPS file" do
       before do
         allow(Vanagon::Component::Source::Http)
           .to receive(:valid_url?)
@@ -96,7 +100,7 @@ describe "Vanagon::Component::Source" do
       end
     end
 
-    context "takes a local file" do
+    context "with a local file" do
       before do
         allow_any_instance_of(Vanagon::Component::Source::Local)
           .to receive(:valid_file?)
@@ -110,6 +114,79 @@ describe "Vanagon::Component::Source" do
       it "returns an object of the correct type for file:// URLS" do
         expect(klass.source(file_url, sum: sum, workdir: workdir).class)
           .to eq Vanagon::Component::Source::Local
+      end
+    end
+  end
+
+  describe "#determine_source_type" do
+    context 'with a github https: URI' do
+
+      let(:github_archive_uri) do
+        'https://github.com/2ndQuadrant/pglogical/archive/a_file_name.tar.gz'
+      end
+      let(:github_tarball_uri) do
+        'https://github.com/Baeldung/kotlin-tutorials/tarball/main'
+      end
+      let(:github_zipball_uri) do
+        'https://github.com/Baeldung/kotlin-tutorials/zipball/master'
+      end
+      let(:github_repo_uri) do
+        'https://github.com/cameronmcnz/rock-paper-scissors'
+      end
+      let(:github_repo_dotgit_uri) do
+        'https://github.com/cameronmcnz/rock-paper-scissors.git'
+      end
+
+      it "identifies github archive uris" do
+        stub_request(:head, github_archive_uri).with(
+          headers: {
+       	    'Accept' => '*/*',
+       	    'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+       	    'Host' => 'github.com',
+       	    'User-Agent' => 'Ruby'
+          }
+        ).to_return(status: 200, body: "", headers: {})
+
+        expect(Vanagon::Component::Source.determine_source_type(github_archive_uri))
+          .to eq(:http)
+      end
+
+      it "identifies github tarball uris" do
+        stub_request(:head, github_tarball_uri).with(
+          headers: {
+       	    'Accept' => '*/*',
+       	    'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+       	    'Host' => 'github.com',
+       	    'User-Agent' => 'Ruby'
+          }
+        ).to_return(status: 200, body: "", headers: {})
+
+        expect(Vanagon::Component::Source.determine_source_type(github_tarball_uri))
+          .to eq(:http)
+      end
+
+      it "identifies github zipball uris" do
+        stub_request(:head, github_zipball_uri).with(
+          headers: {
+       	    'Accept' => '*/*',
+       	    'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+       	    'Host' => 'github.com',
+       	    'User-Agent' => 'Ruby'
+          }
+        ).to_return(status: 200, body: "", headers: {})
+
+        expect(Vanagon::Component::Source.determine_source_type(github_zipball_uri))
+          .to eq(:http)
+      end
+
+      it "identifies github generic repo uris" do
+        expect(Vanagon::Component::Source.determine_source_type(github_repo_uri))
+          .to eq(:git)
+      end
+
+      it "identifies github .git repo uris" do
+        expect(Vanagon::Component::Source.determine_source_type(github_repo_dotgit_uri))
+          .to eq(:git)
       end
     end
   end

--- a/spec/lib/vanagon/component/source_spec.rb
+++ b/spec/lib/vanagon/component/source_spec.rb
@@ -141,7 +141,6 @@ describe "Vanagon::Component::Source" do
         stub_request(:head, github_archive_uri).with(
           headers: {
        	    'Accept' => '*/*',
-       	    'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
        	    'Host' => 'github.com',
        	    'User-Agent' => 'Ruby'
           }
@@ -155,7 +154,6 @@ describe "Vanagon::Component::Source" do
         stub_request(:head, github_tarball_uri).with(
           headers: {
        	    'Accept' => '*/*',
-       	    'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
        	    'Host' => 'github.com',
        	    'User-Agent' => 'Ruby'
           }
@@ -169,7 +167,6 @@ describe "Vanagon::Component::Source" do
         stub_request(:head, github_zipball_uri).with(
           headers: {
        	    'Accept' => '*/*',
-       	    'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
        	    'Host' => 'github.com',
        	    'User-Agent' => 'Ruby'
           }


### PR DESCRIPTION
A https://github.com URL prefix does not guarantee that the resolved URL is
an actual git repository. Many github URLs are download API calls (like
'archive', 'zipball', 'tarball'). Start recognizing them and make
allowances for future options.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.