### PR TITLE
(maint) Add gpg key to provisioning step for default ubuntu-22.04-amd…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ This changelog adheres to [Keep a CHANGELOG](https://keepachangelog.com).
 - (PA-5327) Remove OSX 10.15 (x86_64)
 - (PA-5331) Red Hat 7 (aarch64)
 
+### Changed
+- (maint) Add gpg key to provisioning step for default ubuntu-22.04-amd64 config.
+
 
 ## [0.36.0] - release 2023-04-18
 ### Fixed

--- a/lib/vanagon/platform/defaults/ubuntu-22.04-amd64.rb
+++ b/lib/vanagon/platform/defaults/ubuntu-22.04-amd64.rb
@@ -6,6 +6,7 @@ platform "ubuntu-22.04-amd64" do |plat|
 
   packages = %w(build-essential devscripts make quilt pkg-config debhelper rsync fakeroot cmake)
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
+  plat.provision_with "curl https://apt.puppet.com/DEB-GPG-KEY-puppet-20250406 | apt-key add -"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-2204-x86_64"
 end


### PR DESCRIPTION
…64 config.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.