### PR TITLE
(RE-16095) Abandon fustigit in favor of build-uri.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](https://semver.org).
 This changelog adheres to [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+### Changed
+(RE-16095) Abandon fustigit in favor of build-uri. build-uri provides similar functionality
+  without the monkey-patching
+
 
 ## [0.45.0] - 2024-02-16
 ### Added

--- a/lib/vanagon/component/source.rb
+++ b/lib/vanagon/component/source.rb
@@ -1,4 +1,3 @@
-require 'fustigit'
 require 'vanagon/logger'
 require 'vanagon/component/source/http'
 require 'vanagon/component/source/git'

--- a/lib/vanagon/component/source/git.rb
+++ b/lib/vanagon/component/source/git.rb
@@ -4,7 +4,7 @@ require 'vanagon/logger'
 # This stupid library requires a capital 'E' in its name
 # but it provides a wealth of useful constants
 require 'English'
-require 'fustigit'
+require 'build/uri'
 require 'git/basic_submodules'
 require 'logger'
 require 'timeout'
@@ -98,7 +98,7 @@ class Vanagon
           opts = default_options.merge(options.reject { |k, v| v.nil? })
 
           # Ensure that #url returns a URI object
-          @url = URI.parse(url.to_s)
+          @url = Build::URI.parse(url.to_s)
           @log_url = @url.host + @url.path unless @url.host.nil? || @url.path.nil?
           @ref = opts[:ref]
           @dirname = opts[:dirname]

--- a/lib/vanagon/component/source/rewrite.rb
+++ b/lib/vanagon/component/source/rewrite.rb
@@ -78,11 +78,12 @@ class Vanagon
             return uri if rewrite_rules.empty?
             if !!uri.match(/^git:http/)
               VanagonLogger.info <<-HERE.undent
-                `fustigit` parsing doesn't get along with how we specify the source
+                `build-uri` parsing doesn't get along with how we specify the source
                 type by prefixing `git`. As `rewrite_rules` are deprecated, we'll
                 replace `git:http` with `http` in your uri. At some point this will
                 break.
               HERE
+              # build-uri does not support git:http://host/path
               uri.sub!(/^git:http/, 'http')
             end
             url = URI.parse(uri)

--- a/vanagon.gemspec
+++ b/vanagon.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |gem|
   # - MIT licensed: https://rubygems.org/gems/git
   gem.add_runtime_dependency('git', '~> 1.13.0')
   # Parse scp-style triplets like URIs; used for Git source handling.
-  # - MIT licensed: https://rubygems.org/gems/fustigit
-  gem.add_runtime_dependency('fustigit', '~> 0.3.0')
+  # - MIT licensed: https://rubygems.org/gems/build-uri
+  gem.add_runtime_dependency('build-uri', '~> 1.0')
   # Handle locking hardware resources
   # - ASL v2 licensed: https://rubygems.org/gems/lock_manager
   gem.add_runtime_dependency('lock_manager', '>= 0')


### PR DESCRIPTION
build-uri provides similar functionality as fustigit without the monkey-patching

Also update related specs with some additional light housecleaning in the spec.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.