### PR TITLE
(PA-6886) Add Digicert to Solaris images

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,28 +5,14 @@ require:
 - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.7
+  NewCops: enable
   Exclude:
   - "**/*.erb"
   - spec/**/*
   - vendor/**/*
   - examples/**/*
   - lib/vanagon/platform/defaults/*
-
-Capybara/MatchStyle:
-  Enabled: true
-
-Capybara/NegationMatcher:
-  Enabled: true
-
-Capybara/SpecificActions:
-  Enabled: true
-
-Capybara/SpecificFinders:
-  Enabled: true
-
-Capybara/SpecificMatcher:
-  Enabled: true
 
 Gemspec/DeprecatedAttributeAssignment:
   Enabled: true
@@ -395,15 +381,6 @@ RSpec/DuplicatedMetadata:
 RSpec/ExcessiveDocstringSpacing:
   Enabled: true
 
-RSpec/FactoryBot/ConsistentParenthesesStyle:
-  Enabled: true
-
-RSpec/FactoryBot/FactoryNameStyle:
-  Enabled: true
-
-RSpec/FactoryBot/SyntaxMethods:
-  Enabled: true
-
 RSpec/IdenticalEqualityAssertion:
   Enabled: true
 
@@ -414,21 +391,6 @@ RSpec/NoExpectationExample:
   Enabled: true
 
 RSpec/PendingWithoutReason:
-  Enabled: true
-
-RSpec/Rails/AvoidSetupHook:
-  Enabled: true
-
-RSpec/Rails/HaveHttpStatus:
-  Enabled: true
-
-RSpec/Rails/InferredSpecType:
-  Enabled: true
-
-RSpec/Rails/MinitestAssertions:
-  Enabled: true
-
-RSpec/Rails/TravelAround:
   Enabled: true
 
 RSpec/RedundantAround:
@@ -446,16 +408,16 @@ RSpec/SubjectDeclaration:
 RSpec/VerifiedDoubleReference:
   Enabled: true
 
-Rspec/BeforeAfterAll:
+RSpec/BeforeAfterAll:
   Enabled: false
 
-Rspec/ExampleLength:
+RSpec/ExampleLength:
   Enabled: false
 
-Rspec/HookArgument:
+RSpec/HookArgument:
   Enabled: false
 
-Rspec/MultipleMemoizedHelpers:
+RSpec/MultipleMemoizedHelpers:
   Enabled: false
 
 Security/CompoundHash:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org).
 
 This changelog adheres to [Keep a CHANGELOG](https://keepachangelog.com).
-
+### Changed
 ## [Unreleased]
+- Bump minimum ruby requirement to 2.7
 
 ### Added
 - Add DigiCertGlobalRootG2 cert as part of Solaris default

--- a/lib/vanagon/cli/build.rb
+++ b/lib/vanagon/cli/build.rb
@@ -71,7 +71,7 @@ class Vanagon
           '<platforms>' => :platforms,
           '<targets>' => :targets
         }
-        return docopt_options.map { |k, v| [translations[k], v] }.to_h
+        return docopt_options.transform_keys { |k| translations[k] }
       end
 
       def options_validate(options)

--- a/lib/vanagon/cli/build_host_info.rb
+++ b/lib/vanagon/cli/build_host_info.rb
@@ -51,7 +51,7 @@ class Vanagon
           '<platforms>' => :platforms,
           '<targets>' => :targets
         }
-        return docopt_options.map { |k, v| [translations[k], v] }.to_h
+        return docopt_options.transform_keys { |k| translations[k] }
       end
     end
   end

--- a/lib/vanagon/cli/build_requirements.rb
+++ b/lib/vanagon/cli/build_requirements.rb
@@ -39,9 +39,8 @@ class Vanagon
 
         components = driver.project.components
         component_names = components.map(&:name)
-        build_requirements = []
-        components.each do |component|
-          build_requirements << component.build_requires.reject do |requirement|
+        build_requirements = components.map do |component|
+          component.build_requires.reject do |requirement|
             # only include external requirements: i.e. those that do not match
             # other components in the project
             component_names.include?(requirement)
@@ -61,7 +60,7 @@ class Vanagon
           '<project-name>' => :project_name,
           '<platform>' => :platform,
         }
-        return docopt_options.map { |k, v| [translations[k], v] }.to_h
+        return docopt_options.transform_keys { |k| translations[k] }
       end
     end
   end

--- a/lib/vanagon/cli/completion.rb
+++ b/lib/vanagon/cli/completion.rb
@@ -37,7 +37,7 @@ class Vanagon
         translations = {
           '--shell' => :shell,
         }
-        return docopt_options.map { |k, v| [translations[k], v] }.to_h
+        return docopt_options.transform_keys { |k| translations[k] }
       end
     end
   end

--- a/lib/vanagon/cli/dependencies.rb
+++ b/lib/vanagon/cli/dependencies.rb
@@ -35,12 +35,10 @@ class Vanagon
 
         projects.each do |project|
           platforms.each do |platform|
-            begin
-              artifact = Vanagon::Driver.new(platform, project, options)
-              artifact.dependencies
-            rescue RuntimeError => e
-              failures.push("#{project}, #{platform}: #{e}")
-            end
+            artifact = Vanagon::Driver.new(platform, project, options)
+            artifact.dependencies
+          rescue RuntimeError => e
+            failures.push("#{project}, #{platform}: #{e}")
           end
         end
 
@@ -92,7 +90,7 @@ class Vanagon
           '<project-name>' => :project_name,
           '<platforms>' => :platforms
         }
-        return docopt_options.map { |k, v| [translations[k], v] }.to_h
+        return docopt_options.transform_keys { |k| translations[k] }
       end
     end
   end

--- a/lib/vanagon/cli/inspect.rb
+++ b/lib/vanagon/cli/inspect.rb
@@ -56,7 +56,7 @@ class Vanagon
           '<project-name>' => :project_name,
           '<platforms>' => :platforms
         }
-        return docopt_options.map { |k, v| [translations[k], v] }.to_h
+        return docopt_options.transform_keys { |k| translations[k] }
       end
 
       def options_validate(options)

--- a/lib/vanagon/cli/list.rb
+++ b/lib/vanagon/cli/list.rb
@@ -87,7 +87,7 @@ class Vanagon
           '--projects' => :projects,
           '--use-spaces' => :use_spaces,
         }
-        return docopt_options.map { |k, v| [translations[k], v] }.to_h
+        return docopt_options.transform_keys { |k| translations[k] }
       end
     end
   end

--- a/lib/vanagon/cli/render.rb
+++ b/lib/vanagon/cli/render.rb
@@ -53,7 +53,7 @@ class Vanagon
           '<project-name>' => :project_name,
           '<platforms>' => :platforms,
         }
-        return docopt_options.map { |k, v| [translations[k], v] }.to_h
+        return docopt_options.transform_keys { |k| translations[k] }
       end
     end
   end

--- a/lib/vanagon/cli/ship.rb
+++ b/lib/vanagon/cli/ship.rb
@@ -22,7 +22,7 @@ class Vanagon
       def run(_)
         ENV['PROJECT_ROOT'] = Dir.pwd
 
-        if Dir['output/**/*'].select { |entry| File.file?(entry) }.empty?
+        if Dir['output/**/*'].none? { |entry| File.file?(entry) }
           VanagonLogger.error 'vanagon: Error: No packages to ship in the "output" directory. Maybe build some first?'
           exit 1
         end

