### PR TITLE
(PA-5701) Allow platform's name to be overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org).
 This changelog adheres to [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+### Added
+- (PA-5701) Allow platform's name to be overridden
 
 ## [0.38.0] - release 2023-07-05
 

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -18,7 +18,7 @@ class Vanagon
     class DSL
       # Constructor for the DSL object
       #
-      # @param name [String] name of the platform
+      # @param platform_name [String] name of the platform
       # @return [Vanagon::Platform::DSL] A DSL object to describe the {Vanagon::Platform}
       def initialize(platform_name)
         @name = platform_name
@@ -26,9 +26,15 @@ class Vanagon
 
       # Primary way of interacting with the DSL. Also a simple factory to get the right platform object.
       #
-      # @param name [String] name of the platform
+      # @param platform_name [String] name of the platform
+      # @param override_name [Boolean] whether the specified `platform_name` should override the basename
       # @param block [Proc] DSL definition of the platform to call
-      def platform(platform_name, &block)
+      def platform(platform_name, override_name: false, &block)
+        # By default, the Vanagon::Platform's name/version/arch will be based on
+        # the filename of the platform definition. But if override_name is true,
+        # then use the `platform_name` passed into this method instead.
+        @name = platform_name if override_name
+
         @platform = case platform_name
                     when /^aix-/
                       Vanagon::Platform::RPM::AIX.new(@name)


### PR DESCRIPTION
The puppet-runtime repo needs to build agent-runtime-7.x and agent-runtime-main projects using different solaris 11 sparc platform definitions, one is cross-compiled, the other is not. It's not possible to have conditional logic in the platform definition, because the platform DSL is evaluated before the project DSL[1].

In addition, the platform definition's filename is used to name the build artifacts, for example note solaris-113 in:

    agent-runtime-main-202308020.2.g2ddb502.solaris-113-sparc.tar.gz

However, this breaks vanagon projects that try to consume that tarball, like pxp-agent-vanagon and puppet-agent.

Therefore, this modifies vanagon so that it's possible to override the platform name, version or architecture, different than the platform definition's filename, for example:

    # In configs/platforms/solaris-11-sparc.rb
    platform "solaris-11-sparc" do |plat|
      # used to build agent-runtime-7.x

    # In configs/platforms/solaris-11-native-sparc.rb
    platform("solaris-11-sparc", override_name: true) do |plat|
      # used to build agent-runtime-main

This also eliminates needing to special case `os_version`[2].

This is backwards compatible for existing platform definitions. However, any platform definition that passes `override_name` must update their vanagon dependency.

[1] https://github.com/puppetlabs/vanagon/blob/54d2a797cc95a84b4da48726a9a5b2943bfaf014/lib/vanagon/driver.rb#L34-L35
[2] https://github.com/puppetlabs/puppet-runtime/blob/2ddb50288e18d0f8f189a4b8ecda587cd7135643/configs/projects/_shared-agent-settings.rb#L127

Please add all notable changes to the "Unreleased" section of the CHANGELOG.