### PR TITLE
(maint) Update CHANGELOG for 0.37.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ This project adheres to [Semantic Versioning](https://semver.org).
 This changelog adheres to [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+
+## [0.37.1] - release 2023-06-21
 ### Changed
 - (maint) Add TLS 1.2 to the platform add command for Windows
+- (maint) Use keyword arguments
 
 ## [0.37.0] - release 2023-06-13
 ### Fixed
@@ -1119,7 +1122,8 @@ on Debian < 8 and needs more work and testing.
 
 ## Versions <= 0.3.9 do not have a change log entry
 
-[Unreleased]: https://github.com/puppetlabs/vanagon/compare/0.37.0...HEAD
+[Unreleased]: https://github.com/puppetlabs/vanagon/compare/0.37.1...HEAD
+[0.37.1]: https://github.com/puppetlabs/vanagon/compare/0.37.0...0.37.1
 [0.37.0]: https://github.com/puppetlabs/vanagon/compare/0.36.0...0.37.0
 [0.36.0]: https://github.com/puppetlabs/vanagon/compare/0.35.1...0.36.0
 [0.35.1]: https://github.com/puppetlabs/vanagon/compare/0.35.0...0.35.1


### PR DESCRIPTION
A vanagon release needs to be cut with the commit in PR #805 so Windows vanagon builds stop failing due to TLS.