--- a/lib/vanagon/cli/sign.rb
+++ b/lib/vanagon/cli/sign.rb
@@ -21,7 +21,7 @@ class Vanagon
 
       def run(_)
         ENV['PROJECT_ROOT'] = Dir.pwd
-        if Dir['output/**/*'].select { |entry| File.file?(entry) }.empty?
+        if Dir['output/**/*'].none? { |entry| File.file?(entry) }
           VanagonLogger.error 'sign: Error: No packages to sign in the "output" directory. Maybe build some first?'
           exit 1
         end

--- a/lib/vanagon/common/user.rb
+++ b/lib/vanagon/common/user.rb
@@ -15,10 +15,10 @@ class Vanagon
       #
       # @return [true, false] true if all attributes have equal values. false otherwise.
       def ==(other)
-        other.name == self.name && \
-          other.group == self.group && \
-          other.shell == self.shell && \
-          other.is_system == self.is_system && \
+        other.name == self.name &&
+          other.group == self.group &&
+          other.shell == self.shell &&
+          other.is_system == self.is_system &&
           other.homedir == self.homedir
       end
     end

--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -260,27 +260,25 @@ class Vanagon
     #   if #fetch is successful.
     def fetch_mirrors(options)
       mirrors.to_a.shuffle.each do |mirror|
