### PR TITLE
(VANAGON-243) Add Ubuntu 24.04 (ARM) platform definition to vanagon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org).
 This changelog adheres to [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+### Added
+- (VANAGON-243) Add Ubuntu 24.04 (ARM) platform definition to vanagon
 
 ## [0.50.0] - 2024-04-29
 ### Changed

--- a/lib/vanagon/platform/defaults/ubuntu-24.04-aarch64.rb
+++ b/lib/vanagon/platform/defaults/ubuntu-24.04-aarch64.rb
@@ -1,0 +1,11 @@
+platform "ubuntu-24.04-aarch64" do |plat|
+  plat.servicedir "/lib/systemd/system"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "systemd"
+  plat.codename "noble"
+
+  packages = %w(build-essential devscripts make quilt pkg-config debhelper rsync fakeroot cmake)
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  plat.vmpooler_template "ubuntu-2404-arm64"
+end


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.