### PR TITLE
(VANAGON-242) Add Amazon Linux2 ARM platform definition to vanagon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This changelog adheres to [Keep a CHANGELOG](https://keepachangelog.com).
 ## [Unreleased]
 ### Fixed
 - Use URI.parse when selecting the docker target
+### Added
+- (VANAGON-242) Add Amazon Linux2 ARM platform definition to vanagon
 
 ## [0.48.0] - 2024-04-16
 ### Added

--- a/lib/vanagon/platform/defaults/amazon-7-aarch64.rb
+++ b/lib/vanagon/platform/defaults/amazon-7-aarch64.rb
@@ -1,0 +1,10 @@
+platform "amazon-7-aarch64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  packages = %w(autoconf automake createrepo gcc gcc-c++ rsync cmake make rpm-libs rpm-build libarchive)
+  plat.provision_with("yum install -y --nogpgcheck  #{packages.join(' ')}")
+  plat.install_build_dependencies_with "yum install --assumeyes"
+  plat.vmpooler_template "amazon-7-arm64"
+end


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.