### PR TITLE
(maint) Use keyword arguments

### DIFF
--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -290,7 +290,7 @@ class Vanagon
     # @return [String] the evaluated template
     def erb_string(erbfile, b = binding)
       template = File.read(erbfile)
-      message  = ERB.new(template, nil, "-")
+      message  = ERB.new(template, trim_mode: "-")
       message.result(b)
         .gsub(/[\n]+{3,}/, "\n\n")
         .squeeze("\s")


### PR DESCRIPTION
In Ruby >= 3.0, keyword arguments are separated from positional arguments:

https://bugs.ruby-lang.org/issues/14183

This commit updates method calls that passes a keyword argument as the last argument to separate out those keyword arguments.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.