### PR TITLE
(PA-5786) Stop using posttrans for post-install steps

### DIFF
--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -242,13 +242,17 @@ fi
 
 
 %post
-<%- if @platform.is_aix? || (@platform.is_el? && @platform.os_version.to_i == 4) -%>
-## EL-4 and AIX RPM don't have %posttrans, so we'll put them here
-# Run postinstall scripts on install if defined
-if [ "$1" -eq 1 ] ; then
+# Run post-transaction scripts on install if defined
+if [ -e %{_localstatedir}/lib/rpm-state/%{name}/install ] ; then
   <%= get_postinstall_actions("install") %>
+  rm %{_localstatedir}/lib/rpm-state/%{name}/install
 fi
-<%- end -%>
+
+# Run post-transaction scripts on upgrade if defined
+if [ -e %{_localstatedir}/lib/rpm-state/%{name}/upgrade ] ; then
+  <%= get_postinstall_actions("upgrade") %>
+  rm %{_localstatedir}/lib/rpm-state/%{name}/upgrade
+fi
 <%- get_services.each do |service| -%>
   # switch based on systemd vs systemv vs smf vs aix
   #
@@ -351,21 +355,6 @@ fi
   <%- end -%>
 <%- end -%>
 
-
-<%- unless @platform.is_aix? || (@platform.is_el? && @platform.os_version.to_i == 4) -%>
-%posttrans
-# Run post-transaction scripts on install if defined
-if [ -e %{_localstatedir}/lib/rpm-state/%{name}/install ] ; then
-  <%= get_postinstall_actions("install") %>
-  rm %{_localstatedir}/lib/rpm-state/%{name}/install
-fi
-
-# Run post-transaction scripts on upgrade if defined
-if [ -e %{_localstatedir}/lib/rpm-state/%{name}/upgrade ] ; then
-  <%= get_postinstall_actions("upgrade") %>
-  rm %{_localstatedir}/lib/rpm-state/%{name}/upgrade
-fi
-<%- end -%>
 
 %files <%- unless get_directories.empty? -%>-f %{SOURCE1}<%- end -%>
 


### PR DESCRIPTION
Before this commit, vanagon used the `%posttrans` section of an rpm spec for #add_postinstall_action. Specifying items in the `%posttrans` section means that rpm considers the transaction done, and rpm continues to excecute irregardless of the result of the `%posttrans` scriptlet. This behavior breaks puppet-agent 8 fips upgrades because certain configuration files are created in a #add_postinstall_action, and those configuration files were not yet ready before the agent daemon is killed and then started as part of the upgrade.

This change eliminates the `%posttrans` section entirely in favor of moving all #add_postinstall_action code to the `%post` section.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.