### PR TITLE
Fix git detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](https://semver.org).
 This changelog adheres to [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+### Fixed
+- (maint) Fix git remote detection
+- (maint) Fix valid_url? check
 
 ## [0.39.0] - release 2023-08-07
 ### Added

--- a/lib/vanagon/component/source/http.rb
+++ b/lib/vanagon/component/source/http.rb
@@ -22,20 +22,19 @@ class Vanagon
             return false unless ['http', 'https'].include? uri.scheme
 
             Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
-              http.request(Net::HTTP::Head.new(uri)) do |response|
-                case response
-                when Net::HTTPRedirection
-                  # By parsing the location header, we get either an absolute
-                  # URI or a URI with a relative `path`. Adding it to `uri`
-                  # should correctly update the relative `path` or overwrite
-                  # the entire URI if it's absolute.
-                  location = URI.parse(response.header['location'])
-                  valid_url?(uri + location)
-                when Net::HTTPSuccess
-                  return true
-                else
-                  false
-                end
+              response = http.request(Net::HTTP::Head.new(uri))
+              case response
+              when Net::HTTPRedirection
+                # By parsing the location header, we get either an absolute
+                # URI or a URI with a relative `path`. Adding it to `uri`
+                # should correctly update the relative `path` or overwrite
+                # the entire URI if it's absolute.
+                location = URI.parse(response.header['location'])
+                valid_url?(uri + location)
+              when Net::HTTPSuccess
+                true
+              else
+                false
               end
             end
           end

--- a/spec/lib/vanagon/component/source/git_spec.rb
+++ b/spec/lib/vanagon/component/source/git_spec.rb
@@ -15,11 +15,26 @@ describe "Vanagon::Component::Source::Git" do
     let(:github_archive_uri) do
       'https://github.com/2ndQuadrant/pglogical/archive/a_file_name.tar.gz'
     end
+    let(:github_releases_uri) do
+      'https://github.com/libffi/libffi/releases/download/v3.4.3/libffi-3.4.3.tar.gz'
+    end
     let(:github_tarball_uri) do
       'https://github.com/Baeldung/kotlin-tutorials/tarball/main'
     end
     let(:github_zipball_uri) do
       'https://github.com/Baeldung/kotlin-tutorials/zipball/master'
+    end
+    let(:github_actual_tarball_uri) do
+      'https://github.com/puppetlabs/puppet/archive/refs/tags/8.2.0.tar.gz'
+    end
+    let(:github_actual_tarball_with_unexpected_path_uri) do
+      'https://github.com/puppetlabs/puppet/something/refs/tags/8.2.0.tar.gz'
+    end
+    let(:github_actual_zipball_uri) do
+      'https://github.com/puppetlabs/puppet/archive/refs/tags/8.2.0.zip'
+    end
+    let(:github_actual_zipball_with_unexpected_path_uri) do
+      'https://github.com/puppetlabs/puppet/something/refs/tags/8.2.0.zip'
     end
     let(:github_repo_uri) do
       'https://github.com/cameronmcnz/rock-paper-scissors'
@@ -32,12 +47,32 @@ describe "Vanagon::Component::Source::Git" do
       expect(Vanagon::Component::Source::Git.valid_remote?(github_archive_uri)).to be false
     end
 
+    it "flags github releases uris as not valid repos" do
+      expect(Vanagon::Component::Source::Git.valid_remote?(github_releases_uri)).to be false
+    end
+
     it "flags github tarball uris as not valid repos" do
       expect(Vanagon::Component::Source::Git.valid_remote?(github_tarball_uri)).to be false
     end
 
+    it "flags github actual tarball uris as not valid repos" do
+      expect(Vanagon::Component::Source::Git.valid_remote?(github_actual_tarball_uri)).to be false
+    end
+
+    it "flags github actual tarball uris with an unexpected path as not valid repos" do
+      expect(Vanagon::Component::Source::Git.valid_remote?(github_actual_tarball_with_unexpected_path_uri)).to be false
+    end
+
     it "flags git zipball uris as not valid repos" do
       expect(Vanagon::Component::Source::Git.valid_remote?(github_zipball_uri)).to be false
+    end
+
+    it "flags github actual tarball uris as not valid repos" do
+      expect(Vanagon::Component::Source::Git.valid_remote?(github_actual_zipball_uri)).to be false
+    end
+
+    it "flags github actual tarball uris with an unexpected path as not valid repos" do
+      expect(Vanagon::Component::Source::Git.valid_remote?(github_actual_zipball_with_unexpected_path_uri)).to be false
     end
 
     it "identifies git generic uris as valid repos" do


### PR DESCRIPTION
### (maint) Fix git remote detection
Previously, this was attempting to determine if a github.com URL was a remote or a media type by inspecting part of the path. However, this was missing paths with 'release' in them. Also, we were never actually using any other return type but :github_remote. This changes the logic to return :github_media if the path contains known media tokens, or if the suffix ends with .tar.gz or .zip. Otherwise, we assume it's a remote.

Ideally, we'd reach out to GitHub to determine if it's a repo, but we're doing this to avoid rate limiting.

### (maint) Fix valid_url? check
Because the 'request' function does NOT return the value the block you pass it returns, this function was always returning a Net::HTTP object. With how this function was being used, it would result in valid_url? always being truthy.  Net::HTTP.start DOES return the value that the block you pass it returns, though, so this simply un-blockifies the processing of the request response.