### PR TITLE
(PA-5328) Remove redundant plines to install packages in debian-11-aarch

### DIFF
--- a/lib/vanagon/platform/defaults/debian-11-aarch64.rb
+++ b/lib/vanagon/platform/defaults/debian-11-aarch64.rb
@@ -3,9 +3,6 @@ platform "debian-11-aarch64" do |plat|
   plat.defaultdir "/etc/default"
   plat.servicetype "systemd"
   plat.codename "bullseye"
-
-  packages = %w(build-essential devscripts make quilt pkg-config debhelper rsync fakeroot cmake)
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-11-arm64"
 end


### PR DESCRIPTION
Removed the package install command since these packages are going to be installed in puppet-runtime anyways so keeping them here is redundant.
