### PR TITLE
(vanagon-238) Fix rubocop offence and workflow issue

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,6 +15,6 @@ jobs:
         ruby-version: '2.7'
     - name: Build and test with Rake
       run: |
-        gem install bundler
+        gem install bundler -v 2.4.22
         bundle install --jobs 4 --retry 3
         bundle exec rake

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -288,7 +288,7 @@ Lint/SuppressedException:
   Enabled: true
 
 Lint/SymbolConversion:
-  Enabled: true
+  Enabled: false
 
 Lint/ToEnumArguments:
   Enabled: true

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -474,7 +474,7 @@ class Vanagon
     #
     # @return [true, false] true if it is a linux variety, false otherwise
     def is_linux?
-      return (!is_windows? && !is_unix?)
+      !is_windows? && !is_unix?
     end
 
     # Utility matcher to determine if the platform is a cross-compiled variety
@@ -490,7 +490,7 @@ class Vanagon
     #
     # @return [true, false] true if it is a cross-compiled Linux variety, false otherwise
     def is_cross_compiled_linux?
-      return (is_cross_compiled? && is_linux?)
+      is_cross_compiled? && is_linux?
     end
 
     # Pass in a packaging override. This needs to be implemented for each


### PR DESCRIPTION
ruby 2.7 is compatible with <= bundler 2.4.22. Latest version of bundler is causing failures in checks.