### PR TITLE
Copy amazon-7 to amazon-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org).
 This changelog adheres to [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+### Added
+- Add Amazon 2 (ARM) platform definition to vanagon
 
 ## [0.51.0] - 2024-05-31
 ### Added

--- a/lib/vanagon/platform/defaults/amazon-2-aarch64.rb
+++ b/lib/vanagon/platform/defaults/amazon-2-aarch64.rb
@@ -1,0 +1,10 @@
+platform "amazon-2-aarch64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  packages = %w(autoconf automake createrepo gcc gcc-c++ rsync cmake3  make rpm-libs rpm-build libarchive)
+  plat.provision_with("yum install -y --nogpgcheck  #{packages.join(' ')}")
+  plat.install_build_dependencies_with "yum install --assumeyes"
+  plat.vmpooler_template "amazon-7-arm64"
+end


### PR DESCRIPTION
We're intentionally continuing to use the amazon-7-arm64 VM template

Successfully built puppet-runtime https://builds.delivery.puppetlabs.net/puppet-runtime/d743d36f9d92d18abc43cce9f35d2328b5a6c1f5/repos/agent-runtime-main-202308240.260.gd743d36.amazon-2-aarch64.tar.gz