### PR TITLE
(maint) Handle an invalid mirror gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org).
 This changelog adheres to [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+### Fixed
+- (maint) Handle an invalid mirror gracefully
 
 ## [0.39.1] - release 2023-08-25
 ### Fixed

--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -260,14 +260,21 @@ class Vanagon
           VanagonLogger.info %(Attempting to fetch from mirror URL "#{mirror}")
           @source = Vanagon::Component::Source.source(mirror, **options)
           return true if source.fetch
+        rescue Vanagon::InvalidSource
+          # This means that the URL was not a git repo or a valid downloadable file,
+          # which means either the URL is incorrect, or we don't have access to that
+          # resource. Return false, so that the pkg.url value can be used instead.
+          VanagonLogger.error %(Invalid source "#{mirror}")
         rescue SocketError
           # SocketError means that there was no DNS/name resolution
           # for whatever remote protocol the mirror tried to use.
           VanagonLogger.error %(Unable to resolve mirror URL "#{mirror}")
-        rescue RuntimeError
+        rescue StandardError
           # Source retrieval does not consistently return a meaningful
           # namespaced error message, which means we're brute-force rescuing
-          # RuntimeError. Not a good look, and we should fix this.
+          # StandardError. Also, we want to handle other unexpected things when
+          # we try reaching out to the URL, so that we can gracefully return
+          # false and fall back to fetching the pkg.url value instead.
           VanagonLogger.error %(Unable to retrieve mirror URL "#{mirror}")
         end
       end

--- a/lib/vanagon/component/source.rb
+++ b/lib/vanagon/component/source.rb
@@ -3,8 +3,11 @@ require 'vanagon/logger'
 require 'vanagon/component/source/http'
 require 'vanagon/component/source/git'
 require 'vanagon/component/source/local'
+require 'vanagon/errors'
 
 class Vanagon
+  class InvalidSource < Vanagon::Error
+  end
   class Component
     class Source
       SUPPORTED_PROTOCOLS = %w[file http https git].freeze
@@ -55,8 +58,8 @@ class Vanagon
           end
 
           # Unknown source type!
-          raise Vanagon::Error,
-            "Unknown file type: '#{uri}'; cannot continue"
+          raise Vanagon::InvalidSource,
+            "Source is invalid or of an unknown type: '#{uri}'; cannot continue"
         end
 
         def determine_source_type(uri)


### PR DESCRIPTION
Because the HTTP source's valid_url? check was always returning truthy before, a mirror URL to a file would always seem to be valid, even if it wasn't. Now that https://github.com/puppetlabs/vanagon/commit/9995d5ef7f0370eb41f327ca36dad5a40ea95f9d fixed it, a Vanagon::Error would get thrown saying it was an unknown file type. This means that fetch_url would never get called since this exception in fetch_mirrors would be unhandled.

This handles that particular error, and continues to throw other Vanagon::Error types, as they usually indicate a problem with the definition of the component or some other type of fatal error. Additionally, this changes the catching of RuntimeError to StandardError, so that we can handle issues talking to the particular URL, such as OpenSSL errors.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.