### PR TITLE
(VANAGON-235) Specify which URL is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This changelog adheres to [Keep a CHANGELOG](https://keepachangelog.com).
 ### Added
 - (PA-5786) Add `postinstall_required_actions` forcing scriptlets to run in the %post section for rpm
 
+### Changed
+- (VANAGON-235) Report the actual URL when a Git URL is deemed invalid.
+
 ## [0.41.0] - 2023-10-26
 ### Added
 - (VANAGON-231) Added amazon linux 2023 platform for intel & arm

--- a/lib/vanagon/component/source/git.rb
+++ b/lib/vanagon/component/source/git.rb
@@ -106,7 +106,7 @@ class Vanagon
           @clone_options = opts[:clone_options] ||= {}
 
           # We can test for Repo existence without cloning
-          raise Vanagon::InvalidRepo, "url is not a valid Git repo" unless valid_remote?
+          raise Vanagon::InvalidRepo, "\"#{url}\" is not a valid Git repo" unless valid_remote?
         end
 
         # Fetch the source. In this case, clone the repository into the workdir


### PR DESCRIPTION
Vanagon::Component::Source::Git will throw an error message during
initialization if it thinks that the passed url is invalid.

Make a change to the error message to specify which url it was
reporting as invalid.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.