### PR TITLE
(PA-5786) Add ability to execute direct post installation scriptlets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org).
 This changelog adheres to [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+### Added
+- (PA-5786) Add `postinstall_required_actions` forcing scriptlets to run in the %post section for rpm
 
 ## [0.39.3] - release 2023-09-29
 ### Added

--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -106,6 +106,9 @@ class Vanagon
     # activate_triggers is a one-dimentional Array of Strings, describing scripts that
     # should be executed when a package identifies an activate trigger
     attr_accessor :activate_triggers
+    # postinstall_required_actions is a two-dimensional Array, describing scripts that
+    # must be executed successfully after a given component is installed.
+    attr_accessor :postinstall_required_actions
     # postinstall_actions is a two-dimensional Array, describing scripts that
     # should be executed after a given component is installed.
     attr_accessor :postinstall_actions
@@ -176,6 +179,7 @@ class Vanagon
       @install_triggers = []
       @interest_triggers = []
       @activate_triggers = []
+      @postinstall_required_actions = []
       @postinstall_actions = []
       @preremove_actions = []
       @postremove_actions = []

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -503,6 +503,16 @@ class Vanagon
         @component.activate_triggers << OpenStruct.new(:activate_name => activate_name)
       end
 
+      # Add post installation action that must exit successfully before restarting the service
+      #
+      # @param pkg_state [Array] the state in which the scripts should execute. Can be
+      #   one or multiple of 'install' and 'upgrade'.
+      # @param scripts [Array] the Bourne shell compatible scriptlet(s) to execute
+      def add_postinstall_required_action(pkg_state, scripts)
+        check_pkg_state_array(pkg_state)
+        @component.postinstall_required_actions << OpenStruct.new(:pkg_state => Array(pkg_state), :scripts => Array(scripts))
+      end
+
       # Adds action to run during the postinstall phase of packaging
       #
       # @param pkg_state [Array] the state in which the scripts should execute. Can be

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -494,6 +494,18 @@ class Vanagon
       end
     end
 
+    # Collects the postinstall packaging actions that must exit successfully for the project and it's components
+    #  for the specified packaging state
+    #
+    # @param pkg_state [String] the package state we want to run the given scripts for.
+    #   Can be one of 'install' or 'upgrade'
+    # @return [String] string of Bourne shell compatible scriptlets to execute during the postinstall
+    #   phase of packaging during the state of the system defined by pkg_state (either install or upgrade)
+    def get_postinstall_required_actions(pkg_state)
+      scripts = components.flat_map(&:postinstall_required_actions).compact.select { |s| s.pkg_state.include? pkg_state }.map(&:scripts)
+      return ': no postinstall required scripts provided' if scripts.empty?
+      scripts.join("\n")
+    end
     # Collects the preremove packaging actions for the project and it's components
     # for the specified packaging state
     #

--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -242,6 +242,17 @@ fi
 
 
 %post
+# Run required postinstall scripts on install if defined
+if [ -e %{_localstatedir}/lib/rpm-state/%{name}/install ] ; then
+  <%= get_postinstall_required_actions("install") %>
+  rm %{_localstatedir}/lib/rpm-state/%{name}/install
+fi
+
+# Run required postinstall scripts on upgrade if defined
+if [ -e %{_localstatedir}/lib/rpm-state/%{name}/upgrade ] ; then
+  <%= get_postinstall_required_actions("upgrade") %>
+  rm %{_localstatedir}/lib/rpm-state/%{name}/upgrade
+fi
 <%- if @platform.is_aix? || (@platform.is_el? && @platform.os_version.to_i == 4) -%>
 ## EL-4 and AIX RPM don't have %posttrans, so we'll put them here
 # Run postinstall scripts on install if defined


### PR DESCRIPTION
The existing `#add_postinstall_action` adds actions to the `%posttrans` section of an rpm spec file. This can mean that the action could fail, but the installation/upgrade could still succeed. This commit adds the ability to add actions that must succeed post installation for rpm installations by adding the action to the `%post` section.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.