### PR TITLE
Respect Provides version in Debian control files

### DIFF
--- a/resources/deb/control.erb
+++ b/resources/deb/control.erb
@@ -21,7 +21,7 @@ Conflicts: <%= get_conflicts.map { |conflict| "#{conflict.pkgname} #{conflict.ve
 Depends: <%= get_requires.map { |req| "#{req.requirement} #{req.version ? "(#{req.version})" : ""}" }.join(", ") %>
 <%- end -%>
 <%- unless get_provides.empty? -%>
-Provides: <%= get_provides.map { |prov| prov.provide }.join(", ") %>
+Provides: <%= get_provides.map { |prov| "#{prov.provide} #{prov.version ? "(#{prov.version})" : ""}" }.join(", ") %>
 <%- end -%>
 Description: <%= @description.lines.first.chomp %>
  <%= @description.lines[1..-1].join("\s") -%>


### PR DESCRIPTION
While the version can be passed to RPM spec files, it was completely ignored for Debian. Now there's alignment.

This is a draft because it also needs a patch in openvox-agent because I broke something.