### PR TITLE
(PA-5323) Add RedHat 9 (Power9) platform definition to vanagon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org).
 This changelog adheres to [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+### Added
+- (PA-5323) Add RedHat 9 (Power9) platform definition to vanagon
 
 ## [0.46.0] - 2024-03-18
 ### Changed

--- a/lib/vanagon/platform/defaults/el-9-ppc64le.rb
+++ b/lib/vanagon/platform/defaults/el-9-ppc64le.rb
@@ -1,0 +1,29 @@
+platform 'el-9-ppc64le' do |plat|
+  plat.servicedir '/usr/lib/systemd/system'
+  plat.defaultdir '/etc/sysconfig'
+  plat.servicetype 'systemd'
+
+  # Workaround for an issue with RedHat subscription metadata, see ITSYS-2543
+  plat.provision_with('subscription-manager repos --disable rhel-9-for-ppc64le-baseos-rpms && subscription-manager repos --enable rhel-9-for-ppc64le-baseos-rpms --enable codeready-builder-for-rhel-9-ppc64le-rpms')
+
+  packages = %w(
+    autoconf
+    automake
+    cmake
+    gcc-c++
+    java-1.8.0-openjdk-devel
+    libarchive
+    libselinux-devel
+    make
+    patch
+    perl-Getopt-Long
+    readline-devel
+    swig
+    systemtap-sdt-devel
+    zlib-devel
+  )
+
+  plat.provision_with("dnf install -y --allowerasing  #{packages.join(' ')}")
+  plat.install_build_dependencies_with 'dnf install -y --allowerasing'
+  plat.vmpooler_template 'redhat-9-power9'
+end


### PR DESCRIPTION
(PA-5323) Added changelog

To get `swig` installed I have added: `--enable codeready-builder-for-rhel-9-ppc64le-rpms`