-        begin
-          VanagonLogger.info %(Attempting to fetch from mirror URL "#{mirror}")
-          @source = Vanagon::Component::Source.source(mirror, **options)
-          return true if source.fetch
-        rescue Vanagon::InvalidSource
-          # This means that the URL was not a git repo or a valid downloadable file,
-          # which means either the URL is incorrect, or we don't have access to that
-          # resource. Return false, so that the pkg.url value can be used instead.
-          VanagonLogger.error %(Invalid source "#{mirror}")
-        rescue SocketError
-          # SocketError means that there was no DNS/name resolution
-          # for whatever remote protocol the mirror tried to use.
-          VanagonLogger.error %(Unable to resolve mirror URL "#{mirror}")
-        rescue StandardError
-          # Source retrieval does not consistently return a meaningful
-          # namespaced error message, which means we're brute-force rescuing
-          # StandardError. Also, we want to handle other unexpected things when
-          # we try reaching out to the URL, so that we can gracefully return
-          # false and fall back to fetching the pkg.url value instead.
-          VanagonLogger.error %(Unable to retrieve mirror URL "#{mirror}")
-        end
+        VanagonLogger.info %(Attempting to fetch from mirror URL "#{mirror}")
+        @source = Vanagon::Component::Source.source(mirror, **options)
+        return true if source.fetch
+      rescue Vanagon::InvalidSource
+        # This means that the URL was not a git repo or a valid downloadable file,
+        # which means either the URL is incorrect, or we don't have access to that
+        # resource. Return false, so that the pkg.url value can be used instead.
+        VanagonLogger.error %(Invalid source "#{mirror}")
+      rescue SocketError
+        # SocketError means that there was no DNS/name resolution
+        # for whatever remote protocol the mirror tried to use.
+        VanagonLogger.error %(Unable to resolve mirror URL "#{mirror}")
+      rescue StandardError
+        # Source retrieval does not consistently return a meaningful
+        # namespaced error message, which means we're brute-force rescuing
+        # StandardError. Also, we want to handle other unexpected things when
+        # we try reaching out to the URL, so that we can gracefully return
+        # false and fall back to fetching the pkg.url value instead.
+        VanagonLogger.error %(Unable to retrieve mirror URL "#{mirror}")
       end
       false
     end

--- a/lib/vanagon/engine/docker.rb
+++ b/lib/vanagon/engine/docker.rb
@@ -140,12 +140,10 @@ class Vanagon
       # @return [void]
       def wait_for_ssh
         Vanagon::Utilities.retry_with_timeout(5, 5) do
-          begin
-            Vanagon::Utilities.remote_ssh_command("#{@target_user}@#{@target}", 'exit', @target_port)
-          rescue StandardError => e
-            sleep(1) # Give SSHD some time to start.
-            raise e
-          end
+          Vanagon::Utilities.remote_ssh_command("#{@target_user}@#{@target}", 'exit', @target_port)
+        rescue StandardError => e
+          sleep(1) # Give SSHD some time to start.
+          raise e
         end
       rescue StandardError => e
         raise Vanagon::Error.wrap(e, "SSH was not up in the container after 5 seconds.")

--- a/lib/vanagon/logger.rb
+++ b/lib/vanagon/logger.rb
@@ -22,7 +22,7 @@ class VanagonLogger < Logger
   end
 
   def initialize(output = $stdout)
