### PR TITLE
(maint) do not print redundant headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org).
 This changelog adheres to [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+### Changed
+(maint) When using `vanagon list` with the --platforms or --projects flags do not print the  "-Platforms" or "-Projects" header.
 
 ## [0.36.0] - release 2023-04-18
 ### Fixed

--- a/lib/vanagon/cli/list.rb
+++ b/lib/vanagon/cli/list.rb
@@ -48,12 +48,12 @@ class Vanagon
         end
 
         if options[:projects]
-          puts "- Projects", output(project_list, options[:use_spaces])
+          puts output(project_list, options[:use_spaces])
           return
         end
 
         if options[:platforms]
-          puts "- Platforms", output(platform_list, options[:use_spaces])
+          puts output(platform_list, options[:use_spaces])
           return
         end
       end


### PR DESCRIPTION
With '--platforms' or '--projects' flag, don't print redundant
headers. This allows for easier scripting of the output.

Also, clean up CLI spec examples.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.