### PR TITLE
Use URI.parse when selecting the docker target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org).
 This changelog adheres to [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+### Fixed
+- Use URI.parse when selecting the docker target
 
 ## [0.48.0] - 2024-04-16
 ### Added

--- a/lib/vanagon/engine/docker.rb
+++ b/lib/vanagon/engine/docker.rb
@@ -40,7 +40,7 @@ class Vanagon
         extra_args = @platform.docker_run_args.nil? ? [] : @platform.docker_run_args
 
         Vanagon::Utilities.ex("#{@docker_cmd} run -d --name #{build_host_name}-builder #{ssh_args} #{extra_args.join(' ')} #{@platform.docker_image}")
-        @target = URI.new('localhost')
+        @target = URI.parse('localhost')
 
         wait_for_ssh unless @platform.use_docker_exec
       rescue StandardError => e

--- a/spec/lib/vanagon/engine/docker_spec.rb
+++ b/spec/lib/vanagon/engine/docker_spec.rb
@@ -101,4 +101,26 @@ describe Vanagon::Engine::Docker do
       end
     end
   end
+
+  describe '#select_target' do
+    context 'when platform has use_docker_exec set' do
+      subject { described_class.new(platform_with_docker_exec) }
+
+      it 'starts a new docker instance' do
+        expect(Vanagon::Utilities).to receive(:ex).with("/usr/bin/docker run -d --name debian_10-slim-builder   debian:10-slim")
+
+        subject.select_target
+      end
+
+      it 'sets the target to a localhost URI' do
+        allow(Vanagon::Utilities).to receive(:ex)
+
+        subject.select_target
+
+        uri = subject.target
+        expect(uri).to be_an_instance_of(URI::Generic)
+        expect(uri.path).to eq('localhost')
+      end
+    end
+  end
 end


### PR DESCRIPTION
The select_target method was broken because URI.new is not a valid method.