-    super(output)
+    super
     self.level = ::Logger::INFO
     self.formatter = proc do |severity, datetime, progname, msg|
       "#{msg}\n"

--- a/lib/vanagon/platform/deb.rb
+++ b/lib/vanagon/platform/deb.rb
@@ -144,7 +144,7 @@ class Vanagon
         @num_cores = "/usr/bin/nproc"
         @curl = "curl --silent --show-error --fail --location"
         @valid_operators = ['<', '>', '<=', '>=', '=', '<<', '>>']
-        super(name)
+        super
       end
     end
   end

--- a/lib/vanagon/platform/defaults/solaris-11-i386.rb
+++ b/lib/vanagon/platform/defaults/solaris-11-i386.rb
@@ -5,6 +5,7 @@ platform "solaris-11-i386" do |plat|
 # Serial #: 03:3A:F1:E6:A7:11:A9:A0:BB:28:64:B1:1D:09:FA:E5
 # SHA256 Fingerprint: CB:3C:CB:B7:60:31:E5:E0:13:8F:8D:D3:9A:23:F9:DE:47:FF:C3:5E:43:C1:14:4C:EA:27:D4:6A:5A:B1:CB:5F  
 # https://perforce.atlassian.net/browse/RE-16540 for long term fix for this
+# Required by Vanagon while on Solaris 11.1 (solaris-11-x86_64 in our local vmpooler)
 DigiCertGlobalRootG2 = <<-STRING
 -----BEGIN CERTIFICATE-----
 MIIDjjCCAnagAwIBAgIQAzrx5qcRqaC7KGSxHQn65TANBgkqhkiG9w0BAQsFADBh
@@ -32,7 +33,7 @@ STRING
   plat.servicedir "/lib/svc/manifest"
   plat.defaultdir "/lib/svc/method"
   plat.servicetype "smf"
-
+  
   plat.vmpooler_template "solaris-11-x86_64"
   plat.provision_with "echo '#{DigiCertGlobalRootG2}'> /etc/openssl/certs/DigiCertGlobalRootG2.pem"
   plat.provision_with 'chmod a+r /etc/openssl/certs/DigiCertGlobalRootG2.pem'

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -247,7 +247,7 @@ class Vanagon
         @platform.servicedir = dir
 
         # Add to the servicetypes array if we haven't already
-        if @platform.servicetype && @platform.servicedir && @platform.servicetypes.select { |s| s.servicetype == @platform.servicetype }.empty?
+        if @platform.servicetype && @platform.servicedir && @platform.servicetypes.none? { |s| s.servicetype == @platform.servicetype }
           @platform.servicetypes << OpenStruct.new(:servicetype => @platform.servicetype, :servicedir => @platform.servicedir)
         end
       end
@@ -263,7 +263,7 @@ class Vanagon
       #
       # @param type [String] service type for the platform ('sysv' for example)
       # @param servicedir [String] service dir for this platform and service type ('/etc/init.d' for example). Optional.
-      def servicetype(type, servicedir: nil) # rubocop:disable Metrics/AbcSize
+      def servicetype(type, servicedir: nil)
         if servicedir
           @platform.servicetypes << OpenStruct.new(:servicetype => type, :servicedir => servicedir)
         else
@@ -271,7 +271,7 @@ class Vanagon
         end
 
         # Add to the servicetypes array if we haven't already
-        if @platform.servicetype && @platform.servicedir && @platform.servicetypes.select { |s| s.servicetype == @platform.servicetype }.empty?
+        if @platform.servicetype && @platform.servicedir && @platform.servicetypes.none? { |s| s.servicetype == @platform.servicetype }
           @platform.servicetypes << OpenStruct.new(:servicetype => @platform.servicetype, :servicedir => @platform.servicedir)
         end
       end

--- a/lib/vanagon/platform/osx.rb
+++ b/lib/vanagon/platform/osx.rb
@@ -136,7 +136,7 @@ class Vanagon
         @num_cores = "/usr/sbin/sysctl -n hw.physicalcpu"
         @mktemp = "mktemp -d -t 'tmp'"
         @brew = '/usr/local/bin/brew'
