### PR TITLE
(maint) Force >= 4.0 of psych gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](https://semver.org).
 This changelog adheres to [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+### Changed
+- (maint) Force psych gem to use >= 4.0 to avoid breaking change in safe_load between v3 and
+  v4 of the gem.
 
 ## [0.39.2] - release 2023-08-29
 ### Fixed

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -850,7 +850,7 @@ class Vanagon
                       source.file
                     end
 
-        @settings.merge!(yaml_safe_load_shim(yaml_path))
+        @settings.merge!(YAML.safe_load(File.read(yaml_path), permitted_classes: [Symbol]))
       end
     end
 
@@ -874,19 +874,6 @@ class Vanagon
       end
 
       source_type
-    end
-
-    # YAML.safe_load introduced an incompatible change in Ruby 3.1.0
-    # Shim that until no longer relevant.
-    def yaml_safe_load_shim(yaml_path)
-      new_safe_load_version = Gem::Version.new('3.1.0')
-      this_version = Gem::Version.new(RUBY_VERSION)
-
-      if this_version >= new_safe_load_version
-        YAML.safe_load(File.read(yaml_path), permitted_classes: [Symbol])
-      else
-        YAML.safe_load(File.read(yaml_path), [Symbol])
-      end
     end
 
     def load_upstream_metadata(metadata_uri)

--- a/vanagon.gemspec
+++ b/vanagon.gemspec
@@ -31,6 +31,8 @@ Gem::Specification.new do |gem|
   # Utilities for `ship` and `repo` commands
   # - ASL v2 licensed: https://rubygems.org/gems/packaging
   gem.add_runtime_dependency('packaging')
+  gem.add_runtime_dependency('psych', '>= 4.0')
+
   gem.require_path = 'lib'
   gem.bindir       = 'bin'
   gem.executables  = %w[vanagon build inspect ship render repo sign


### PR DESCRIPTION
This allows us to remove the yaml_safe_load_shim hack and treat
safe_load consistently.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.