-        super(name)
+        super
       end
     end
   end

--- a/lib/vanagon/platform/rpm.rb
+++ b/lib/vanagon/platform/rpm.rb
@@ -104,7 +104,7 @@ class Vanagon
         @num_cores ||= "/bin/grep -c 'processor' /proc/cpuinfo"
         @rpmbuild ||= "/usr/bin/rpmbuild"
         @curl = "curl --silent --show-error --fail --location"
-        super(name)
+        super
       end
     end
   end

--- a/lib/vanagon/platform/rpm/aix.rb
+++ b/lib/vanagon/platform/rpm/aix.rb
@@ -22,7 +22,7 @@ class Vanagon
           @num_cores = "lsdev -Cc processor |wc -l"
           @install = "/opt/freeware/bin/install"
           @rpmbuild = "/usr/bin/rpm"
-          super(name)
+          super
         end
       end
     end

--- a/lib/vanagon/platform/rpm/eos.rb
+++ b/lib/vanagon/platform/rpm/eos.rb
@@ -14,7 +14,7 @@ class Vanagon
           else
             case project.platform.package_type
             when "rpm"
-              return super(project)
+              return super
             when "swix"
               return generate_swix_package(project)
             else
@@ -34,7 +34,7 @@ class Vanagon
           else
             case project.platform.package_type
             when "rpm"
-              return super(project)
+              return super
             when "swix"
               return swix_package_name(project)
             else

--- a/lib/vanagon/platform/solaris_10.rb
+++ b/lib/vanagon/platform/solaris_10.rb
@@ -189,7 +189,7 @@ class Vanagon
         @shasum = "/opt/csw/bin/shasum"
         # solaris 10
         @num_cores = "/usr/bin/kstat cpu_info | awk '{print $$1}' | grep '^core_id$$' | wc -l"
-        super(name)
+        super
         if @architecture == "sparc"
           @platform_triple = "sparc-sun-solaris2.#{@os_version}"
         elsif @architecture == "i386"

--- a/lib/vanagon/platform/solaris_11.rb
+++ b/lib/vanagon/platform/solaris_11.rb
@@ -118,7 +118,7 @@ class Vanagon
         @patch = "/usr/bin/gpatch"
         @sed = "/usr/gnu/bin/sed"
         @num_cores = "/usr/bin/kstat cpu_info | /usr/bin/ggrep -E '[[:space:]]+core_id[[:space:]]' | wc -l"
-        super(name)
+        super
         if @architecture == "sparc"
           @platform_triple = "sparc-sun-solaris2.#{@os_version}"
         elsif @architecture == "i386"

--- a/lib/vanagon/platform/windows.rb
+++ b/lib/vanagon/platform/windows.rb
@@ -457,7 +457,7 @@ class Vanagon
         @install = "/usr/bin/install"
         @copy = "/usr/bin/cp"
         @package_type = "msi"
-        super(name)
+        super
       end
     end
   end

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -462,11 +462,10 @@ class Vanagon
     # @return [Array] of OpenStructs of all interest triggers for the pkg_state
     #   Use array of openstructs because we need both interest_name and the scripts
     def get_interest_triggers(pkg_state)
-      interest_triggers = []
       check_pkg_state_string(pkg_state)
       interests = components.flat_map(&:interest_triggers).compact.select { |s| s.pkg_state.include? pkg_state }
-      interests.each do |interest|
-        interest_triggers.push(interest)
+      interest_triggers = interests.map do |interest|
+        interest
       end
       interest_triggers.flatten.compact
     end

--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -162,13 +162,11 @@ class Vanagon
       error = nil
       tries.to_i.times do
         Timeout::timeout(timeout.to_i) do
-          begin
-            yield
-            return true
-          rescue StandardError => e
-            VanagonLogger.error 'An error was encountered evaluating block. Retrying..'
-            error = e
-          end
+          yield
+          return true
+        rescue StandardError => e
+          VanagonLogger.error 'An error was encountered evaluating block. Retrying..'
+          error = e
         end
       end
 

--- a/spec/lib/vanagon/engine/docker_spec.rb
+++ b/spec/lib/vanagon/engine/docker_spec.rb
@@ -2,6 +2,10 @@ require 'vanagon/engine/docker'
 require 'vanagon/platform'
 
 describe Vanagon::Engine::Docker do
+  before(:each) do
+    allow(Vanagon::Utilities).to receive(:find_program_on_path).with('docker').and_return('/usr/bin/docker')
+  end
+
   let (:platform_with_docker_image) do
     plat = Vanagon::Platform::DSL.new('debian-10-amd64')
     plat.instance_eval(<<~EOF)
@@ -34,6 +38,7 @@ describe Vanagon::Engine::Docker do
 
   describe '#initialize' do
     it 'fails without docker installed' do
+      allow(Vanagon::Utilities).to receive(:find_program_on_path).with('docker').and_call_original
       ENV['PATH'].split(File::PATH_SEPARATOR).each do |path_elem|
         expect(FileTest).to receive(:executable?).with(File.join(path_elem, 'docker')).and_return(false)
       end
@@ -44,18 +49,15 @@ describe Vanagon::Engine::Docker do
 
   describe "#validate_platform" do
     it 'raises an error if the platform is missing a required attribute' do
-      expect(Vanagon::Utilities).to receive(:find_program_on_path).with('docker').and_return('/usr/bin/docker')
       expect { described_class.new(platform_without_docker_image).validate_platform }.to raise_error(Vanagon::Error)
     end
 
     it 'returns true if the platform has the required attributes' do
-      expect(Vanagon::Utilities).to receive(:find_program_on_path).with('docker').and_return('/usr/bin/docker')
       expect(described_class.new(platform_with_docker_image).validate_platform).to be(true)
     end
   end
 
   it 'returns "docker" name' do
-    expect(Vanagon::Utilities).to receive(:find_program_on_path).with('docker').and_return('/usr/bin/docker')
     expect(described_class.new(platform_with_docker_image).name).to eq('docker')
   end
 

--- a/vanagon.gemspec
+++ b/vanagon.gemspec
@@ -16,22 +16,22 @@ Gem::Specification.new do |gem|
   gem.authors  = ['Puppet By Perforce']
   gem.email    = 'release@puppet.com'
   gem.homepage = 'http://github.com/puppetlabs/vanagon'
-  gem.required_ruby_version = '>=2.3', '<4'
+  gem.required_ruby_version = '>=2.7', '<4'
 
-  gem.add_runtime_dependency('docopt')
+  gem.add_dependency('docopt')
   # Handle git repos responsibly
   # - MIT licensed: https://rubygems.org/gems/git
-  gem.add_runtime_dependency('git', '~> 1.13.0')
+  gem.add_dependency('git', '~> 1.13.0')
   # Parse scp-style triplets like URIs; used for Git source handling.
   # - MIT licensed: https://rubygems.org/gems/build-uri
-  gem.add_runtime_dependency('build-uri', '~> 1.0')
+  gem.add_dependency('build-uri', '~> 1.0')
   # Handle locking hardware resources
   # - ASL v2 licensed: https://rubygems.org/gems/lock_manager
-  gem.add_runtime_dependency('lock_manager', '>= 0')
+  gem.add_dependency('lock_manager', '>= 0')
   # Utilities for `ship` and `repo` commands
   # - ASL v2 licensed: https://rubygems.org/gems/packaging
-  gem.add_runtime_dependency('packaging')
-  gem.add_runtime_dependency('psych', '>= 4.0')
+  gem.add_dependency('packaging')
+  gem.add_dependency('psych', '>= 4.0')
 
   gem.require_path = 'lib'
   gem.bindir       = 'bin'


### PR DESCRIPTION
The DigiCertGlobalRootG2 is now used by Artifactory and the VMs we're using for Solaris don't contain that cert by default.
We for sure update our images to include that, but until that is done we need to make sure to use it.
Also, in our case the OpenSSL used on our Solaris VMs is ancient and doesn't support openssl-rehash, so we have to create the sim link ourself. Once we update our images this commit can be reverted.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.